### PR TITLE
fix: proper iCloud container with Developer ID distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,12 @@ jobs:
           security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
 
+      - name: Install Provisioning Profile
+        env:
+          PROVISIONING_PROFILE: ${{ secrets.PROVISIONING_PROFILE }}
+        run: |
+          echo "$PROVISIONING_PROFILE" | base64 --decode > src-tauri/embedded.provisionprofile
+
       - name: Verify Certificate
         run: |
           CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application")

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2367,6 +2367,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2892,6 +2893,8 @@ dependencies = [
  "chrono",
  "epub",
  "futures",
+ "objc2",
+ "objc2-foundation",
  "rand 0.8.5",
  "reqwest 0.12.28",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,9 @@ sha2 = "0.10"
 base64 = "0.22"
 rand = "0.8"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSFileManager", "NSString", "NSURL", "NSError"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.application-identifier</key>
+    <string>49B2V2W538.com.wycstudios.quill</string>
+    <key>com.apple.developer.team-identifier</key>
+    <string>49B2V2W538</string>
+    <key>com.apple.developer.icloud-services</key>
+    <string>*</string>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array>
+        <string>iCloud.com.wycstudios.quill</string>
+    </array>
+    <key>com.apple.developer.ubiquity-container-identifiers</key>
+    <array>
+        <string>iCloud.com.wycstudios.quill</string>
+    </array>
+    <key>com.apple.developer.icloud-container-environment</key>
+    <string>Production</string>
+</dict>
+</plist>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,7 +16,7 @@
       "identifier": "fs:scope",
       "allow": [
         { "path": "$APPDATA/**" },
-        { "path": "$HOME/Library/Mobile Documents/com~apple~CloudDocs/Quill/**" }
+        { "path": "$HOME/Library/Mobile Documents/iCloud~com~wycstudios~quill/Documents/**" }
       ]
     }
   ]

--- a/src-tauri/src/icloud.rs
+++ b/src-tauri/src/icloud.rs
@@ -6,18 +6,32 @@ use rusqlite::Connection;
 use crate::db::Db;
 use crate::error::{AppError, AppResult};
 
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSFileManager, NSString};
+
+#[cfg(target_os = "macos")]
+const ICLOUD_CONTAINER_ID: &str = "iCloud.com.wycstudios.quill";
 const MARKER_FILE: &str = ".icloud_enabled";
 
-/// Get the iCloud Drive directory for Quill.
-/// Uses the user-visible iCloud Drive folder (com~apple~CloudDocs/Quill/).
-/// Returns `None` if iCloud Drive is not available (user not signed in).
+/// Get the iCloud ubiquity container URL for this app.
+/// Returns `None` if iCloud is unavailable (not signed in, no entitlement).
+#[cfg(target_os = "macos")]
+pub fn get_icloud_container_url() -> Option<PathBuf> {
+    let fm = NSFileManager::defaultManager();
+    let container_id = NSString::from_str(ICLOUD_CONTAINER_ID);
+    let url = fm.URLForUbiquityContainerIdentifier(Some(&container_id))?;
+    let path = url.path()?;
+    Some(PathBuf::from(path.to_string()))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn get_icloud_container_url() -> Option<PathBuf> {
+    None
+}
+
+/// Returns the iCloud Documents directory (container/Documents/).
 pub fn icloud_data_dir() -> Option<PathBuf> {
-    let home = std::env::var("HOME").ok()?;
-    let icloud_drive = PathBuf::from(home).join("Library/Mobile Documents/com~apple~CloudDocs");
-    if !icloud_drive.exists() {
-        return None;
-    }
-    Some(icloud_drive.join("Quill"))
+    get_icloud_container_url().map(|p| p.join("Documents"))
 }
 
 /// Check if iCloud sync is enabled by looking for the marker file in the local app dir.
@@ -123,7 +137,23 @@ pub fn wal_checkpoint(db: &Db) -> AppResult<()> {
     Ok(())
 }
 
-/// iCloud Drive handles file downloads automatically — no manual trigger needed.
+/// Trigger iCloud to download evicted files. Best-effort — errors are logged but don't block.
+#[cfg(target_os = "macos")]
+pub fn ensure_downloaded(icloud_dir: &Path) -> AppResult<()> {
+    use objc2_foundation::NSURL;
+    let fm = NSFileManager::defaultManager();
+    for name in &["quill.db", "books", "covers"] {
+        let path = icloud_dir.join(name);
+        let path_str = NSString::from_str(&path.to_string_lossy());
+        let url = NSURL::fileURLWithPath(&path_str);
+        if let Err(e) = fm.startDownloadingUbiquitousItemAtURL_error(&url) {
+            eprintln!("iCloud: failed to trigger download for {}: {}", name, e);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
 pub fn ensure_downloaded(_icloud_dir: &Path) -> AppResult<()> {
     Ok(())
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       "csp": null,
       "assetProtocol": {
         "enable": true,
-        "scope": ["$APPDATA/**", "$HOME/Library/Mobile Documents/com~apple~CloudDocs/Quill/**"]
+        "scope": ["$APPDATA/**", "$HOME/Library/Mobile Documents/iCloud~com~wycstudios~quill/Documents/**"]
       }
     }
   },
@@ -37,7 +37,11 @@
       "icons/icon.icns"
     ],
     "macOS": {
-      "signingIdentity": null
+      "signingIdentity": null,
+      "entitlements": "Entitlements.plist",
+      "files": {
+        "embedded.provisionprofile": "embedded.provisionprofile"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Restore iCloud container approach with correct entitlements for Developer ID distribution.

Key learning: entitlements must **exactly match** the Distribution provisioning profile — Production only, with application-identifier and team-identifier. Including Development environment causes launch failure.

## Changes
- Restore objc2 API (`URLForUbiquityContainerIdentifier`)
- Entitlements.plist matches Distribution profile exactly
- Tauri embeds provisioning profile via `macOS.files`
- CI decodes `PROVISIONING_PROFILE` secret
- CloudKit schema deployed to Production (already done in portal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)