### PR TITLE
fix: preserve quoted passages across AI conversation history

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+labels: bug
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+
+
+## Actual Behavior
+
+
+
+## Root Cause (if known)
+
+
+
+## Environment
+
+- Quill version:
+- macOS version:
+- AI provider:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest a new feature
+labels: feature
+---
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+## Scope
+
+What should this feature do? Be specific about what's in and out of scope.
+
+## Design (optional)
+
+Any thoughts on how it should work or look?

--- a/docs/roadmap/milestone3-companion.md
+++ b/docs/roadmap/milestone3-companion.md
@@ -2,7 +2,13 @@
 
 Turn the AI reading assistant into a personalized companion powered by the persona engine.
 
----
+## Architecture
+
+- **Persona backend (private)** — stateful AI service that builds personality models from behavioral signals
+- **Quill remains local-first** — all data stays in local SQLite + iCloud sync. Backend is an optional upgrade, not a dependency
+- **Two backend endpoint types:**
+  - AI endpoints — drop-in replacement for direct LLM calls, returns personalized responses
+  - Signal collection — Quill pushes reading signals (highlights, notes, vocab, chats) for persona model updates
 
 ## Features
 

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -223,7 +223,6 @@ pub async fn ai_generate_title(
 #[tauri::command]
 pub async fn ai_chat(
     messages: Vec<ChatMessage>,
-    context: Option<String>,
     app: AppHandle,
     db: State<'_, Db>,
     secrets: State<'_, Secrets>,
@@ -261,18 +260,12 @@ pub async fn ai_chat(
         (api_key, None)
     };
 
-    // Build messages with optional context
+    // Build messages: system prompt + conversation history (context is inlined by frontend)
     let mut api_messages = Vec::new();
     api_messages.push(ChatMessage {
         role: "system".to_string(),
         content: "You are a helpful reading assistant. Help the user understand and discuss the book they are reading.".to_string(),
     });
-    if let Some(ctx) = context {
-        api_messages.push(ChatMessage {
-            role: "system".to_string(),
-            content: format!("The user has selected the following text from the book:\n\n{}", ctx),
-        });
-    }
     api_messages.extend(messages);
 
     // Spawn streaming in a background task so events emit immediately

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -334,14 +334,19 @@ export function useAiChat(bookId?: string) {
       );
 
       // Build API messages from current ref (avoids stale closure)
+      // Include each message's context inline so the AI sees all quoted passages
       const apiMessages = messagesRef.current
         .filter((m) => m.id !== assistantId)
-        .map((m) => ({ role: m.role, content: m.content }));
+        .map((m) => ({
+          role: m.role,
+          content: m.context
+            ? `[Selected passage: "${m.context}"]\n\n${m.content}`
+            : m.content,
+        }));
 
       try {
         await invoke("ai_chat", {
           messages: apiMessages,
-          context: context || null,
         });
       } catch (err) {
         setStreaming(false);


### PR DESCRIPTION
## Summary
- Fix: quoted passages from earlier "Ask AI" messages were lost in conversation history — AI only saw the most recent passage (#48)
- Add GitHub issue templates (bug report + feature request)
- Update milestone 3 architecture notes

## What changed
- **`useAiChat.ts`** — inline each message's `context` into `content` when building API messages, remove separate `context` param
- **`ai.rs`** — remove `context` parameter and system message injection (context now arrives inline)

## Test plan
- [ ] Select text → "Ask AI" → AI responds referencing passage A
- [ ] Send a custom follow-up message
- [ ] Select different text → "Ask AI" → AI should still be aware of passage A
- [ ] Purple blockquote UI display unchanged

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)