### PR TITLE
fix: enable iCloud entitlements in CI builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,13 @@ jobs:
           security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
 
+      - name: Install Provisioning Profile
+        env:
+          PROVISIONING_PROFILE: ${{ secrets.PROVISIONING_PROFILE }}
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "$PROVISIONING_PROFILE" | base64 --decode > ~/Library/MobileDevice/Provisioning\ Profiles/quill.provisionprofile
+
       - name: Verify Certificate
         run: |
           CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application")
@@ -82,3 +89,23 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: --target ${{ matrix.target }}
+
+      - name: Embed Provisioning Profile and Re-sign
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          APP=$(find src-tauri/target/${{ matrix.target }}/release/bundle/macos -name "*.app" -maxdepth 1)
+          echo "App bundle: $APP"
+          cp ~/Library/MobileDevice/Provisioning\ Profiles/quill.provisionprofile "$APP/Contents/embedded.provisionprofile"
+          codesign --force --sign "$APPLE_SIGNING_IDENTITY" --entitlements src-tauri/Entitlements.plist "$APP"
+          echo "Embedded provisioning profile and re-signed with entitlements"
+          codesign -d --entitlements - "$APP"
+          # Re-notarize the app
+          DMG=$(find src-tauri/target/${{ matrix.target }}/release/bundle/dmg -name "*.dmg" -maxdepth 1)
+          echo "Re-creating DMG with signed app..."
+          hdiutil create -volname "Quill" -srcfolder "$APP" -ov -format UDZO "$DMG"
+          codesign --force --sign "$APPLE_SIGNING_IDENTITY" "$DMG"
+          xcrun notarytool submit "$DMG" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+          xcrun stapler staple "$DMG"

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -13,5 +13,7 @@
     <array>
         <string>iCloud.com.wycstudios.quill</string>
     </array>
+    <key>com.apple.developer.icloud-container-environment</key>
+    <string>Production</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Embed Developer ID provisioning profile in app bundle during CI
- Re-sign with iCloud entitlements after Tauri build
- Re-create and re-notarize DMG with the properly signed app

Requires `PROVISIONING_PROFILE` GitHub secret (already added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)