### PR TITLE
fix: OpenAI OAuth default model and auto-save after login

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -181,6 +181,17 @@ export default function SettingsPage() {
       setOauthStatus(result);
       setOauthToast(true);
       setTimeout(() => setOauthToast(false), 2000);
+      // Auto-save AI configuration after successful OAuth login
+      await saveBulk({
+        ai_provider: provider,
+        ai_api_key: apiKey,
+        ai_model: model,
+        ai_base_url: baseUrl,
+        ai_temperature: String(temperature),
+        ai_keep_alive: keepAlive,
+        ai_auth_mode: authMode,
+      });
+      setAiDirty(false);
     } catch (err) {
       setOauthError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -244,7 +255,7 @@ export default function SettingsPage() {
                   if (p === "ollama") {
                     setBaseUrl("http://localhost:11434"); setModel("qwen3.5");
                   } else if (p === "openai") {
-                    setBaseUrl("https://api.openai.com"); setModel("gpt-4o"); setAuthMode("oauth");
+                    setBaseUrl("https://api.openai.com"); setModel("gpt-5.3-codex"); setAuthMode("oauth");
                   } else if (p === "anthropic") {
                     setBaseUrl(""); setModel("claude-sonnet-4-20250514");
                   } else if (p === "minimax") {


### PR DESCRIPTION
## Summary
- Fix default model when selecting OpenAI provider: `gpt-4o` → `gpt-5.3-codex` (since auth mode defaults to OAuth)
- Auto-save AI configuration after successful OAuth login, so users don't need to manually click "Save AI Configuration"

## Test plan
- [ ] Select OpenAI as provider → model field shows `gpt-5.3-codex` (not `gpt-4o`)
- [ ] Switch auth mode to API Key → model changes to `gpt-4o`
- [ ] Switch auth mode back to OAuth → model changes to `gpt-5.3-codex`
- [ ] Complete OAuth login flow → AI config is saved automatically, "Save" button is no longer dirty

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)