### PR TITLE
fix: add Remove from Collection context menu option

### DIFF
--- a/src/components/BookContextMenu.tsx
+++ b/src/components/BookContextMenu.tsx
@@ -3,6 +3,7 @@ import {
   BookOpen,
   CheckCircle2,
   FolderPlus,
+  FolderMinus,
   Trash2,
   ChevronRight,
   Plus,
@@ -15,6 +16,7 @@ interface BookContextMenuProps {
   y: number;
   bookId: string;
   bookStatus: string;
+  activeCollectionId?: string;
   onClose: () => void;
   onMarkFinished: () => void;
   onMarkReading: () => void;
@@ -27,6 +29,7 @@ export default function BookContextMenu({
   y,
   bookId,
   bookStatus,
+  activeCollectionId,
   onClose,
   onMarkFinished,
   onMarkReading,
@@ -37,7 +40,7 @@ export default function BookContextMenu({
   const [showCollections, setShowCollections] = useState(false);
   const [newName, setNewName] = useState("");
   const [creatingNew, setCreatingNew] = useState(false);
-  const { collections, create, addBook } = useCollections();
+  const { collections, create, addBook, removeBook } = useCollections();
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const submenuRef = useRef<HTMLDivElement>(null);
 
@@ -92,6 +95,13 @@ export default function BookContextMenu({
     onClose();
   };
 
+  const handleRemoveFromCollection = async () => {
+    if (!activeCollectionId) return;
+    await removeBook(activeCollectionId, bookId);
+    onBooksChanged?.();
+    onClose();
+  };
+
   const handleCreateAndAdd = async () => {
     const trimmed = newName.trim();
     if (!trimmed) return;
@@ -121,7 +131,7 @@ export default function BookContextMenu({
     <>
       <div
         ref={menuRef}
-        className="fixed z-50 bg-bg-surface/95 border border-border/80 rounded-[10px] py-1 w-[200px] backdrop-blur-sm shadow-[0px_20px_25px_0px_rgba(0,0,0,0.15),0px_8px_10px_0px_rgba(0,0,0,0.15)]"
+        className="fixed z-50 bg-bg-surface/95 border border-border/80 rounded-[10px] py-1 w-[220px] backdrop-blur-sm shadow-[0px_20px_25px_0px_rgba(0,0,0,0.15),0px_8px_10px_0px_rgba(0,0,0,0.15)]"
         style={{ left: x, top: y }}
       >
         {/* Status indicator */}
@@ -169,6 +179,19 @@ export default function BookContextMenu({
           </span>
           <ChevronRight size={12} className="text-text-muted" />
         </button>
+
+        {/* Remove from Collection (only when viewing a collection) */}
+        {activeCollectionId && (
+          <button
+            onClick={handleRemoveFromCollection}
+            className="flex items-center gap-3 w-[calc(100%-8px)] mx-1 px-3 h-[31.5px] rounded-sm text-left cursor-pointer hover:bg-accent-bg transition-colors"
+          >
+            <FolderMinus size={16} className="text-text-muted" />
+            <span className="flex-1 text-[13px] font-medium text-text-primary tracking-[-0.08px] whitespace-nowrap">
+              Remove from Collection
+            </span>
+          </button>
+        )}
 
         <div className="mx-3 my-1 h-px bg-border/80" />
 

--- a/src/components/BookGrid.tsx
+++ b/src/components/BookGrid.tsx
@@ -7,10 +7,11 @@ import BookContextMenu from "./BookContextMenu";
 
 interface BookGridProps {
   books: Book[];
+  activeCollectionId?: string;
   onBooksChanged?: () => void;
 }
 
-export default function BookGrid({ books, onBooksChanged }: BookGridProps) {
+export default function BookGrid({ books, activeCollectionId, onBooksChanged }: BookGridProps) {
   const navigate = useNavigate();
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -67,6 +68,7 @@ export default function BookGrid({ books, onBooksChanged }: BookGridProps) {
           y={contextMenu.y}
           bookId={contextMenu.book.id}
           bookStatus={contextMenu.book.status}
+          activeCollectionId={activeCollectionId}
           onClose={() => setContextMenu(null)}
           onMarkFinished={async () => {
             await markFinished(contextMenu.book.id);

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -8,10 +8,11 @@ import BookContextMenu from "./BookContextMenu";
 
 interface BookListProps {
   books: Book[];
+  activeCollectionId?: string;
   onBooksChanged?: () => void;
 }
 
-export default function BookList({ books, onBooksChanged }: BookListProps) {
+export default function BookList({ books, activeCollectionId, onBooksChanged }: BookListProps) {
   const navigate = useNavigate();
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -105,6 +106,7 @@ export default function BookList({ books, onBooksChanged }: BookListProps) {
           y={contextMenu.y}
           bookId={contextMenu.book.id}
           bookStatus={contextMenu.book.status}
+          activeCollectionId={activeCollectionId}
           onClose={() => setContextMenu(null)}
           onMarkFinished={async () => {
             await markFinished(contextMenu.book.id);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Search, LayoutGrid, List, Settings, Plus, Upload, BookOpen } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { invoke } from "@tauri-apps/api/core";
@@ -32,16 +32,21 @@ export default function Home() {
 
   // Collection-filtered books
   const [collectionBookIds, setCollectionBookIds] = useState<string[]>([]);
-  useEffect(() => {
-    if (!isCollectionFilter) {
-      setCollectionBookIds([]);
-      return;
-    }
+  const refreshCollectionBooks = useCallback(() => {
+    if (!isCollectionFilter) return;
     const collectionId = activeFilter.replace("collection:", "");
     invoke<string[]>("list_books_in_collection", { collectionId })
       .then(setCollectionBookIds)
       .catch(() => setCollectionBookIds([]));
   }, [activeFilter, isCollectionFilter]);
+
+  useEffect(() => {
+    if (!isCollectionFilter) {
+      setCollectionBookIds([]);
+      return;
+    }
+    refreshCollectionBooks();
+  }, [activeFilter, isCollectionFilter, refreshCollectionBooks]);
 
   // Keep stable refs for refresh functions so the drag-drop effect doesn't re-register
   const refreshRef = useRef(refresh);
@@ -192,19 +197,19 @@ export default function Home() {
                       ? "No books in this collection"
                       : activeFilter !== "all"
                         ? `No ${activeFilter} books`
-                        : "No books yet"}
+                        : "No books yet — import an EPUB or PDF to get started"}
                 </p>
                 {activeFilter === "all" && !searchQuery && (
                   <Button variant="primary" size="md" onClick={handleImport}>
                     <Plus size={16} />
-                    Import EPUB
+                    Import Book
                   </Button>
                 )}
               </div>
             ) : viewMode === "grid" ? (
-              <BookGrid books={displayBooks} onBooksChanged={() => { refresh(); allBooks.refresh(); collections.refresh(); }} />
+              <BookGrid books={displayBooks} activeCollectionId={isCollectionFilter ? activeFilter.replace("collection:", "") : undefined} onBooksChanged={() => { refresh(); allBooks.refresh(); collections.refresh(); refreshCollectionBooks(); }} />
             ) : (
-              <BookList books={displayBooks} onBooksChanged={() => { refresh(); allBooks.refresh(); collections.refresh(); }} />
+              <BookList books={displayBooks} activeCollectionId={isCollectionFilter ? activeFilter.replace("collection:", "") : undefined} onBooksChanged={() => { refresh(); allBooks.refresh(); collections.refresh(); refreshCollectionBooks(); }} />
             )}
           </div>
 


### PR DESCRIPTION
## Summary
- Add "Remove from Collection" option to the book context menu, shown only when viewing a collection
- Update empty state: "Import EPUB" → "Import Book" with hint that both EPUB & PDF are supported
- Collection view refreshes immediately after removing a book

## Test plan
- [ ] Right-click a book while viewing a collection → "Remove from Collection" appears
- [ ] Click "Remove from Collection" → book disappears from the collection view, sidebar count updates
- [ ] Right-click a book from "All Books" → "Remove from Collection" does NOT appear
- [ ] With no books, empty state shows "No books yet — import an EPUB or PDF to get started"

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)