### PR TITLE
fix: context-aware iCloud enable dialog and dev-mode data isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: dev dev-web build package lint typecheck clean install
 
-# Start Tauri app (frontend + backend)
+# Start Tauri app (frontend + backend) with dev-mode config overlay
 dev:
-	npm run tauri dev
+	npm run tauri dev -- --config src-tauri/tauri.dev.conf.json
 
 # Start frontend only (browser)
 dev-web:

--- a/src-tauri/src/commands/icloud.rs
+++ b/src-tauri/src/commands/icloud.rs
@@ -1,49 +1,44 @@
 use serde::Serialize;
-use tauri::{AppHandle, Manager, State};
+use tauri::State;
 
 use crate::db::Db;
-use crate::error::{AppError, AppResult};
+use crate::error::AppResult;
 use crate::icloud;
+use crate::LocalDir;
 
 #[derive(Serialize)]
 pub struct ICloudStatus {
     available: bool,
     enabled: bool,
+    /// Whether the iCloud container already has a quill.db (another device set it up).
+    has_existing_data: bool,
 }
 
 #[tauri::command]
-pub fn icloud_status(app: AppHandle) -> AppResult<ICloudStatus> {
-    let local_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| AppError::Other(e.to_string()))?;
+pub fn icloud_status(local: State<'_, LocalDir>) -> AppResult<ICloudStatus> {
+    let has_existing_data = icloud::icloud_data_dir()
+        .map(|dir| dir.join("quill.db").exists())
+        .unwrap_or(false);
     Ok(ICloudStatus {
         available: icloud::icloud_data_dir().is_some(),
-        enabled: icloud::is_icloud_enabled(&local_dir),
+        enabled: icloud::is_icloud_enabled(&local.0),
+        has_existing_data,
     })
 }
 
 #[tauri::command]
-pub fn icloud_enable(app: AppHandle, db: State<'_, Db>) -> AppResult<()> {
-    let local_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| AppError::Other(e.to_string()))?;
+pub fn icloud_enable(local: State<'_, LocalDir>, db: State<'_, Db>) -> AppResult<()> {
     let icloud_dir = icloud::icloud_data_dir()
-        .ok_or_else(|| AppError::Other("iCloud is not available".to_string()))?;
+        .ok_or_else(|| crate::error::AppError::Other("iCloud is not available".to_string()))?;
 
     icloud::ensure_downloaded(&icloud_dir)?;
-    icloud::migrate_to_icloud(&db, &local_dir, &icloud_dir)
+    icloud::migrate_to_icloud(&db, &local.0, &icloud_dir)
 }
 
 #[tauri::command]
-pub fn icloud_disable(app: AppHandle, db: State<'_, Db>) -> AppResult<()> {
-    let local_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| AppError::Other(e.to_string()))?;
+pub fn icloud_disable(local: State<'_, LocalDir>, db: State<'_, Db>) -> AppResult<()> {
     let icloud_dir = icloud::icloud_data_dir()
-        .ok_or_else(|| AppError::Other("iCloud is not available".to_string()))?;
+        .ok_or_else(|| crate::error::AppError::Other("iCloud is not available".to_string()))?;
 
-    icloud::migrate_from_icloud(&db, &local_dir, &icloud_dir)
+    icloud::migrate_from_icloud(&db, &local.0, &icloud_dir)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,9 +6,14 @@ mod error;
 mod icloud;
 mod secrets;
 
+use std::path::PathBuf;
+
 use db::Db;
 use secrets::Secrets;
 use tauri::Manager;
+
+/// The resolved local app data directory, accounting for dev-mode isolation.
+pub struct LocalDir(pub PathBuf);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -17,10 +22,18 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .setup(|app| {
-            let local_dir = app
-                .path()
-                .app_data_dir()
-                .expect("failed to resolve app data dir");
+            let local_dir = {
+                let base = app
+                    .path()
+                    .app_data_dir()
+                    .expect("failed to resolve app data dir");
+                if cfg!(debug_assertions) {
+                    base.with_file_name("com.wycstudios.quill-dev")
+                } else {
+                    base
+                }
+            };
+            std::fs::create_dir_all(&local_dir).expect("failed to create app data dir");
 
             // If iCloud sync is enabled and available, use the iCloud directory
             let data_dir = if icloud::is_icloud_enabled(&local_dir) {
@@ -46,6 +59,7 @@ pub fn run() {
                 .migrate_from_settings(&db)
                 .expect("failed to migrate secrets");
 
+            app.manage(LocalDir(local_dir));
             app.manage(db);
             app.manage(secrets);
 

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "security": {
+      "assetProtocol": {
+        "scope": ["$APPDATA/**", "$HOME/Library/Application Support/com.wycstudios.quill-dev/**", "$HOME/Library/Mobile Documents/iCloud~com~wycstudios~quill/Documents/**"]
+      }
+    }
+  }
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -48,6 +48,7 @@ export default function SettingsPage() {
   // iCloud
   const [icloudAvailable, setIcloudAvailable] = useState(false);
   const [icloudEnabled, setIcloudEnabled] = useState(false);
+  const [icloudHasExistingData, setIcloudHasExistingData] = useState(false);
   const [icloudLoading, setIcloudLoading] = useState(false);
   const [icloudError, setIcloudError] = useState<string | null>(null);
   const [icloudConfirm, setIcloudConfirm] = useState<"enable" | "disable" | null>(null);
@@ -109,10 +110,11 @@ export default function SettingsPage() {
 
   // Fetch iCloud status on mount
   useEffect(() => {
-    invoke<{ available: boolean; enabled: boolean }>("icloud_status")
+    invoke<{ available: boolean; enabled: boolean; has_existing_data: boolean }>("icloud_status")
       .then((status) => {
         setIcloudAvailable(status.available);
         setIcloudEnabled(status.enabled);
+        setIcloudHasExistingData(status.has_existing_data);
       })
       .catch(() => {});
   }, []);
@@ -662,11 +664,17 @@ export default function SettingsPage() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay">
           <div className="bg-bg-surface rounded-xl shadow-lg w-[400px] p-6">
             <h3 className="text-[18px] font-semibold text-text-primary mb-2">
-              {icloudConfirm === "enable" ? "Move Library to iCloud?" : "Move Library Back to Local?"}
+              {icloudConfirm === "enable"
+                ? icloudHasExistingData
+                  ? "Sync with Existing iCloud Library?"
+                  : "Move Library to iCloud?"
+                : "Move Library Back to Local?"}
             </h3>
             <p className="text-[14px] text-text-secondary leading-5 mb-6">
               {icloudConfirm === "enable"
-                ? "Your books, reading progress, and highlights will be moved to iCloud Drive and synced across your Macs."
+                ? icloudHasExistingData
+                  ? "An existing library was found in iCloud from another device. Your local library will be replaced by the iCloud library."
+                  : "Your books, reading progress, and highlights will be moved to iCloud Drive and synced across your Macs."
                 : "Your library will be copied back to local storage. The iCloud copy will remain until you delete it manually."}
             </p>
             <div className="flex justify-end gap-3">
@@ -674,7 +682,9 @@ export default function SettingsPage() {
                 Cancel
               </Button>
               <Button variant="primary" size="md" onClick={confirmIcloudToggle}>
-                {icloudConfirm === "enable" ? "Move to iCloud" : "Move to Local"}
+                {icloudConfirm === "enable"
+                  ? icloudHasExistingData ? "Sync with iCloud" : "Move to iCloud"
+                  : "Move to Local"}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Show context-aware confirmation dialog when enabling iCloud sync: if iCloud already has data from another device, inform the user their local library will be replaced by the iCloud library instead of saying it will be "moved"
- Isolate dev builds (`make dev`) to a separate data directory (`com.wycstudios.quill-dev`) so local development doesn't interfere with the production app
- Introduce `LocalDir` managed state so all iCloud commands use the correct resolved path instead of calling `app.path().app_data_dir()` directly

## Test plan
- [x] `make dev` uses isolated `-dev` data directory (no `.icloud_enabled` marker from production)
- [x] Cover images and book files load correctly in dev mode
- [x] Production build (`npm run tauri build`) uses original data directory, unaffected by changes
- [x] Production build includes provisioning profile and signs/notarizes successfully
- [ ] Verify "Sync with Existing iCloud Library?" dialog appears on a second device with existing iCloud data

🤖 Generated with [Claude Code](https://claude.com/claude-code)