### PR TITLE
fix: remove iCloud entitlements until capability is configured

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,7 @@
     ],
     "macOS": {
       "signingIdentity": null,
-      "entitlements": "Entitlements.plist"
+      "entitlements": null
     }
   }
 }


### PR DESCRIPTION
The app can't open because the iCloud entitlement requires the capability in the Developer portal.