### PR TITLE
chore: release v0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quill",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "0.4.1"
+version = "0.4.2"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quill",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "com.wycstudios.quill",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Release v0.4.2

### Changes since v0.4.1
- **fix:** Rename Vocabulary to Dictionary across all UI and file names (#29)
- **fix:** Consistent grid icon (LayoutGrid) across Home and Dictionary pages (#29)
- **fix:** Chat auto-title now works for "Ask AI" context selections (#29)
- **docs:** i18n feature spec (English + Chinese) (#28)