### PR TITLE
fix: rename Vocabulary to Dictionary, consistent grid icon, fix auto-title

### DIFF
--- a/src/components/DictionaryContent.tsx
+++ b/src/components/DictionaryContent.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import {
-  ArrowLeft,
   ArrowRight,
   Languages,
   Search,
@@ -14,29 +13,28 @@ import {
   ArrowDownAZ,
   ArrowDownWideNarrow,
   ArrowUpWideNarrow,
+  Settings,
 } from "lucide-react";
-import { useAllVocab, type VocabWord } from "../hooks/useVocab";
+import Button from "./ui/Button";
+import { useAllDictionary, type DictionaryWord } from "../hooks/useDictionary";
 import { timeAgo } from "../utils/timeAgo";
 
 type SortMode = "newest" | "oldest" | "az";
 type ViewMode = "list" | "card";
 
-export default function VocabPage() {
+export default function DictionaryContent() {
   const navigate = useNavigate();
-  const { words, remove } = useAllVocab();
+  const { words, remove } = useAllDictionary();
   const [sort, setSort] = useState<SortMode>("newest");
   const [view, setView] = useState<ViewMode>("list");
   const [search, setSearch] = useState("");
   const [bookFilter, setBookFilter] = useState<string | null>(null);
 
-  // Filter
   const filtered = useMemo(() => {
     let result = words;
     if (search) {
       const q = search.toLowerCase();
-      result = result.filter(
-        (w) => w.word.toLowerCase().startsWith(q)
-      );
+      result = result.filter((w) => w.word.toLowerCase().startsWith(q));
     }
     if (bookFilter) {
       result = result.filter((w) => w.book_id === bookFilter);
@@ -44,7 +42,6 @@ export default function VocabPage() {
     return result;
   }, [words, search, bookFilter]);
 
-  // Sort
   const sorted = useMemo(() => {
     const copy = [...filtered];
     if (sort === "oldest") {
@@ -52,36 +49,30 @@ export default function VocabPage() {
     } else if (sort === "az") {
       copy.sort((a, b) => a.word.localeCompare(b.word, undefined, { sensitivity: "base" }));
     }
-    // newest is default order from backend (created_at DESC)
     return copy;
   }, [filtered, sort]);
 
-  // Group by book for card view
   const groupedByBook = useMemo(() => {
-    const map = new Map<string, { title: string; words: VocabWord[] }>();
+    const map = new Map<string, { title: string; words: DictionaryWord[] }>();
     for (const w of sorted) {
-      const key = w.book_id;
-      if (!map.has(key)) {
-        map.set(key, { title: w.book_title || "Unknown Book", words: [] });
+      if (!map.has(w.book_id)) {
+        map.set(w.book_id, { title: w.book_title || "Unknown Book", words: [] });
       }
-      map.get(key)!.words.push(w);
+      map.get(w.book_id)!.words.push(w);
     }
     return Array.from(map.values());
   }, [sorted]);
 
-  // Group by letter for list view
   const groupedByLetter = useMemo(() => {
-    const map = new Map<string, VocabWord[]>();
+    const map = new Map<string, DictionaryWord[]>();
     for (const w of sorted) {
       const letter = w.word[0]?.toUpperCase() || "#";
       if (!map.has(letter)) map.set(letter, []);
       map.get(letter)!.push(w);
     }
-    // Sort letters alphabetically
     return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
   }, [sorted]);
 
-  // Book pills data
   const bookPills = useMemo(() => {
     const map = new Map<string, { title: string; count: number }>();
     for (const w of words) {
@@ -96,89 +87,28 @@ export default function VocabPage() {
   const isEmpty = words.length === 0;
 
   return (
-    <div className="flex flex-col h-screen bg-bg-surface">
+    <div className="flex-1 flex flex-col min-w-0">
       {/* Header */}
-      <header className="flex items-center justify-between px-section pt-11 pb-4 shrink-0 relative">
+      <div className="px-page pb-2 relative">
         <div data-tauri-drag-region className="absolute top-0 left-0 right-0 h-11" />
-        <div className="flex items-center gap-3">
-          <button
-            onClick={() => navigate("/")}
-            className="size-9 flex items-center justify-center rounded-lg hover:bg-bg-input cursor-pointer"
-          >
-            <ArrowLeft size={16} className="text-text-body" />
-          </button>
-          <div
-            className="size-8 rounded-[14px] flex items-center justify-center shadow-sm"
-            style={{ background: "linear-gradient(135deg, #AD46FF, #7F22FE)" }}
-          >
-            <Languages size={16} className="text-white" />
-          </div>
-          <div className="flex flex-col">
-            <h1 className="text-[20px] font-semibold text-text-primary leading-7 tracking-[-0.45px]">
-              Vocabulary
-            </h1>
-            <span className="text-[12px] text-text-muted leading-[18px]">
-              {words.length} word{words.length !== 1 ? "s" : ""} saved
-            </span>
+        <div className="pt-11 flex items-center justify-between mb-6">
+          <h1 className="text-[24px] font-semibold text-text-primary tracking-[0.07px]">
+            Dictionary
+          </h1>
+          <div className="flex items-center gap-0">
+            <Button variant="icon" size="md" active={view === "card"} onClick={() => setView("card")}>
+              <LayoutGrid size={16} />
+            </Button>
+            <Button variant="icon" size="md" active={view === "list"} onClick={() => setView("list")}>
+              <List size={16} />
+            </Button>
+            <div className="w-px h-6 bg-border mx-2" />
+            <Button variant="icon" size="md" onClick={() => navigate("/settings")}>
+              <Settings size={16} />
+            </Button>
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
-          {/* View toggle */}
-          <div className="flex items-center bg-border rounded-[10px] h-[30px] p-0.5">
-            <button
-              onClick={() => setView("card")}
-              className={`flex items-center justify-center size-[26px] rounded-lg cursor-pointer transition-colors ${
-                view === "card" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
-              }`}
-            >
-              <LayoutGrid size={14} />
-            </button>
-            <button
-              onClick={() => setView("list")}
-              className={`flex items-center justify-center size-[26px] rounded-lg cursor-pointer transition-colors ${
-                view === "list" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
-              }`}
-            >
-              <List size={14} />
-            </button>
-          </div>
-
-          {/* Sort control */}
-          <div className="flex items-center bg-border rounded-[10px] h-[32.5px] p-0.5">
-            <button
-              onClick={() => setSort("newest")}
-              className={`flex items-center gap-1 h-[28px] px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
-                sort === "newest" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
-              }`}
-            >
-              <ArrowDownWideNarrow size={12} />
-              Newest
-            </button>
-            <button
-              onClick={() => setSort("oldest")}
-              className={`flex items-center gap-1 h-[28px] px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
-                sort === "oldest" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
-              }`}
-            >
-              <ArrowUpWideNarrow size={12} />
-              Oldest
-            </button>
-            <button
-              onClick={() => { setSort("az"); setView("list"); }}
-              className={`flex items-center gap-1 h-[28px] px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
-                sort === "az" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
-              }`}
-            >
-              <ArrowDownAZ size={12} />
-              A-Z
-            </button>
-          </div>
-        </div>
-      </header>
-
-      {/* Search */}
-      <div className={`px-section pt-2 pb-2${isEmpty ? " border-b border-border" : ""}`}>
         <div className="flex items-center gap-2 h-9 px-3 rounded-lg bg-bg-input max-w-[448px]">
           <Search size={16} className="text-text-muted shrink-0" />
           <input
@@ -195,9 +125,9 @@ export default function VocabPage() {
         </div>
       </div>
 
-      {/* Book filter pills */}
+      {/* Book filter pills + sort */}
       {!isEmpty && (
-        <div className="flex items-center gap-2 px-section pt-2 pb-5 overflow-x-auto border-b border-border">
+        <div className="flex items-center gap-2 px-page pt-2 pb-4 overflow-x-auto border-b border-border">
           <button
             onClick={() => setBookFilter(null)}
             className={`flex items-center gap-1.5 h-8 px-[13px] rounded-full text-[12px] font-medium cursor-pointer shrink-0 transition-colors border ${
@@ -229,36 +159,62 @@ export default function VocabPage() {
               </span>
             </button>
           ))}
+
+          <div className="ml-auto flex items-center gap-1 shrink-0">
+            <button
+              onClick={() => setSort("newest")}
+              className={`flex items-center gap-1 h-7 px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
+                sort === "newest" ? "text-accent-text" : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              <ArrowDownWideNarrow size={12} />
+              Newest
+            </button>
+            <button
+              onClick={() => setSort("oldest")}
+              className={`flex items-center gap-1 h-7 px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
+                sort === "oldest" ? "text-accent-text" : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              <ArrowUpWideNarrow size={12} />
+              Oldest
+            </button>
+            <button
+              onClick={() => { setSort("az"); setView("list"); }}
+              className={`flex items-center gap-1 h-7 px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
+                sort === "az" ? "text-accent-text" : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              <ArrowDownAZ size={12} />
+              A-Z
+            </button>
+          </div>
         </div>
       )}
 
       {/* Content */}
-      <div className="flex-1 overflow-auto px-section py-4">
+      <div className="flex-1 overflow-auto p-page pb-20">
         {isEmpty ? (
-          /* Empty state */
           <div className="flex flex-col items-center justify-center h-full">
             <div className="size-16 rounded-full bg-bg-input flex items-center justify-center mb-4">
               <Languages size={28} className="text-text-muted" />
             </div>
             <h2 className="text-[18px] font-medium text-text-primary mb-2">
-              Start Building Your Vocabulary
+              Start Building Your Dictionary
             </h2>
             <p className="text-[14px] text-text-muted text-center max-w-[296px]">
               Select a word while reading, use "Look Up" to see its definition, then tap "Save to Vocab" to add it here.
             </p>
           </div>
         ) : view === "list" ? (
-          /* A-Z list view */
           <div>
             {groupedByLetter.map(([letter, letterWords]) => (
               <div key={letter} className="mb-6">
-                {/* Letter header */}
                 <div className="flex items-center gap-3 mb-2">
                   <span className="text-[18px] font-bold text-accent">{letter}</span>
                   <div className="flex-1 h-px bg-border-light" />
                   <span className="text-[11px] text-text-muted">{letterWords.length}</span>
                 </div>
-                {/* Word rows */}
                 {letterWords.map((word) => {
                   const parts = word.definition.split("\n\n");
                   const defText = parts[0] || "";
@@ -268,7 +224,6 @@ export default function VocabPage() {
                       key={word.id}
                       className="flex items-start gap-4 px-3 pt-3 pb-3 rounded-[10px] hover:bg-bg-input group"
                     >
-                      {/* Left column */}
                       <div className="w-[160px] shrink-0">
                         <span className="block text-[14px] font-semibold text-text-primary leading-5">
                           {word.word}
@@ -280,22 +235,16 @@ export default function VocabPage() {
                           </span>
                         )}
                       </div>
-                      {/* Middle */}
                       <div className="flex-1 min-w-0">
-                        <p className="text-[13px] text-text-secondary leading-5 truncate">
-                          {defText}
-                        </p>
+                        <p className="text-[13px] text-text-secondary leading-5 truncate">{defText}</p>
                         {ctxText && (
                           <p className="text-[11px] italic text-text-muted leading-4 truncate mt-0.5">
                             "{ctxText}"
                           </p>
                         )}
                       </div>
-                      {/* Right */}
                       <div className="flex items-center gap-3 shrink-0">
-                        <span className="text-[11px] text-text-muted">
-                          {timeAgo(word.created_at)}
-                        </span>
+                        <span className="text-[11px] text-text-muted">{timeAgo(word.created_at)}</span>
                         <button
                           onClick={() => navigate(`/reader/${word.book_id}`, { state: { openVocab: true, cfi: word.cfi } })}
                           className="flex items-center gap-1 text-[12px] font-medium text-accent-text cursor-pointer hover:opacity-70"
@@ -311,11 +260,9 @@ export default function VocabPage() {
             ))}
           </div>
         ) : (
-          /* Card view — grouped by book */
           <div className="max-w-[525px] space-y-6">
             {groupedByBook.map((group) => (
               <div key={group.title}>
-                {/* Book section header */}
                 <div className="flex items-center gap-2 mb-3">
                   <BookOpen size={14} className="text-text-muted" />
                   <span className="text-[12px] font-semibold uppercase text-text-muted tracking-[0.3px]">
@@ -323,7 +270,6 @@ export default function VocabPage() {
                   </span>
                   <span className="text-[11px] text-text-muted">({group.words.length})</span>
                 </div>
-                {/* Word cards */}
                 <div className="space-y-3">
                   {group.words.map((word) => {
                     const parts = word.definition.split("\n\n");
@@ -334,25 +280,18 @@ export default function VocabPage() {
                         key={word.id}
                         className="group relative bg-bg-muted border border-border rounded-[14px] p-[17px] flex flex-col gap-2"
                       >
-                        {/* Trash — top right */}
                         <button
                           onClick={() => remove(word.id)}
                           className="absolute top-4 right-4 p-1 rounded hover:bg-bg-surface/80 cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
                         >
                           <Trash2 size={15} className="text-text-muted" />
                         </button>
-
-                        {/* Word */}
                         <span className="text-[15px] font-semibold text-text-primary leading-[22.5px] tracking-[-0.23px]">
                           {word.word}
                         </span>
-
-                        {/* Definition */}
                         <p className="text-[13px] text-text-secondary leading-[20.15px] tracking-[-0.08px] line-clamp-3 w-[460px] max-w-full">
                           {defText}
                         </p>
-
-                        {/* AI context — blockquote style */}
                         {ctxText && (
                           <div className="border-l-2 border-accent/30 pl-2 overflow-hidden">
                             <p className="text-[11px] italic text-text-muted leading-[16.5px] tracking-[0.06px] line-clamp-2">
@@ -360,8 +299,6 @@ export default function VocabPage() {
                             </p>
                           </div>
                         )}
-
-                        {/* Footer */}
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-3">
                             {word.cfi && (

--- a/src/components/DictionaryPanel.tsx
+++ b/src/components/DictionaryPanel.tsx
@@ -1,17 +1,17 @@
 import { useState } from "react";
 import { BookOpen, Search, Trash2, Clock, FileText, ArrowRight, Sparkles } from "lucide-react";
-import { useVocab } from "../hooks/useVocab";
+import { useDictionary } from "../hooks/useDictionary";
 import { timeAgo } from "../utils/timeAgo";
 
-interface VocabPanelProps {
+interface DictionaryPanelProps {
   bookId: string;
   onNavigate?: (cfi: string) => void;
   getPageFromCfi?: (cfi: string) => number | null;
 }
 
-export default function VocabPanel({ bookId, onNavigate, getPageFromCfi }: VocabPanelProps) {
+export default function DictionaryPanel({ bookId, onNavigate, getPageFromCfi }: DictionaryPanelProps) {
   const [search, setSearch] = useState("");
-  const { words, remove } = useVocab(bookId);
+  const { words, remove } = useDictionary(bookId);
 
   const filtered = words.filter((w) => {
     if (!search) return true;
@@ -30,7 +30,7 @@ export default function VocabPanel({ bookId, onNavigate, getPageFromCfi }: Vocab
             <Sparkles size={12} className="text-white" />
           </div>
           <span className="text-[14px] font-semibold text-text-primary tracking-[-0.15px]">
-            Vocabulary
+            Dictionary
           </span>
         </div>
         <span className="text-[11px] text-text-muted tracking-[0.06px]">
@@ -44,7 +44,7 @@ export default function VocabPanel({ bookId, onNavigate, getPageFromCfi }: Vocab
           <Search size={12} className="text-text-muted shrink-0" />
           <input
             type="search"
-            placeholder="Search vocabulary..."
+            placeholder="Search dictionary..."
             defaultValue=""
             onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
             onKeyDown={(e) => e.stopPropagation()}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -104,7 +104,7 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
             <span className={`text-[14px] font-medium tracking-[-0.15px] ${
               activeFilter === "vocab" ? "text-accent-text" : "text-text-secondary"
             }`}>
-              Vocabulary
+              Dictionary
             </span>
           </button>
           <button

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -246,7 +246,8 @@ export function useAiChat(bookId?: string) {
               try {
                 const chat = await invoke<ChatRecord>("get_chat", { chatId: currentChatId });
                 if (chat.title === "New chat") {
-                  const title = deriveTitle(content);
+                  // Use context (selected passage) if available, otherwise user message
+                  const title = deriveTitle(context || content);
                   if (title) {
                     await invoke("rename_chat", { chatId: currentChatId, title });
                     await refreshChats(currentBookId);

--- a/src/hooks/useDictionary.ts
+++ b/src/hooks/useDictionary.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 
-export interface VocabWord {
+export interface DictionaryWord {
   id: string;
   book_id: string;
   word: string;
@@ -16,12 +16,12 @@ export interface VocabWord {
   book_title: string | null;
 }
 
-export function useVocab(bookId: string) {
-  const [words, setWords] = useState<VocabWord[]>([]);
+export function useDictionary(bookId: string) {
+  const [words, setWords] = useState<DictionaryWord[]>([]);
 
   const refresh = useCallback(async () => {
     try {
-      const result = await invoke<VocabWord[]>("list_vocab_words", { bookId });
+      const result = await invoke<DictionaryWord[]>("list_vocab_words", { bookId });
       setWords(result);
     } catch (err) {
       console.error("Failed to load vocab words:", err);
@@ -39,15 +39,15 @@ export function useVocab(bookId: string) {
       contextSentence?: string,
       cfi?: string
     ) => {
-      const vocabWord = await invoke<VocabWord>("add_vocab_word", {
+      const dictionaryWord = await invoke<DictionaryWord>("add_vocab_word", {
         bookId,
         word,
         definition,
         contextSentence: contextSentence || null,
         cfi: cfi || null,
       });
-      setWords((prev) => [vocabWord, ...prev]);
-      return vocabWord;
+      setWords((prev) => [dictionaryWord, ...prev]);
+      return dictionaryWord;
     },
     [bookId]
   );
@@ -67,12 +67,12 @@ export function useVocab(bookId: string) {
   return { words, refresh, add, remove, checkExists };
 }
 
-export function useAllVocab() {
-  const [words, setWords] = useState<VocabWord[]>([]);
+export function useAllDictionary() {
+  const [words, setWords] = useState<DictionaryWord[]>([]);
 
   const refresh = useCallback(async () => {
     try {
-      const result = await invoke<VocabWord[]>("list_all_vocab_words");
+      const result = await invoke<DictionaryWord[]>("list_all_vocab_words");
       setWords(result);
     } catch (err) {
       console.error("Failed to load all vocab words:", err);

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import {
+  ArrowLeft,
   ArrowRight,
   Languages,
   Search,
@@ -13,28 +14,29 @@ import {
   ArrowDownAZ,
   ArrowDownWideNarrow,
   ArrowUpWideNarrow,
-  Settings,
 } from "lucide-react";
-import Button from "./ui/Button";
-import { useAllVocab, type VocabWord } from "../hooks/useVocab";
+import { useAllDictionary, type DictionaryWord } from "../hooks/useDictionary";
 import { timeAgo } from "../utils/timeAgo";
 
 type SortMode = "newest" | "oldest" | "az";
 type ViewMode = "list" | "card";
 
-export default function VocabContent() {
+export default function DictionaryPage() {
   const navigate = useNavigate();
-  const { words, remove } = useAllVocab();
+  const { words, remove } = useAllDictionary();
   const [sort, setSort] = useState<SortMode>("newest");
   const [view, setView] = useState<ViewMode>("list");
   const [search, setSearch] = useState("");
   const [bookFilter, setBookFilter] = useState<string | null>(null);
 
+  // Filter
   const filtered = useMemo(() => {
     let result = words;
     if (search) {
       const q = search.toLowerCase();
-      result = result.filter((w) => w.word.toLowerCase().startsWith(q));
+      result = result.filter(
+        (w) => w.word.toLowerCase().startsWith(q)
+      );
     }
     if (bookFilter) {
       result = result.filter((w) => w.book_id === bookFilter);
@@ -42,6 +44,7 @@ export default function VocabContent() {
     return result;
   }, [words, search, bookFilter]);
 
+  // Sort
   const sorted = useMemo(() => {
     const copy = [...filtered];
     if (sort === "oldest") {
@@ -49,30 +52,36 @@ export default function VocabContent() {
     } else if (sort === "az") {
       copy.sort((a, b) => a.word.localeCompare(b.word, undefined, { sensitivity: "base" }));
     }
+    // newest is default order from backend (created_at DESC)
     return copy;
   }, [filtered, sort]);
 
+  // Group by book for card view
   const groupedByBook = useMemo(() => {
-    const map = new Map<string, { title: string; words: VocabWord[] }>();
+    const map = new Map<string, { title: string; words: DictionaryWord[] }>();
     for (const w of sorted) {
-      if (!map.has(w.book_id)) {
-        map.set(w.book_id, { title: w.book_title || "Unknown Book", words: [] });
+      const key = w.book_id;
+      if (!map.has(key)) {
+        map.set(key, { title: w.book_title || "Unknown Book", words: [] });
       }
-      map.get(w.book_id)!.words.push(w);
+      map.get(key)!.words.push(w);
     }
     return Array.from(map.values());
   }, [sorted]);
 
+  // Group by letter for list view
   const groupedByLetter = useMemo(() => {
-    const map = new Map<string, VocabWord[]>();
+    const map = new Map<string, DictionaryWord[]>();
     for (const w of sorted) {
       const letter = w.word[0]?.toUpperCase() || "#";
       if (!map.has(letter)) map.set(letter, []);
       map.get(letter)!.push(w);
     }
+    // Sort letters alphabetically
     return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
   }, [sorted]);
 
+  // Book pills data
   const bookPills = useMemo(() => {
     const map = new Map<string, { title: string; count: number }>();
     for (const w of words) {
@@ -87,28 +96,89 @@ export default function VocabContent() {
   const isEmpty = words.length === 0;
 
   return (
-    <div className="flex-1 flex flex-col min-w-0">
+    <div className="flex flex-col h-screen bg-bg-surface">
       {/* Header */}
-      <div className="px-page pb-2 relative">
+      <header className="flex items-center justify-between px-section pt-11 pb-4 shrink-0 relative">
         <div data-tauri-drag-region className="absolute top-0 left-0 right-0 h-11" />
-        <div className="pt-11 flex items-center justify-between mb-6">
-          <h1 className="text-[24px] font-semibold text-text-primary tracking-[0.07px]">
-            Vocabulary
-          </h1>
-          <div className="flex items-center gap-0">
-            <Button variant="icon" size="md" active={view === "card"} onClick={() => setView("card")}>
-              <LayoutGrid size={16} />
-            </Button>
-            <Button variant="icon" size="md" active={view === "list"} onClick={() => setView("list")}>
-              <List size={16} />
-            </Button>
-            <div className="w-px h-6 bg-border mx-2" />
-            <Button variant="icon" size="md" onClick={() => navigate("/settings")}>
-              <Settings size={16} />
-            </Button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate("/")}
+            className="size-9 flex items-center justify-center rounded-lg hover:bg-bg-input cursor-pointer"
+          >
+            <ArrowLeft size={16} className="text-text-body" />
+          </button>
+          <div
+            className="size-8 rounded-[14px] flex items-center justify-center shadow-sm"
+            style={{ background: "linear-gradient(135deg, #AD46FF, #7F22FE)" }}
+          >
+            <Languages size={16} className="text-white" />
+          </div>
+          <div className="flex flex-col">
+            <h1 className="text-[20px] font-semibold text-text-primary leading-7 tracking-[-0.45px]">
+              Dictionary
+            </h1>
+            <span className="text-[12px] text-text-muted leading-[18px]">
+              {words.length} word{words.length !== 1 ? "s" : ""} saved
+            </span>
           </div>
         </div>
 
+        <div className="flex items-center gap-2">
+          {/* View toggle */}
+          <div className="flex items-center bg-border rounded-[10px] h-[30px] p-0.5">
+            <button
+              onClick={() => setView("card")}
+              className={`flex items-center justify-center size-[26px] rounded-lg cursor-pointer transition-colors ${
+                view === "card" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
+              }`}
+            >
+              <LayoutGrid size={14} />
+            </button>
+            <button
+              onClick={() => setView("list")}
+              className={`flex items-center justify-center size-[26px] rounded-lg cursor-pointer transition-colors ${
+                view === "list" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
+              }`}
+            >
+              <List size={14} />
+            </button>
+          </div>
+
+          {/* Sort control */}
+          <div className="flex items-center bg-border rounded-[10px] h-[32.5px] p-0.5">
+            <button
+              onClick={() => setSort("newest")}
+              className={`flex items-center gap-1 h-[28px] px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
+                sort === "newest" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
+              }`}
+            >
+              <ArrowDownWideNarrow size={12} />
+              Newest
+            </button>
+            <button
+              onClick={() => setSort("oldest")}
+              className={`flex items-center gap-1 h-[28px] px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
+                sort === "oldest" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
+              }`}
+            >
+              <ArrowUpWideNarrow size={12} />
+              Oldest
+            </button>
+            <button
+              onClick={() => { setSort("az"); setView("list"); }}
+              className={`flex items-center gap-1 h-[28px] px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
+                sort === "az" ? "bg-bg-surface shadow-sm text-text-primary" : "text-text-secondary"
+              }`}
+            >
+              <ArrowDownAZ size={12} />
+              A-Z
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Search */}
+      <div className={`px-section pt-2 pb-2${isEmpty ? " border-b border-border" : ""}`}>
         <div className="flex items-center gap-2 h-9 px-3 rounded-lg bg-bg-input max-w-[448px]">
           <Search size={16} className="text-text-muted shrink-0" />
           <input
@@ -125,9 +195,9 @@ export default function VocabContent() {
         </div>
       </div>
 
-      {/* Book filter pills + sort */}
+      {/* Book filter pills */}
       {!isEmpty && (
-        <div className="flex items-center gap-2 px-page pt-2 pb-4 overflow-x-auto border-b border-border">
+        <div className="flex items-center gap-2 px-section pt-2 pb-5 overflow-x-auto border-b border-border">
           <button
             onClick={() => setBookFilter(null)}
             className={`flex items-center gap-1.5 h-8 px-[13px] rounded-full text-[12px] font-medium cursor-pointer shrink-0 transition-colors border ${
@@ -159,62 +229,36 @@ export default function VocabContent() {
               </span>
             </button>
           ))}
-
-          <div className="ml-auto flex items-center gap-1 shrink-0">
-            <button
-              onClick={() => setSort("newest")}
-              className={`flex items-center gap-1 h-7 px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
-                sort === "newest" ? "text-accent-text" : "text-text-muted hover:text-text-primary"
-              }`}
-            >
-              <ArrowDownWideNarrow size={12} />
-              Newest
-            </button>
-            <button
-              onClick={() => setSort("oldest")}
-              className={`flex items-center gap-1 h-7 px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
-                sort === "oldest" ? "text-accent-text" : "text-text-muted hover:text-text-primary"
-              }`}
-            >
-              <ArrowUpWideNarrow size={12} />
-              Oldest
-            </button>
-            <button
-              onClick={() => { setSort("az"); setView("list"); }}
-              className={`flex items-center gap-1 h-7 px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
-                sort === "az" ? "text-accent-text" : "text-text-muted hover:text-text-primary"
-              }`}
-            >
-              <ArrowDownAZ size={12} />
-              A-Z
-            </button>
-          </div>
         </div>
       )}
 
       {/* Content */}
-      <div className="flex-1 overflow-auto p-page pb-20">
+      <div className="flex-1 overflow-auto px-section py-4">
         {isEmpty ? (
+          /* Empty state */
           <div className="flex flex-col items-center justify-center h-full">
             <div className="size-16 rounded-full bg-bg-input flex items-center justify-center mb-4">
               <Languages size={28} className="text-text-muted" />
             </div>
             <h2 className="text-[18px] font-medium text-text-primary mb-2">
-              Start Building Your Vocabulary
+              Start Building Your Dictionary
             </h2>
             <p className="text-[14px] text-text-muted text-center max-w-[296px]">
               Select a word while reading, use "Look Up" to see its definition, then tap "Save to Vocab" to add it here.
             </p>
           </div>
         ) : view === "list" ? (
+          /* A-Z list view */
           <div>
             {groupedByLetter.map(([letter, letterWords]) => (
               <div key={letter} className="mb-6">
+                {/* Letter header */}
                 <div className="flex items-center gap-3 mb-2">
                   <span className="text-[18px] font-bold text-accent">{letter}</span>
                   <div className="flex-1 h-px bg-border-light" />
                   <span className="text-[11px] text-text-muted">{letterWords.length}</span>
                 </div>
+                {/* Word rows */}
                 {letterWords.map((word) => {
                   const parts = word.definition.split("\n\n");
                   const defText = parts[0] || "";
@@ -224,6 +268,7 @@ export default function VocabContent() {
                       key={word.id}
                       className="flex items-start gap-4 px-3 pt-3 pb-3 rounded-[10px] hover:bg-bg-input group"
                     >
+                      {/* Left column */}
                       <div className="w-[160px] shrink-0">
                         <span className="block text-[14px] font-semibold text-text-primary leading-5">
                           {word.word}
@@ -235,16 +280,22 @@ export default function VocabContent() {
                           </span>
                         )}
                       </div>
+                      {/* Middle */}
                       <div className="flex-1 min-w-0">
-                        <p className="text-[13px] text-text-secondary leading-5 truncate">{defText}</p>
+                        <p className="text-[13px] text-text-secondary leading-5 truncate">
+                          {defText}
+                        </p>
                         {ctxText && (
                           <p className="text-[11px] italic text-text-muted leading-4 truncate mt-0.5">
                             "{ctxText}"
                           </p>
                         )}
                       </div>
+                      {/* Right */}
                       <div className="flex items-center gap-3 shrink-0">
-                        <span className="text-[11px] text-text-muted">{timeAgo(word.created_at)}</span>
+                        <span className="text-[11px] text-text-muted">
+                          {timeAgo(word.created_at)}
+                        </span>
                         <button
                           onClick={() => navigate(`/reader/${word.book_id}`, { state: { openVocab: true, cfi: word.cfi } })}
                           className="flex items-center gap-1 text-[12px] font-medium text-accent-text cursor-pointer hover:opacity-70"
@@ -260,9 +311,11 @@ export default function VocabContent() {
             ))}
           </div>
         ) : (
+          /* Card view — grouped by book */
           <div className="max-w-[525px] space-y-6">
             {groupedByBook.map((group) => (
               <div key={group.title}>
+                {/* Book section header */}
                 <div className="flex items-center gap-2 mb-3">
                   <BookOpen size={14} className="text-text-muted" />
                   <span className="text-[12px] font-semibold uppercase text-text-muted tracking-[0.3px]">
@@ -270,6 +323,7 @@ export default function VocabContent() {
                   </span>
                   <span className="text-[11px] text-text-muted">({group.words.length})</span>
                 </div>
+                {/* Word cards */}
                 <div className="space-y-3">
                   {group.words.map((word) => {
                     const parts = word.definition.split("\n\n");
@@ -280,18 +334,25 @@ export default function VocabContent() {
                         key={word.id}
                         className="group relative bg-bg-muted border border-border rounded-[14px] p-[17px] flex flex-col gap-2"
                       >
+                        {/* Trash — top right */}
                         <button
                           onClick={() => remove(word.id)}
                           className="absolute top-4 right-4 p-1 rounded hover:bg-bg-surface/80 cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
                         >
                           <Trash2 size={15} className="text-text-muted" />
                         </button>
+
+                        {/* Word */}
                         <span className="text-[15px] font-semibold text-text-primary leading-[22.5px] tracking-[-0.23px]">
                           {word.word}
                         </span>
+
+                        {/* Definition */}
                         <p className="text-[13px] text-text-secondary leading-[20.15px] tracking-[-0.08px] line-clamp-3 w-[460px] max-w-full">
                           {defText}
                         </p>
+
+                        {/* AI context — blockquote style */}
                         {ctxText && (
                           <div className="border-l-2 border-accent/30 pl-2 overflow-hidden">
                             <p className="text-[11px] italic text-text-muted leading-[16.5px] tracking-[0.06px] line-clamp-2">
@@ -299,6 +360,8 @@ export default function VocabContent() {
                             </p>
                           </div>
                         )}
+
+                        {/* Footer */}
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-3">
                             {word.cfi && (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useRef } from "react";
-import { Search, Grid3x3, List, Settings, Plus, Upload, BookOpen } from "lucide-react";
+import { Search, LayoutGrid, List, Settings, Plus, Upload, BookOpen } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import Sidebar from "../components/Sidebar";
 import BookGrid from "../components/BookGrid";
 import BookList from "../components/BookList";
-import VocabContent from "../components/VocabContent";
+import DictionaryContent from "../components/DictionaryContent";
 import ChatsContent from "../components/ChatsContent";
 import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
@@ -119,7 +119,7 @@ export default function Home() {
       />
 
       {activeFilter === "vocab" ? (
-        <VocabContent />
+        <DictionaryContent />
       ) : activeFilter === "chats" ? (
         <ChatsContent />
       ) : (
@@ -137,7 +137,7 @@ export default function Home() {
                   active={viewMode === "grid"}
                   onClick={() => setViewMode("grid")}
                 >
-                  <Grid3x3 size={16} />
+                  <LayoutGrid size={16} />
                 </Button>
                 <Button
                   variant="icon"

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -17,7 +17,7 @@ import ReaderSettings, { type ReaderSettingsState, getFontFamily, getThemeStyles
 import ReaderContextMenu from "../components/ReaderContextMenu";
 import HighlightToolbar from "../components/HighlightToolbar";
 import LookupPopover from "../components/LookupPopover";
-import VocabPanel from "../components/VocabPanel";
+import DictionaryPanel from "../components/DictionaryPanel";
 import TableOfContents from "../components/TableOfContents";
 import { getBook, updateReadingProgress, type Book } from "../hooks/useBooks";
 import { getAllSettings } from "../hooks/useSettings";
@@ -563,7 +563,7 @@ export default function Reader() {
     navigate(location.pathname, { replace: true });
   }, [bookReady, location.state, location.pathname, navigate]);
 
-  // Handle navigation state from VocabPage ("Open in Reader")
+  // Handle navigation state from DictionaryPage ("Open in Reader")
   useEffect(() => {
     const state = location.state as { openVocab?: boolean; cfi?: string } | null;
     if (!state?.openVocab || !bookReady) return;
@@ -799,7 +799,7 @@ export default function Reader() {
             />
           )}
           {sidePanel === "vocab" && bookId && (
-            <VocabPanel
+            <DictionaryPanel
               bookId={bookId}
               onNavigate={(cfi) => {
                 viewRef.current?.goTo(cfi).then(() => {


### PR DESCRIPTION
## Summary
- Rename Vocabulary → Dictionary across all UI text, file names, and exported symbols
- Use `LayoutGrid` icon consistently in Home (was `Grid3x3`, Dictionary already used `LayoutGrid`)
- Fix chat auto-title for "Ask AI" — derive title from the selected passage context, not the word "Explain"

🤖 Generated with [Claude Code](https://claude.com/claude-code)