### PR TITLE
fix: retry stapling and re-upload DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           APP=$(find src-tauri/target/${{ matrix.target }}/release/bundle/macos -name "*.app" -maxdepth 1)
           echo "App bundle: $APP"
@@ -102,10 +103,22 @@ jobs:
           codesign --force --sign "$APPLE_SIGNING_IDENTITY" --entitlements src-tauri/Entitlements.plist "$APP"
           echo "Embedded provisioning profile and re-signed with entitlements"
           codesign -d --entitlements - "$APP"
-          # Re-notarize the app
+          # Re-create DMG with signed app
           DMG=$(find src-tauri/target/${{ matrix.target }}/release/bundle/dmg -name "*.dmg" -maxdepth 1)
           echo "Re-creating DMG with signed app..."
           hdiutil create -volname "Quill" -srcfolder "$APP" -ov -format UDZO "$DMG"
           codesign --force --sign "$APPLE_SIGNING_IDENTITY" "$DMG"
+          # Notarize
           xcrun notarytool submit "$DMG" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
-          xcrun stapler staple "$DMG"
+          # Staple with retry (ticket propagation delay)
+          for i in 1 2 3; do
+            if xcrun stapler staple "$DMG"; then
+              echo "Stapling succeeded"
+              break
+            fi
+            echo "Stapling attempt $i failed, waiting 30s..."
+            sleep 30
+          done
+          # Re-upload to release
+          gh release upload "${{ github.ref_name }}" "$DMG" --clobber
+          echo "Uploaded $(basename $DMG) to release"


### PR DESCRIPTION
Fix stapling failure by retrying with 30s delay. Also re-upload the re-signed DMG to the release.