### PR TITLE
fix: preserve nested hierarchy in Table of Contents

### DIFF
--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -3,6 +3,7 @@ import { useEffect, useCallback, useRef } from "react";
 interface Chapter {
   title: string;
   page: number;
+  depth: number;
 }
 
 interface TableOfContentsProps {
@@ -84,7 +85,8 @@ export default function TableOfContents({
                 onNavigate(chapter.page);
                 onClose();
               }}
-              className={`flex items-center justify-between px-4 py-2 cursor-pointer transition-colors ${
+              style={{ paddingLeft: `${16 + chapter.depth * 16}px` }}
+              className={`flex items-center justify-between pr-4 py-2 cursor-pointer transition-colors ${
                 isActive
                   ? "bg-accent-bg"
                   : "hover:bg-bg-input"

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -91,6 +91,7 @@ type SidePanel = "ai" | "bookmarks" | "vocab" | null;
 interface TocChapter {
   title: string;
   href: string;
+  depth: number;
 }
 
 const highlightColorMap: Record<string, string> = {
@@ -263,11 +264,11 @@ export default function Reader() {
       const toc = view.book.toc;
       if (toc) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const flattenToc = (items: any[]): TocChapter[] =>
+        const flattenToc = (items: any[], depth = 0): TocChapter[] =>
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           items.flatMap((item: any) => [
-            { title: item.label?.trim() || "", href: item.href },
-            ...(item.subitems ? flattenToc(item.subitems) : []),
+            { title: item.label?.trim() || "", href: item.href, depth },
+            ...(item.subitems ? flattenToc(item.subitems, depth + 1) : []),
           ]);
         const chs = flattenToc(toc);
         chaptersRef.current = chs;
@@ -782,7 +783,7 @@ export default function Reader() {
           <TableOfContents
             open={tocOpen}
             onClose={() => setTocOpen(false)}
-            chapters={chapters.map((c, i) => ({ title: c.title, page: i + 1 }))}
+            chapters={chapters.map((c, i) => ({ title: c.title, page: i + 1, depth: c.depth }))}
             currentPage={currentChapterIndex + 1}
             onNavigate={(page) => {
               const ch = chapters[page - 1];


### PR DESCRIPTION
## Summary
- Preserve depth information when flattening TOC from foliate-js, instead of discarding it
- Render nested chapters with indentation (16px per level) in the ToC panel

Fixes #58

## Test plan
- [ ] Open an EPUB with nested TOC (chapters with sub-sections) — verify indentation
- [ ] Open a PDF with nested outline — verify indentation
- [ ] Verify active chapter highlighting still works at all depth levels
- [ ] Verify chapter navigation works for nested items

🤖 Generated with [Claude Code](https://claude.com/claude-code)