### PR TITLE
docs: add i18n feature spec (English + Chinese)

### DIFF
--- a/docs/features/11-i18n.md
+++ b/docs/features/11-i18n.md
@@ -1,0 +1,277 @@
+# 11 — Internationalization (i18n)
+
+## Motivation
+
+Quill's UI is entirely in English. Supporting Chinese (Simplified) as a second language opens the app to a much larger audience and establishes the i18n foundation for future languages. Beyond UI strings, the AI reading assistant should also respond in the user's preferred language by default.
+
+## Scope
+
+- All user-facing UI strings externalized into translation files
+- Language switcher in Settings (English / 简体中文)
+- AI assistant system prompt adapted to respond in the selected language
+- Suggested prompts, empty states, and toast messages translated
+- Persist language preference in settings DB
+- No changes to book content rendering (books are in whatever language they're written in)
+
+---
+
+## Language Files
+
+### Structure
+
+```
+src/
+  i18n/
+    index.ts          — init, hook, helper
+    en.json           — English strings
+    zh.json           — Chinese (Simplified) strings
+```
+
+### Translation format
+
+Flat key-value JSON with dot-separated namespaces:
+
+```json
+{
+  "sidebar.library": "Library",
+  "sidebar.allBooks": "All Books",
+  "sidebar.currentlyReading": "Currently Reading",
+  "sidebar.finished": "Finished",
+  "sidebar.tools": "Tools",
+  "sidebar.vocabulary": "Vocabulary",
+  "sidebar.chats": "Chats",
+  "sidebar.collections": "Collections",
+
+  "home.title.all": "All Books",
+  "home.title.reading": "Currently Reading",
+  "home.title.finished": "Finished",
+  "home.search": "Search books...",
+  "home.empty": "No books yet",
+  "home.import": "Import EPUB",
+  "home.dropHint": "Drop files or click to import more books",
+  "home.dropOverlay": "Drop to add to your library",
+
+  "reader.pageOf": "Page {current} of {total}",
+  "reader.pagesLeft": "{count} pages left in chapter",
+  "reader.aiAssistant": "AI Assistant",
+
+  "ai.newChat": "New Chat",
+  "ai.startChat": "Start a new chat",
+  "ai.startChatSub": "Ask anything about the book you're reading",
+  "ai.placeholder": "Ask me anything about what you're reading...",
+  "ai.sendHint": "Press Enter to send, Shift+Enter for new line",
+  "ai.thinking": "Thinking...",
+  "ai.explain": "Explain",
+  "ai.prompt.summarize": "Summarize this chapter",
+  "ai.prompt.themes": "Explain the main themes",
+  "ai.prompt.characters": "Who are the key characters?",
+  "ai.generatingTitle": "Generating title...",
+  "ai.noChats": "No chats yet",
+  "ai.deleteChat": "Delete Chat?",
+  "ai.deleteChatMsg": "\"{title}\" and all its messages will be permanently deleted. This action cannot be undone.",
+
+  "chats.title": "Chats",
+  "chats.subtitle": "{count} chats across all books",
+  "chats.search": "Search chats...",
+  "chats.allBooks": "All Books",
+  "chats.noMessages": "No messages yet",
+  "chats.msgs": "{count} msgs",
+  "chats.openInReader": "Open in Reader",
+  "chats.empty": "No Chats Yet",
+  "chats.emptySub": "Start a conversation in the AI panel while reading a book.",
+  "chats.noMatch": "No matching chats",
+
+  "vocab.title": "Vocabulary",
+  "vocab.search": "Search words, definitions, or books...",
+  "vocab.empty": "Start Building Your Vocabulary",
+  "vocab.emptySub": "Select a word while reading, use \"Look Up\" to see its definition, then tap \"Save to Vocab\" to add it here.",
+  "vocab.openInReader": "Open in Reader",
+  "vocab.newest": "Newest",
+  "vocab.oldest": "Oldest",
+
+  "settings.title": "Settings",
+  "settings.language": "Language",
+  "settings.languageSub": "Choose your preferred language",
+  "settings.appearance": "Appearance",
+  "settings.theme": "Theme",
+  "settings.themeSub": "Choose your preferred color scheme",
+  "settings.icloud": "iCloud Sync",
+  "settings.icloudSub": "Sync your books, reading progress, and highlights across your Macs",
+  "settings.saved": "Settings saved",
+
+  "common.cancel": "Cancel",
+  "common.delete": "Delete",
+  "common.save": "Save",
+  "common.allBooks": "All Books"
+}
+```
+
+Chinese (`zh.json`) follows the same keys with translated values.
+
+---
+
+## Implementation Approach
+
+### Library: `react-i18next`
+
+Lightweight, well-maintained, supports:
+- JSON resource bundles
+- Interpolation (`{count}`, `{title}`)
+- Namespace support (optional, can use flat keys)
+- React hook `useTranslation()` → `t("key")`
+- Language detection and persistence
+
+### Hook usage
+
+```tsx
+import { useTranslation } from "react-i18next";
+
+function Sidebar() {
+  const { t } = useTranslation();
+  return <span>{t("sidebar.allBooks")}</span>;
+}
+```
+
+### Interpolation
+
+```tsx
+t("reader.pageOf", { current: 1, total: 3 })
+// → "Page 1 of 3" (en)
+// → "第 1 页，共 3 页" (zh)
+```
+
+---
+
+## AI Language Adaptation
+
+### System prompt
+
+The AI assistant's system prompt (in `src-tauri/src/commands/ai.rs`) is currently hardcoded in English:
+
+```
+"You are a helpful reading assistant. Help the user understand and discuss the book they are reading."
+```
+
+**Change:** Read the `language` setting from the DB. If `zh`, prepend a language instruction:
+
+```
+"You are a helpful reading assistant. Always respond in Chinese (Simplified). Help the user understand and discuss the book they are reading."
+```
+
+This is the simplest approach — no frontend changes needed for AI language adaptation. The system prompt controls the response language.
+
+### Suggested prompts
+
+The suggested prompt pills in AiPanel ("Summarize this chapter", etc.) are already externalized as `ai.prompt.*` keys. They will be translated so the user sees them in their language. The AI receives the translated prompt and responds accordingly.
+
+### Auto-title
+
+The `deriveTitle` function works on the raw user message text, which will be in the user's language. No changes needed — the title will naturally be in whatever language the user typed.
+
+---
+
+## Settings UI
+
+Add a **Language** section to SettingsPage, above or below Appearance:
+
+```
+┌─────────────────────────────────┐
+│  🌐  Language                   │
+│  Choose your preferred language │
+│                                 │
+│  [English      ▼]              │
+└─────────────────────────────────┘
+```
+
+Dropdown with two options:
+- `English`
+- `简体中文`
+
+Selection saved to `settings` table as `language` key with value `en` or `zh`. App reloads translations immediately (no restart required — `react-i18next` supports runtime language switching).
+
+---
+
+## Persistence
+
+| Setting | Key | Values | Default |
+|---------|-----|--------|---------|
+| Language | `language` | `en`, `zh` | `en` |
+
+Stored in the existing `settings` table via `set_setting` / `get_setting`. On app startup, `i18n.init()` reads the persisted language and sets it.
+
+---
+
+## Backend Changes
+
+### `src-tauri/src/commands/ai.rs`
+
+- Read `language` setting from DB alongside other AI settings
+- If `language == "zh"`, add "Always respond in Chinese (Simplified)." to the system prompt
+- No new commands needed
+
+---
+
+## Frontend Changes
+
+### New files
+
+| File | Description |
+|------|-------------|
+| `src/i18n/index.ts` | i18next init, language detection from settings |
+| `src/i18n/en.json` | English translations |
+| `src/i18n/zh.json` | Chinese translations |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/main.tsx` | Import `i18n/index.ts` to initialize before app renders |
+| `src/components/Sidebar.tsx` | Replace hardcoded strings with `t()` calls |
+| `src/components/AiPanel.tsx` | Replace hardcoded strings with `t()` calls |
+| `src/components/ChatsContent.tsx` | Replace hardcoded strings with `t()` calls |
+| `src/components/VocabContent.tsx` | Replace hardcoded strings with `t()` calls |
+| `src/components/BookmarksPanel.tsx` | Replace hardcoded strings with `t()` calls |
+| `src/pages/Home.tsx` | Replace hardcoded strings with `t()` calls |
+| `src/pages/Reader.tsx` | Replace hardcoded strings with `t()` calls |
+| `src/pages/SettingsPage.tsx` | Add Language section, replace hardcoded strings |
+| `src-tauri/src/commands/ai.rs` | Adapt system prompt based on language setting |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Foundation
+- Install `react-i18next` and `i18next`
+- Create `src/i18n/index.ts` with init config
+- Create `en.json` with all current hardcoded strings
+- Create `zh.json` with Chinese translations
+- Import i18n in `main.tsx`
+
+### Phase 2: Migrate UI strings
+- Replace hardcoded strings in all components with `t()` calls
+- Start with the most visible surfaces: Sidebar, Home, Settings
+- Then: AiPanel, ChatsContent, VocabContent, Reader, BookmarksPanel
+
+### Phase 3: Settings UI
+- Add Language dropdown to SettingsPage
+- Persist to DB via `set_setting("language", "zh")`
+- On change, call `i18n.changeLanguage()` for immediate switch
+
+### Phase 4: AI language adaptation
+- Read `language` setting in `ai_chat` and `ai_lookup` commands
+- Prepend language instruction to system prompt when `zh`
+- Translate suggested prompt pills via `t()` keys
+
+### Phase 5: Polish
+- Verify all surfaces render correctly in Chinese (text overflow, layout)
+- Ensure date/time formatting adapts (timeAgo utility)
+- Test with both languages end-to-end
+
+---
+
+## Notes
+
+- **No RTL support needed** — both English and Chinese are LTR
+- **Font handling** — Inter supports basic Chinese but may need a fallback. Consider adding `"PingFang SC", "Microsoft YaHei"` to the font stack in `index.css`
+- **Text length** — Chinese text is generally shorter than English, so layout overflow is unlikely. Verify anyway.
+- **Adding languages later** — just add a new JSON file and a dropdown option. The architecture supports any number of languages.


### PR DESCRIPTION
## Summary
- Feature spec for internationalization: English + Simplified Chinese
- Covers UI strings (react-i18next), AI language adaptation (system prompt), settings UI, and implementation phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)