### PR TITLE
chore: release v0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quill",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "0.4.0"
+version = "0.4.1"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quill",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "com.wycstudios.quill",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Release v0.4.1

### Changes since v0.4.0
- **feat:** Persistent AI chat threads scoped to books (#26)
- **fix:** Context-aware iCloud enable dialog and dev-mode data isolation (#25)
- **docs:** PDF support feature spec

### Version bumps
- `package.json`: 0.4.0 → 0.4.1
- `src-tauri/Cargo.toml`: 0.4.0 → 0.4.1
- `src-tauri/tauri.conf.json`: 0.4.0 → 0.4.1