### PR TITLE
feat: settings modal with user profile

### DIFF
--- a/docs/impls/settings-modal.md
+++ b/docs/impls/settings-modal.md
@@ -1,0 +1,130 @@
+# Settings Modal & User Profile — Implementation Plan
+
+## Reference
+
+- **Issue:** [#59](https://github.com/yicheng47/quill/issues/59)
+- **Feature spec:** `docs/features/13-settings-modal.md`
+- **Style reference:** Obsidian settings (full-window modal, sidebar nav, scrollable content)
+
+---
+
+## Design (Figma)
+
+Style reference: **Obsidian settings modal**.
+
+### Modal
+
+- **Overlay**: full viewport, semi-transparent dark backdrop (`bg-overlay`)
+- **Container**: nearly full-window with ~40px margin on all sides, `bg-bg-page` background, `rounded-xl`, `border-border`
+- **Layout**: two-column horizontal split
+  - **Left panel** (sidebar): fixed ~200px width, `bg-bg-muted` background, right border separator
+  - **Right panel** (content): flex-1, scrollable vertically, padded (~24px)
+- **Close button**: top-right of the container, ✕ icon
+- **Dismissal**: Escape key, close button, backdrop click
+
+### Sidebar Navigation (left panel)
+
+- **Header**: "Settings" label at top, muted text, semibold
+- **Nav items**: flat vertical list, each row is icon (16px) + label (14px), left-aligned
+- **Active state**: `bg-bg-surface` background, `text-text-primary`, `rounded-lg`
+- **Inactive state**: `text-text-muted`, hover `bg-bg-input`
+- **No chevrons, no value previews** — icon + label only
+- **Sections** (in order):
+  1. General (Globe icon) — language, theme
+  2. Reading (BookOpen icon) — font, spacing, margins, auto-save
+  3. AI Assistant (Bot icon) — provider, model, auth, temperature
+  4. Lookup (Search icon) — native language, translation toggle, preview
+  5. iCloud (Cloud icon) — sync toggle, status
+  6. About (Info icon) — version
+
+### Content Area (right panel)
+
+- **Section title**: top of content area, 20px semibold `text-text-primary`
+- **Setting rows**: each setting is a horizontal row with thin `border-border` separator between items
+  - **Left**: setting name (14px semibold `text-text-primary`) + description below (13px `text-text-muted`)
+  - **Right**: control (dropdown, toggle, slider, input) aligned to the right, vertically centered
+- **Style**: Obsidian's borderless row-with-separator style (not grouped cards)
+- **Scrolls independently** from the sidebar
+
+### User Profile Region (Home page sidebar, bottom-left)
+
+- **Position**: bottom of the left sidebar, above the bottom edge, separated by border-top
+- **Content**: circular avatar with initials (from `user_name` setting) + name text beside it
+- **Fallback**: if no name set, show settings gear icon with "Settings" label
+- **Click action**: opens the settings modal
+- **Style**: subtle, `text-text-muted`, hover highlight, matches sidebar aesthetic
+
+### Design Tokens (existing system)
+
+- Backgrounds: `bg-bg-page`, `bg-bg-surface`, `bg-bg-muted`, `bg-bg-input`
+- Text: `text-text-primary`, `text-text-secondary`, `text-text-muted`
+- Accent: `text-accent-text`, `bg-accent`, `bg-accent-bg`
+- Border: `border-border`
+- Overlay: `bg-overlay`
+
+---
+
+## Implementation
+
+### Phase 1 — Settings modal shell + General section
+
+| File | Action |
+|------|--------|
+| `src/components/SettingsModal.tsx` | CREATE — modal overlay + two-panel layout |
+| `src/components/settings/GeneralSettings.tsx` | CREATE — language + theme |
+| `src/pages/Home.tsx` | MODIFY — add modal state, open trigger |
+| `src/components/Sidebar.tsx` | MODIFY — replace settings gear with user profile region |
+
+**SettingsModal:**
+- Full-viewport overlay with semi-transparent backdrop
+- Left panel: nav list (icon + label), fixed width (~200px)
+- Right panel: scrollable content, renders the active section component
+- Close on Escape, close button top-right
+- Close on backdrop click
+
+**Sidebar user profile:**
+- Bottom of sidebar: initials circle + user name
+- Click opens `SettingsModal`
+- Name stored in `settings` table as `user_name`
+- If empty, show settings gear icon with "Settings" label
+
+### Phase 2 — Migrate remaining sections
+
+| File | Action |
+|------|--------|
+| `src/components/settings/ReadingSettings.tsx` | CREATE — font, spacing, margins, auto-save |
+| `src/components/settings/AiSettings.tsx` | CREATE — provider, model, auth, temperature |
+| `src/components/settings/LookupSettings.tsx` | CREATE — native language, translation toggle, preview |
+| `src/components/settings/ICloudSettings.tsx` | CREATE — sync toggle, status |
+| `src/components/settings/AboutSettings.tsx` | CREATE — version info |
+
+Each component is extracted from the current `SettingsPage.tsx` monolith. Same logic, same auto-save behavior, just rendered inside the modal's content panel.
+
+### Phase 3 — Cleanup
+
+| File | Action |
+|------|--------|
+| `src/pages/SettingsPage.tsx` | DELETE |
+| `src/App.tsx` | MODIFY — remove `/settings` route |
+| `src/pages/Reader.tsx` | MODIFY — open modal instead of navigating to `/settings` |
+| `src/pages/Home.tsx` | MODIFY — remove settings navigation, use modal |
+
+---
+
+## Settings Sections Mapping
+
+| Section | Current location in `SettingsPage.tsx` | Content |
+|---------|---------------------------------------|---------|
+| General | Language + Appearance sections | Language dropdown, theme dropdown |
+| Reading | Default Layout + Reading Preferences | Font family, font size, line spacing, char/word spacing, margins, auto-save |
+| AI | AI Assistant Configuration | Provider, auth mode, OAuth, API key, base URL, model, temperature, keep-alive |
+| Lookup | Lookup section | Native language, show translation toggle, preview card |
+| iCloud | iCloud Sync section | Enable/disable, status, confirmation dialogs |
+| About | (new) | App version, links |
+
+## Notes
+
+- All settings share one `useSettings()` hook — already works, no change needed
+- i18n keys already exist for most settings labels
+- The modal should be rendered at the app root (in `Home.tsx` or `App.tsx`) so it can overlay any page
+- Reader page also needs a way to open settings (currently has a gear icon in the header)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { invoke } from "@tauri-apps/api/core";
 import Home from "./pages/Home";
 import Reader from "./pages/Reader";
-import SettingsPage from "./pages/SettingsPage";
 
 function applyTheme(theme: string) {
   const root = document.documentElement;
@@ -38,7 +37,6 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/reader/:bookId" element={<Reader />} />
-        <Route path="/settings" element={<SettingsPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/ChatsContent.tsx
+++ b/src/components/ChatsContent.tsx
@@ -8,7 +8,6 @@ import {
   Sparkles,
   Trash2,
   MessageSquare,
-  Settings,
   ArrowDownWideNarrow,
   ArrowUpWideNarrow,
 } from "lucide-react";
@@ -93,11 +92,7 @@ export default function ChatsContent() {
           <h1 className="text-[24px] font-semibold text-text-primary tracking-[0.07px]">
             {t("chats.title")}
           </h1>
-          <div className="flex items-center gap-0">
-            <Button variant="icon" size="md" onClick={() => navigate("/settings")}>
-              <Settings size={16} />
-            </Button>
-          </div>
+          <div className="flex items-center gap-0" />
         </div>
 
         <div className="flex items-center gap-2 h-9 px-3 rounded-lg bg-bg-input max-w-[448px]">

--- a/src/components/DictionaryContent.tsx
+++ b/src/components/DictionaryContent.tsx
@@ -14,7 +14,6 @@ import {
   ArrowDownAZ,
   ArrowDownWideNarrow,
   ArrowUpWideNarrow,
-  Settings,
 } from "lucide-react";
 import Button from "./ui/Button";
 import { useAllDictionary, type DictionaryWord } from "../hooks/useDictionary";
@@ -103,10 +102,6 @@ export default function DictionaryContent() {
             </Button>
             <Button variant="icon" size="md" active={view === "list"} onClick={() => setView("list")}>
               <List size={16} />
-            </Button>
-            <div className="w-px h-6 bg-border mx-2" />
-            <Button variant="icon" size="md" onClick={() => navigate("/settings")}>
-              <Settings size={16} />
             </Button>
           </div>
         </div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,190 @@
+import { useState, useEffect, useRef, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { Globe, BookOpen, Bot, Search, Cloud, Info, X, ChevronRight } from "lucide-react";
+import GeneralSettings from "./settings/GeneralSettings";
+import ReadingSettings from "./settings/ReadingSettings";
+import AiSettings from "./settings/AiSettings";
+import LookupSettings from "./settings/LookupSettings";
+import ICloudSettings from "./settings/ICloudSettings";
+import AboutSettings from "./settings/AboutSettings";
+import { useSettings } from "../hooks/useSettings";
+
+type Section = "general" | "reading" | "ai" | "lookup" | "icloud" | "about";
+
+interface SettingsModalProps {
+  open: boolean;
+  onClose: () => void;
+  initialSection?: Section;
+}
+
+export default function SettingsModal({ open, onClose, initialSection = "general" }: SettingsModalProps) {
+  const { t } = useTranslation();
+  const [activeSection, setActiveSection] = useState<Section>(initialSection);
+  const { settings, loading, save, saveBulk } = useSettings();
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Toast state
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
+  const toastTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const showSavedToast = (msg = t("settings.saved")) => {
+    if (toastTimeout.current) clearTimeout(toastTimeout.current);
+    setToastMessage(msg);
+    setShowToast(true);
+    toastTimeout.current = setTimeout(() => setShowToast(false), 1500);
+  };
+
+  useEffect(() => {
+    if (open) setActiveSection(initialSection);
+  }, [open, initialSection]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  // AI save state (must be before early return)
+  const [aiDirty, setAiDirty] = useState(false);
+  const aiSaveRef = useRef<(() => void) | null>(null);
+
+  if (!open) return null;
+
+  const sections: { id: Section; label: string; subtitle: string; icon: typeof Globe }[] = [
+    { id: "general", label: t("settings.general.title"), subtitle: t("settings.general.subtitle"), icon: Globe },
+    { id: "reading", label: t("settings.reading.title"), subtitle: t("settings.reading.subtitle"), icon: BookOpen },
+    { id: "ai", label: t("settings.ai.shortTitle"), subtitle: t("settings.ai.shortSubtitle"), icon: Bot },
+    { id: "lookup", label: t("settings.lookup.title"), subtitle: t("settings.lookup.shortSub"), icon: Search },
+    { id: "icloud", label: t("settings.icloud.title"), subtitle: t("settings.icloud.subtitle"), icon: Cloud },
+    { id: "about", label: t("settings.about.title"), subtitle: t("settings.about.subtitle"), icon: Info },
+  ];
+
+  const settingsProps = { settings, loading, save, saveBulk, showSavedToast };
+
+  const renderContent = (): ReactNode => {
+    switch (activeSection) {
+      case "general": return <GeneralSettings {...settingsProps} />;
+      case "reading": return <ReadingSettings {...settingsProps} />;
+      case "ai": return <AiSettings {...settingsProps} onDirtyChange={setAiDirty} onSaveRef={(fn) => { aiSaveRef.current = fn; }} />;
+      case "lookup": return <LookupSettings {...settingsProps} />;
+      case "icloud": return <ICloudSettings {...settingsProps} />;
+      case "about": return <AboutSettings />;
+    }
+  };
+
+  const active = sections.find((s) => s.id === activeSection);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={modalRef}
+        className="bg-white dark:bg-bg-surface rounded-2xl shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)] border border-border w-[780px] h-[80vh] max-h-[720px] min-h-[480px] flex overflow-hidden"
+      >
+        {/* Sidebar */}
+        <div className="w-[220px] shrink-0 bg-bg-muted border-r border-border">
+          <p className="text-[13px] font-semibold text-text-primary px-4 pt-4 pb-2">
+            {t("settings.title")}
+          </p>
+          <nav className="flex flex-col gap-0.5 px-2">
+            {sections.map((section) => {
+              const Icon = section.icon;
+              const isActive = activeSection === section.id;
+              return (
+                <button
+                  key={section.id}
+                  onClick={() => setActiveSection(section.id)}
+                  className={`flex items-center gap-3 px-3 h-[56px] rounded-[10px] w-full cursor-pointer text-left transition-colors ${
+                    isActive ? "bg-accent-bg" : "hover:bg-bg-input"
+                  }`}
+                >
+                  <Icon
+                    size={16}
+                    className={`shrink-0 ${isActive ? "text-accent-text" : "text-text-muted"}`}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className={`text-[14px] font-medium leading-[20px] tracking-[-0.15px] ${
+                      isActive ? "text-accent-text" : "text-text-secondary"
+                    }`}>
+                      {section.label}
+                    </p>
+                    <p className={`text-[11px] font-medium leading-[16px] tracking-[0.06px] truncate ${
+                      isActive ? "text-accent-text/60" : "text-text-muted"
+                    }`}>
+                      {section.subtitle}
+                    </p>
+                  </div>
+                  <ChevronRight
+                    size={14}
+                    className={`shrink-0 ${isActive ? "text-accent-text" : "text-text-muted/40"}`}
+                  />
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 flex flex-col min-w-0">
+          {/* Header actions */}
+          <div className="flex items-center justify-end gap-2 pr-3 pt-3">
+            {activeSection === "ai" && (
+              <button
+                onClick={() => aiSaveRef.current?.()}
+                disabled={!aiDirty}
+                className={`text-[13px] font-medium px-3 py-1 rounded-lg cursor-pointer transition-colors ${
+                  aiDirty
+                    ? "text-accent-text hover:bg-accent-bg"
+                    : "text-text-muted/40 cursor-default"
+                }`}
+              >
+                Save
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="size-7 flex items-center justify-center rounded-[10px] hover:bg-bg-input cursor-pointer"
+            >
+              <X size={16} className="text-text-muted" />
+            </button>
+          </div>
+
+          {/* Scrollable content */}
+          <div className="flex-1 overflow-y-auto px-6">
+            {/* Section header */}
+            <div className="mb-1">
+              <h3 className="text-[17px] font-semibold text-text-primary leading-[25px] tracking-[-0.43px]">
+                {active?.label}
+              </h3>
+              <p className="text-[13px] text-text-muted tracking-[-0.08px]">
+                {active?.subtitle}
+              </p>
+            </div>
+            <div className="h-px bg-black/10 mb-2" />
+
+            {renderContent()}
+          </div>
+        </div>
+      </div>
+
+      {/* Toast */}
+      {showToast && (
+        <div className="fixed top-6 left-1/2 -translate-x-1/2 bg-white dark:bg-bg-surface border border-border px-4 py-2.5 rounded-xl text-[13px] font-medium shadow-lg z-[60] flex items-center gap-2">
+          <div className="size-5 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center shrink-0">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <path d="M2.5 6L5 8.5L9.5 3.5" stroke="#22c55e" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </div>
+          <span className="text-text-primary">{toastMessage}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,9 +14,11 @@ interface SidebarProps {
     collections: Collection[];
     create: (name: string) => Promise<Collection>;
   };
+  userName?: string;
+  onOpenSettings?: () => void;
 }
 
-export default function Sidebar({ activeFilter, onFilterChange, books, collections: collectionsHook }: SidebarProps) {
+export default function Sidebar({ activeFilter, onFilterChange, books, collections: collectionsHook, userName, onOpenSettings }: SidebarProps) {
   const { t } = useTranslation();
 
   const libraryFilters = [
@@ -198,6 +200,26 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
             );
           })}
         </div>
+      </div>
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* User profile */}
+      <div className="border-t border-border pt-3 pb-3">
+        <button
+          onClick={onOpenSettings}
+          className="flex items-center gap-2.5 px-2 py-1.5 rounded-lg w-full cursor-pointer hover:bg-bg-input"
+        >
+          <div className="size-7 rounded-full bg-accent flex items-center justify-center text-[12px] font-semibold text-white shrink-0">
+            {userName
+              ? userName.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2)
+              : "R"}
+          </div>
+          <div className="min-w-0">
+            <p className="text-[13px] font-medium text-text-primary truncate">{userName || "Reader"}</p>
+            <p className="text-[11px] text-text-muted">{t("settings.title")}</p>
+          </div>
+        </button>
       </div>
     </aside>
   );

--- a/src/components/settings/AboutSettings.tsx
+++ b/src/components/settings/AboutSettings.tsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { getVersion } from "@tauri-apps/api/app";
+
+export default function AboutSettings() {
+  const { t } = useTranslation();
+  const [version, setVersion] = useState("");
+
+  useEffect(() => {
+    getVersion().then(setVersion).catch(() => setVersion("unknown"));
+  }, []);
+
+  return (
+    <div className="space-y-0">
+      {/* Version */}
+      <div className="py-3 border-b border-border">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-[14px] font-medium text-text-primary">Quill</p>
+            <p className="text-[12px] text-text-muted mt-0.5">{t("settings.about.description")}</p>
+          </div>
+          <span className="text-[13px] text-text-muted tabular-nums">v{version}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/AiSettings.tsx
+++ b/src/components/settings/AiSettings.tsx
@@ -1,0 +1,344 @@
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { KeyRound, Shield } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import Button from "../ui/Button";
+import Select from "../ui/Select";
+import Input from "../ui/Input";
+import Slider from "../ui/Slider";
+import type { SettingsProps } from "./types";
+
+interface AiSettingsProps extends SettingsProps {
+  onSaveRef?: (save: (() => void) | null) => void;
+  onDirtyChange?: (dirty: boolean) => void;
+}
+
+export default function AiSettings({ settings, loading, saveBulk, showSavedToast, onSaveRef, onDirtyChange }: AiSettingsProps) {
+  const { t } = useTranslation();
+  const [aiDirty, setAiDirty] = useState(false);
+
+  // AI config
+  const [provider, setProvider] = useState("openai");
+  const [apiKey, setApiKey] = useState("");
+  const [model, setModel] = useState("gpt-5.3-codex");
+  const [baseUrl, setBaseUrl] = useState("https://api.openai.com");
+  const [temperature, setTemperature] = useState(0.3);
+  const [keepAlive, setKeepAlive] = useState("30m");
+
+  // OAuth
+  const [authMode, setAuthMode] = useState<"api_key" | "oauth">("oauth");
+  const [oauthStatus, setOauthStatus] = useState<{ connected: boolean; account_id: string | null }>({ connected: false, account_id: null });
+  const [oauthLoading, setOauthLoading] = useState(false);
+  const [oauthError, setOauthError] = useState<string | null>(null);
+  const [oauthToast, setOauthToast] = useState(false);
+
+  // Load saved settings
+  useEffect(() => {
+    if (loading) return;
+    if (settings.ai_provider) setProvider(settings.ai_provider);
+    if (settings.ai_api_key) setApiKey(settings.ai_api_key);
+    if (settings.ai_model) setModel(settings.ai_model);
+    if (settings.ai_base_url) setBaseUrl(settings.ai_base_url);
+    if (settings.ai_temperature) setTemperature(parseFloat(settings.ai_temperature));
+    if (settings.ai_keep_alive) setKeepAlive(settings.ai_keep_alive);
+    if (settings.ai_auth_mode) setAuthMode(settings.ai_auth_mode as "api_key" | "oauth");
+  }, [settings, loading]);
+
+  // Fetch OAuth status when provider is OpenAI
+  useEffect(() => {
+    if (provider === "openai") {
+      invoke<{ connected: boolean; account_id: string | null }>("openai_oauth_status")
+        .then(setOauthStatus)
+        .catch(() => setOauthStatus({ connected: false, account_id: null }));
+    }
+  }, [provider]);
+
+  // Expose dirty state and save handler to parent
+  useEffect(() => {
+    onDirtyChange?.(aiDirty);
+  }, [aiDirty, onDirtyChange]);
+
+  useEffect(() => {
+    onSaveRef?.(handleSaveAI);
+    return () => onSaveRef?.(null);
+  });
+
+  const handleSaveAI = async () => {
+    try {
+      await saveBulk({
+        ai_provider: provider,
+        ai_api_key: apiKey,
+        ai_model: model,
+        ai_base_url: baseUrl,
+        ai_temperature: String(temperature),
+        ai_keep_alive: keepAlive,
+        ai_auth_mode: authMode,
+      });
+      setAiDirty(false);
+      showSavedToast(t("settings.ai.savedToast"));
+    } catch (err) {
+      console.error("Failed to save AI settings:", err);
+    }
+  };
+
+  const handleOAuthLogin = async () => {
+    setOauthLoading(true);
+    setOauthError(null);
+    try {
+      const result = await invoke<{ connected: boolean; account_id: string | null }>("openai_oauth_login");
+      setOauthStatus(result);
+      setOauthToast(true);
+      setTimeout(() => setOauthToast(false), 2000);
+      // Auto-save AI configuration after successful OAuth login
+      await saveBulk({
+        ai_provider: provider,
+        ai_api_key: apiKey,
+        ai_model: model,
+        ai_base_url: baseUrl,
+        ai_temperature: String(temperature),
+        ai_keep_alive: keepAlive,
+        ai_auth_mode: authMode,
+      });
+      setAiDirty(false);
+    } catch (err) {
+      setOauthError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setOauthLoading(false);
+    }
+  };
+
+  const handleOAuthLogout = async () => {
+    try {
+      await invoke("openai_oauth_logout");
+      setOauthStatus({ connected: false, account_id: null });
+    } catch (err) {
+      console.error("Failed to logout:", err);
+    }
+  };
+
+  return (
+    <div className="space-y-0">
+      {/* Provider */}
+      <div className="py-3 border-b border-border">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-[14px] font-medium text-text-primary">{t("settings.ai.provider")}</p>
+            <p className="text-[12px] text-text-muted mt-0.5">{t("settings.ai.providerHint")}</p>
+          </div>
+          <Select
+            className="w-[160px] shrink-0"
+            value={provider}
+            onChange={(p) => {
+              setProvider(p);
+              setApiKey("");
+              setAiDirty(true);
+              if (p === "ollama") {
+                setBaseUrl("http://localhost:11434"); setModel("qwen3.5");
+              } else if (p === "openai") {
+                setBaseUrl("https://api.openai.com"); setModel("gpt-5.3-codex"); setAuthMode("oauth");
+              } else if (p === "anthropic") {
+                setBaseUrl(""); setModel("claude-sonnet-4-20250514");
+              } else if (p === "minimax") {
+                setBaseUrl("https://api.minimax.io/anthropic"); setModel("MiniMax-M2.5");
+              } else {
+                setBaseUrl(""); setModel("");
+              }
+            }}
+            options={[
+              { value: "openai", label: "OpenAI" },
+              { value: "anthropic", label: "Anthropic" },
+              { value: "minimax", label: "MiniMax" },
+              { value: "google", label: "Google AI" },
+              { value: "ollama", label: "Ollama (Local)" },
+            ]}
+          />
+        </div>
+      </div>
+
+      {/* Authentication Method (OpenAI only) */}
+      {provider === "openai" && (
+        <div className="py-3 border-b border-border">
+          <p className="text-[14px] font-medium text-text-primary mb-1.5">
+            {t("settings.ai.authMethod")}
+          </p>
+          <div className="flex rounded-lg border border-border overflow-hidden">
+            <button
+              type="button"
+              className={`flex-1 flex items-center justify-center gap-2 h-9 text-[13px] font-medium transition-colors ${
+                authMode === "api_key"
+                  ? "bg-accent text-white"
+                  : "bg-bg-page text-text-secondary hover:bg-bg-input"
+              }`}
+              onClick={() => { setAuthMode("api_key"); setModel("gpt-4o"); setAiDirty(true); }}
+            >
+              <KeyRound size={14} />
+              {t("settings.ai.apiKey")}
+            </button>
+            <button
+              type="button"
+              className={`flex-1 flex items-center justify-center gap-2 h-9 text-[13px] font-medium transition-colors ${
+                authMode === "oauth"
+                  ? "bg-accent text-white"
+                  : "bg-bg-page text-text-secondary hover:bg-bg-input"
+              }`}
+              onClick={() => { setAuthMode("oauth"); setModel("gpt-5.3-codex"); setAiDirty(true); }}
+            >
+              <Shield size={14} />
+              {t("settings.ai.oauthLogin")}
+            </button>
+          </div>
+          <p className="text-[12px] text-text-muted mt-1.5">{t("settings.ai.authMethodHint")}</p>
+        </div>
+      )}
+
+      {/* OAuth Login Panel (OpenAI + OAuth mode) */}
+      {provider === "openai" && authMode === "oauth" && (
+        <div className="py-3 border-b border-border">
+          {oauthStatus.connected ? (
+            <div className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5">
+              <div className="flex items-center gap-2">
+                <span className="size-2 rounded-full bg-accent" />
+                <span className="size-2 rounded-full bg-green-500" />
+                <span className="text-[13px] text-text-primary font-medium">
+                  {t("settings.ai.connected", { account: oauthStatus.account_id ?? "Unknown" })}
+                </span>
+              </div>
+              <button
+                type="button"
+                className="text-[13px] font-medium text-text-muted hover:text-text-primary transition-colors"
+                onClick={handleOAuthLogout}
+              >
+                {t("settings.ai.logout")}
+              </button>
+            </div>
+          ) : (
+            <>
+              <Button
+                variant="primary"
+                size="lg"
+                className="w-full justify-center"
+                disabled={oauthLoading}
+                onClick={handleOAuthLogin}
+              >
+                {oauthLoading ? t("settings.ai.waitingAuth") : t("settings.ai.loginWithOpenAI")}
+              </Button>
+              {oauthError ? (
+                <div className="flex items-center justify-between mt-2 px-3 py-2 rounded-lg bg-red-50 dark:bg-red-950/30">
+                  <span className="text-[12px] text-red-600 dark:text-red-400">
+                    {t("settings.ai.authFailed")}
+                  </span>
+                  <button
+                    type="button"
+                    className="text-[12px] font-medium text-red-600 dark:text-red-400 hover:underline"
+                    onClick={handleOAuthLogin}
+                  >
+                    {t("settings.ai.retry")}
+                  </button>
+                </div>
+              ) : (
+                <p className="text-[12px] text-text-muted mt-1.5">
+                  {t("settings.ai.oauthHint")}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* API Key (for Anthropic / OpenAI Compatible -- hidden when OpenAI + OAuth) */}
+      {(provider === "anthropic" || (provider === "openai" && authMode === "api_key") || provider === "minimax") && (
+        <div className="py-3 border-b border-border">
+          <p className="text-[14px] font-medium text-text-primary mb-1.5">
+            {t("settings.ai.apiKey")}
+          </p>
+          <Input
+            type="password"
+            value={apiKey}
+            onChange={(e) => { setApiKey(e.target.value); setAiDirty(true); }}
+            placeholder={provider === "anthropic" ? "sk-ant-..." : "sk-..."}
+          />
+          <p className="text-[12px] text-text-muted mt-1.5">
+            {t("settings.ai.apiKeyHint")}
+          </p>
+        </div>
+      )}
+
+      {/* Base URL (for Ollama / OpenAI Compatible) */}
+      {(provider === "ollama" || (provider === "openai" && authMode === "api_key") || provider === "minimax" || provider === "anthropic") && (
+        <div className="py-3 border-b border-border">
+          <p className="text-[14px] font-medium text-text-primary mb-1.5">
+            {t("settings.ai.baseUrl")}
+          </p>
+          <Input
+            value={baseUrl}
+            onChange={(e) => { setBaseUrl(e.target.value); setAiDirty(true); }}
+            placeholder={provider === "ollama" ? "http://localhost:11434" : "https://api.openai.com"}
+          />
+          <p className="text-[12px] text-text-muted mt-1.5">
+            {provider === "ollama" ? t("settings.ai.baseUrlOllama") : t("settings.ai.baseUrlGeneric")}
+          </p>
+        </div>
+      )}
+
+      {/* Model */}
+      <div className="py-3 border-b border-border">
+        <p className="text-[14px] font-medium text-text-primary mb-1.5">
+          {t("settings.ai.model")}
+        </p>
+        <Input
+          value={model}
+          onChange={(e) => { setModel(e.target.value); setAiDirty(true); }}
+          placeholder={
+            provider === "ollama" ? "qwen3.5" :
+            provider === "anthropic" ? "claude-sonnet-4-20250514" :
+            provider === "minimax" ? "MiniMax-M2.5" :
+            provider === "google" ? "gemini-2.0-flash" :
+            (provider === "openai" && authMode === "oauth") ? "gpt-5.3-codex" :
+            "gpt-4o"
+          }
+        />
+        <p className="text-[12px] text-text-muted mt-1.5">
+          {t("settings.ai.modelHint")}
+        </p>
+      </div>
+
+      {/* Temperature */}
+      <div className="py-3 border-b border-border">
+        <Slider
+          label={t("settings.ai.temperature")}
+          min={0}
+          max={100}
+          value={Math.round(temperature * 100)}
+          onChange={(v) => { setTemperature(v / 100); setAiDirty(true); }}
+          displayValue={temperature.toFixed(1)}
+          hint={t("settings.ai.temperatureHint")}
+        />
+      </div>
+
+      {/* Keep Alive (Ollama only) */}
+      {provider === "ollama" && (
+        <div className="py-3 border-b border-border">
+          <p className="text-[14px] font-medium text-text-primary mb-1.5">
+            {t("settings.ai.keepAlive")}
+          </p>
+          <Input
+            value={keepAlive}
+            onChange={(e) => { setKeepAlive(e.target.value); setAiDirty(true); }}
+            placeholder="30m"
+          />
+          <p className="text-[12px] text-text-muted mt-1.5">
+            {t("settings.ai.keepAliveHint")}
+          </p>
+        </div>
+      )}
+
+
+      {/* OAuth success toast */}
+      {oauthToast && (
+        <div className="fixed top-6 left-1/2 -translate-x-1/2 z-50 bg-accent text-white text-[13px] font-medium px-4 py-2 rounded-lg shadow-popover flex items-center gap-2">
+          {t("settings.ai.oauthSuccess")}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/GeneralSettings.tsx
+++ b/src/components/settings/GeneralSettings.tsx
@@ -1,0 +1,116 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import i18n from "../../i18n";
+import Select from "../ui/Select";
+import Toggle from "../ui/Toggle";
+import type { SettingsProps } from "./types";
+
+export default function GeneralSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
+  const { t } = useTranslation();
+  const [displayName, setDisplayName] = useState("Reader");
+  const [language, setLanguage] = useState("en");
+  const [theme, setTheme] = useState("system");
+  const [autoSave, setAutoSave] = useState(true);
+
+  useEffect(() => {
+    if (loading) return;
+    if (settings.user_name) setDisplayName(settings.user_name);
+    if (settings.language) setLanguage(settings.language);
+    if (settings.theme) setTheme(settings.theme);
+    if (settings.auto_save) setAutoSave(settings.auto_save === "true");
+  }, [settings, loading]);
+
+  const applyTheme = (value: string) => {
+    const root = document.documentElement;
+    if (value === "dark") root.classList.add("dark");
+    else if (value === "light") root.classList.remove("dark");
+    else {
+      const dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      root.classList.toggle("dark", dark);
+    }
+  };
+
+  return (
+    <div>
+      {/* Display Name */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.general.displayName")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.general.displayNameHint")}</p>
+        </div>
+        <input
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          onBlur={() => { save("user_name", displayName); showSavedToast(); }}
+          onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+          placeholder="Reader"
+          className="w-[120px] shrink-0 h-8 bg-white dark:bg-bg-surface rounded-[10px] px-3 text-[13px] font-medium text-text-secondary text-center outline-none border border-border focus:border-accent transition-colors"
+        />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Language */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.language")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.general.languageHint")}</p>
+        </div>
+        <Select
+          className="w-[130px] shrink-0"
+          value={language}
+          onChange={(lang) => {
+            setLanguage(lang);
+            save("language", lang);
+            i18n.changeLanguage(lang);
+            showSavedToast();
+          }}
+          options={[
+            { value: "en", label: "English" },
+            { value: "zh", label: "简体中文" },
+          ]}
+        />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Theme */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.appearance.theme")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.general.themeHint")}</p>
+        </div>
+        <Select
+          className="w-[130px] shrink-0"
+          value={theme}
+          onChange={(value) => {
+            setTheme(value);
+            save("theme", value);
+            applyTheme(value);
+            showSavedToast();
+          }}
+          options={[
+            { value: "system", label: t("settings.appearance.system") },
+            { value: "light", label: t("settings.appearance.light") },
+            { value: "dark", label: t("settings.appearance.dark") },
+          ]}
+        />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Auto Save */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.reading.autoSave")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.reading.autoSaveHint")}</p>
+        </div>
+        <Toggle
+          checked={autoSave}
+          onChange={(v) => {
+            setAutoSave(v);
+            save("auto_save", String(v));
+            showSavedToast();
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ICloudSettings.tsx
+++ b/src/components/settings/ICloudSettings.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import Button from "../ui/Button";
+import Toggle from "../ui/Toggle";
+import type { SettingsProps } from "./types";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function ICloudSettings(_props: SettingsProps) {
+  const { t } = useTranslation();
+
+  const [icloudAvailable, setIcloudAvailable] = useState(false);
+  const [icloudEnabled, setIcloudEnabled] = useState(false);
+  const [icloudHasExistingData, setIcloudHasExistingData] = useState(false);
+  const [icloudLoading, setIcloudLoading] = useState(false);
+  const [icloudError, setIcloudError] = useState<string | null>(null);
+  const [icloudConfirm, setIcloudConfirm] = useState<"enable" | "disable" | null>(null);
+
+  useEffect(() => {
+    invoke<{ available: boolean; enabled: boolean; has_existing_data: boolean }>("icloud_status")
+      .then((status) => {
+        setIcloudAvailable(status.available);
+        setIcloudEnabled(status.enabled);
+        setIcloudHasExistingData(status.has_existing_data);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleIcloudToggle = () => {
+    setIcloudConfirm(icloudEnabled ? "disable" : "enable");
+  };
+
+  const confirmIcloudToggle = async () => {
+    const action = icloudConfirm;
+    setIcloudConfirm(null);
+    setIcloudLoading(true);
+    setIcloudError(null);
+    try {
+      const minDelay = new Promise((r) => setTimeout(r, 1500));
+      if (action === "disable") {
+        await Promise.all([invoke("icloud_disable"), minDelay]);
+        setIcloudEnabled(false);
+      } else {
+        await Promise.all([invoke("icloud_enable"), minDelay]);
+        setIcloudEnabled(true);
+      }
+    } catch (err) {
+      setIcloudError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIcloudLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div>
+        {/* Enable / Disable Toggle */}
+        <div className="flex items-center justify-between h-[73px]">
+          {icloudLoading ? (
+            <div className="flex items-center gap-2">
+              <Loader2 size={16} className="text-text-muted animate-spin" />
+              <p className="text-[13px] text-text-muted">{t("settings.icloud.moving")}</p>
+            </div>
+          ) : (
+            <>
+              <div>
+                <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">
+                  {t("settings.icloud.enable")}
+                </p>
+                <p className="text-[12px] text-text-muted mt-0.5">
+                  {!icloudAvailable
+                    ? t("settings.icloud.signIn")
+                    : t("settings.icloud.enableSub")}
+                </p>
+              </div>
+              <Toggle
+                checked={icloudEnabled}
+                onChange={handleIcloudToggle}
+                disabled={!icloudAvailable}
+              />
+            </>
+          )}
+        </div>
+
+        {/* Note */}
+        <p className="text-[12px] text-text-muted leading-[1.5] mt-1">
+          {t("settings.icloud.keysNote")}
+        </p>
+
+        {/* Error */}
+        {icloudError && (
+          <div className="flex items-center justify-between bg-[#fef2f2] dark:bg-red-950/30 border border-[#ffc9c9] dark:border-red-800 rounded-lg px-3.5 py-2 mt-3">
+            <span className="text-[12px] text-[#e7000b] dark:text-red-400">
+              {t("settings.icloud.error")}
+            </span>
+            <button
+              type="button"
+              className="text-[12px] font-medium text-[#e7000b] dark:text-red-400 underline cursor-pointer"
+              onClick={handleIcloudToggle}
+            >
+              {t("settings.ai.retry")}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Confirmation dialog */}
+      {icloudConfirm && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40">
+          <div className="bg-bg-surface rounded-xl shadow-lg w-[400px] p-6">
+            <h3 className="text-[18px] font-semibold text-text-primary mb-2">
+              {icloudConfirm === "enable"
+                ? icloudHasExistingData
+                  ? t("settings.icloud.confirmEnableExisting")
+                  : t("settings.icloud.confirmEnable")
+                : t("settings.icloud.confirmDisable")}
+            </h3>
+            <p className="text-[14px] text-text-secondary leading-5 mb-6">
+              {icloudConfirm === "enable"
+                ? icloudHasExistingData
+                  ? t("settings.icloud.confirmEnableExistingMsg")
+                  : t("settings.icloud.confirmEnableMsg")
+                : t("settings.icloud.confirmDisableMsg")}
+            </p>
+            <div className="flex justify-end gap-3">
+              <Button variant="ghost" size="md" onClick={() => setIcloudConfirm(null)}>
+                {t("common.cancel")}
+              </Button>
+              <Button variant="primary" size="md" onClick={confirmIcloudToggle}>
+                {icloudConfirm === "enable"
+                  ? icloudHasExistingData ? t("settings.icloud.syncWithIcloud") : t("settings.icloud.moveToIcloud")
+                  : t("settings.icloud.moveToLocal")}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/settings/LookupSettings.tsx
+++ b/src/components/settings/LookupSettings.tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Sparkles, X } from "lucide-react";
+import Select from "../ui/Select";
+import Toggle from "../ui/Toggle";
+import type { SettingsProps } from "./types";
+
+export default function LookupSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
+  const { t, i18n } = useTranslation();
+  const [nativeLanguage, setNativeLanguage] = useState("en");
+  const [showTranslation, setShowTranslation] = useState(false);
+
+  const language = i18n.language;
+
+  useEffect(() => {
+    if (loading) return;
+    if (settings.native_language) setNativeLanguage(settings.native_language);
+    if (settings.show_translation) setShowTranslation(settings.show_translation === "true");
+  }, [settings, loading]);
+
+  return (
+    <div>
+      {/* Native Language */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">
+            {t("settings.lookup.nativeLanguage")}
+          </p>
+          <p className="text-[12px] text-text-muted mt-0.5">
+            {t("settings.lookup.nativeLanguageHint")}
+          </p>
+        </div>
+        <Select
+          className="w-[130px] shrink-0"
+          value={nativeLanguage}
+          onChange={(lang) => {
+            setNativeLanguage(lang);
+            save("native_language", lang);
+            showSavedToast();
+          }}
+          options={[
+            { value: "en", label: "English" },
+            { value: "zh", label: "简体中文" },
+          ]}
+        />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Show Translation */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">
+            {t("settings.lookup.showTranslation")}
+          </p>
+          <p className="text-[12px] text-text-muted mt-0.5">
+            {t("settings.lookup.showTranslationHint")}
+          </p>
+        </div>
+        <Toggle
+          checked={showTranslation}
+          onChange={(checked) => {
+            setShowTranslation(checked);
+            save("show_translation", String(checked));
+            showSavedToast();
+          }}
+        />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Preview */}
+      <div className="mt-5">
+        <p className="text-[12px] font-medium text-text-muted mb-2 uppercase tracking-[0.3px]">Preview</p>
+        <div className="bg-white dark:bg-bg-surface border border-border/80 rounded-xl shadow-sm overflow-hidden max-w-[360px]">
+          <div className="flex items-center justify-between px-3 pt-2.5 pb-2 bg-accent-bg border-b border-border/40">
+            <div className="flex items-center gap-1.5">
+              <Sparkles size={13} className="text-accent-text" />
+              <span className="text-[12px] font-medium text-accent-text">{t("lookup.title")}</span>
+            </div>
+            <X size={12} className="text-text-muted" />
+          </div>
+          <div className="px-3 py-2.5">
+            <p className="text-[15px] font-bold text-text-primary mb-0.5">interfaces</p>
+            {language !== "en" ? (
+              <>
+                <p className="text-[12px] text-text-secondary leading-[1.5] mb-2">
+                  {language === "zh"
+                    ? "\u540d\u8bcd\u3002\u4e24\u4e2a\u7cfb\u7edf\u76f8\u4e92\u8fde\u63a5\u548c\u4ea4\u4e92\u7684\u70b9\u6216\u533a\u57df\u3002"
+                    : "A term used in this passage to convey a specific quality relevant to themes of technological advancement."}
+                </p>
+                <div className="p-2 rounded-md bg-bg-muted border border-border/50">
+                  <p className="text-[10px] font-medium text-text-muted mb-0.5">{t("lookup.inContext")}</p>
+                  <p className="text-[10px] text-text-secondary leading-[1.5]">
+                    {language === "zh"
+                      ? "\u5728\u8fd9\u6bb5\u6587\u5b57\u4e2d\uff0cinterfaces \u6307\u7684\u662f\u4eba\u7c7b\u4e0e\u6280\u672f\u4e4b\u95f4\u7684\u8fb9\u754c\u3002"
+                      : 'This word contributes to the author\u2019s exploration of the intersection between humanity and technology.'}
+                  </p>
+                </div>
+              </>
+            ) : (
+              <>
+                {showTranslation && nativeLanguage !== "en" && (
+                  <p className="text-[12px] text-accent-text mb-1">
+                    {nativeLanguage === "zh" ? "\u754c\u9762\uff1b\u63a5\u53e3" : "interfaces"}
+                  </p>
+                )}
+                <p className="text-[11px] text-text-secondary leading-[1.5] mb-2">
+                  A term used in this passage to convey a specific quality relevant to themes of technological advancement.
+                </p>
+                <div className="p-2 rounded-md bg-bg-muted border border-border/50">
+                  <p className="text-[10px] font-medium text-text-muted mb-0.5">{t("lookup.inContext")}</p>
+                  <p className="text-[10px] text-text-secondary leading-[1.5]">
+                    {"This word contributes to the author\u2019s exploration of the intersection between humanity and technology."}
+                  </p>
+                </div>
+              </>
+            )}
+          </div>
+          <div className="flex items-center justify-between px-3 py-2 border-t border-border/40">
+            <span className="text-[11px] font-medium text-accent-text">{t("lookup.saveToDict")}</span>
+            <span className="text-[11px] font-medium text-text-muted">{t("lookup.copy")}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ReadingSettings.tsx
+++ b/src/components/settings/ReadingSettings.tsx
@@ -1,0 +1,114 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import Select from "../ui/Select";
+import type { SettingsProps } from "./types";
+
+function NumberInput({ value, onChange, onBlur, suffix, min, max }: {
+  value: number;
+  onChange: (v: number) => void;
+  onBlur: () => void;
+  suffix?: string;
+  min?: number;
+  max?: number;
+}) {
+  return (
+    <div className="flex items-center gap-1 shrink-0 w-[90px] justify-end">
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => {
+          const v = Number(e.target.value);
+          if (min !== undefined && v < min) return;
+          if (max !== undefined && v > max) return;
+          onChange(v);
+        }}
+        onBlur={onBlur}
+        onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+        className="w-[64px] h-8 bg-white dark:bg-bg-surface rounded-[10px] px-2 text-[13px] font-medium text-text-secondary text-center outline-none border border-border focus:border-accent transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+      />
+      <span className="text-[12px] text-text-muted w-[16px] text-left">{suffix}</span>
+    </div>
+  );
+}
+
+export default function ReadingSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
+  const { t } = useTranslation();
+  const [fontFamily, setFontFamily] = useState("georgia");
+  const [fontSize, setFontSize] = useState(26);
+  const [lineSpacing, setLineSpacing] = useState(1.8);
+  const [wordSpacing, setWordSpacing] = useState(0);
+  const [margins, setMargins] = useState(0);
+
+  useEffect(() => {
+    if (loading) return;
+    if (settings.font_family) setFontFamily(settings.font_family);
+    if (settings.font_size) setFontSize(parseInt(settings.font_size));
+    if (settings.line_spacing) setLineSpacing(parseFloat(settings.line_spacing));
+    if (settings.word_spacing) setWordSpacing(parseInt(settings.word_spacing));
+    if (settings.margins) setMargins(parseInt(settings.margins));
+  }, [settings, loading]);
+
+  return (
+    <div>
+      {/* Font Family */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.layout.fontFamily")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.layout.fontFamilyHint")}</p>
+        </div>
+        <Select
+          className="w-[160px] shrink-0"
+          value={fontFamily}
+          onChange={(v) => { setFontFamily(v); save("font_family", v); showSavedToast(); }}
+          options={[
+            { value: "georgia", label: "Georgia" },
+            { value: "palatino", label: "Palatino" },
+            { value: "times", label: "Times New Roman" },
+            { value: "system-ui", label: "System" },
+            { value: "sans-serif", label: "Sans Serif" },
+          ]}
+        />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Font Size */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.layout.fontSize")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.layout.fontSizeHint")}</p>
+        </div>
+        <NumberInput value={fontSize} onChange={setFontSize} onBlur={() => save("font_size", String(fontSize))} suffix="px" min={8} max={48} />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Line Spacing */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.layout.lineSpacing")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.layout.lineSpacingHint")}</p>
+        </div>
+        <NumberInput value={lineSpacing} onChange={setLineSpacing} onBlur={() => save("line_spacing", String(lineSpacing))} suffix="x" min={1} max={3} />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Word Spacing */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.layout.wordSpacing")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.layout.wordSpacingHint")}</p>
+        </div>
+        <NumberInput value={wordSpacing} onChange={setWordSpacing} onBlur={() => save("word_spacing", String(wordSpacing))} suffix="px" min={-4} max={16} />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Margins */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.layout.margins")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.layout.marginsHint")}</p>
+        </div>
+        <NumberInput value={margins} onChange={setMargins} onBlur={() => save("margins", String(margins))} suffix="%" min={0} max={30} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -1,0 +1,7 @@
+export interface SettingsProps {
+  settings: Record<string, string>;
+  loading: boolean;
+  save: (key: string, value: string) => Promise<void>;
+  saveBulk: (entries: Record<string, string>) => Promise<void>;
+  showSavedToast: (msg?: string) => void;
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -15,7 +15,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         )}
         <input
           ref={ref}
-          className={`w-full h-9 bg-bg-input rounded-lg text-[14px] tracking-[-0.15px] text-text-primary placeholder:text-text-placeholder outline-none border border-transparent focus:border-accent ${
+          className={`w-full h-9 bg-bg-surface rounded-lg text-[14px] tracking-[-0.15px] text-text-primary placeholder:text-text-placeholder outline-none border border-border focus:border-accent ${
             icon ? "pl-9 pr-3" : "px-3"
           }`}
           {...props}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -46,7 +46,7 @@ export default function Select({ label, value, onChange, options, className = ""
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="w-full h-10 bg-bg-input rounded-lg px-3 text-[14px] text-text-primary flex items-center justify-between cursor-pointer border border-transparent hover:border-border transition-colors"
+        className="w-full h-9 bg-bg-input rounded-lg px-3 text-[13px] font-medium text-text-primary flex items-center justify-between cursor-pointer border border-transparent hover:border-border transition-colors"
       >
         <span>{selected?.label ?? ""}</span>
         <ChevronDown size={16} className={`text-text-muted transition-transform ${open ? "rotate-180" : ""}`} />
@@ -66,12 +66,12 @@ export default function Select({ label, value, onChange, options, className = ""
                 }}
                 className={`w-full flex items-center justify-between px-4 h-10 text-[14px] cursor-pointer transition-colors ${
                   isActive
-                    ? "bg-bg-input text-text-primary"
+                    ? "bg-accent-bg text-accent-text"
                     : "text-text-primary hover:bg-bg-input"
                 }`}
               >
                 <span>{option.label}</span>
-                {isActive && <Check size={16} className="text-text-muted" />}
+                {isActive && <Check size={16} className="text-accent-text" />}
               </button>
             );
           })}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -140,11 +140,40 @@
   "settings.subtitle": "Manage your reading preferences and AI configuration",
   "settings.saved": "Settings saved",
 
+  "settings.general.title": "General",
+  "settings.general.subtitle": "Language & appearance",
+  "settings.general.displayName": "Display Name",
+  "settings.general.displayNameHint": "Your local identity — used for highlights and notes",
+  "settings.general.edit": "Edit",
+  "settings.general.languageHint": "Interface language",
+  "settings.general.themeHint": "Choose your preferred color scheme",
+
   "settings.language": "Language",
   "settings.languageSub": "Choose your preferred language",
 
+  "settings.reading.title": "Reading",
+  "settings.reading.subtitle": "Font, spacing & layout",
+  "settings.reading.fontHint": "Default font for reading",
+  "settings.reading.autoSaveHint": "Automatically save your reading position",
+
+  "settings.ai.shortTitle": "AI Assistant",
+  "settings.ai.shortSubtitle": "Provider & model config",
+
+  "settings.icloud.title": "iCloud",
+  "settings.icloud.subtitle": "Sync across devices",
+
+  "settings.about.title": "About",
+  "settings.about.subtitle": "Version & updates",
+  "settings.about.version": "Version",
+  "settings.about.description": "An elegant eBook reader",
+  "settings.about.checkUpdates": "Check for Updates",
+  "settings.about.lastChecked": "Last checked",
+  "settings.about.checkNow": "Check Now",
+  "settings.about.buildInfo": "Build Info",
+
   "settings.lookup.title": "Lookup",
   "settings.lookup.sub": "Customize how word lookups appear",
+  "settings.lookup.shortSub": "Translation & dictionary",
   "settings.lookup.nativeLanguage": "Native Language",
   "settings.lookup.nativeLanguageHint": "Your native language for word translations",
   "settings.lookup.showTranslation": "Show Translation",
@@ -195,8 +224,6 @@
   "settings.layout.marginsHint": "Default margins around the reading area",
   "settings.layout.systemDefault": "System Default",
 
-  "settings.reading.title": "Reading Preferences",
-  "settings.reading.subtitle": "Customize your reading experience",
   "settings.reading.autoSave": "Auto-save Progress",
   "settings.reading.autoSaveSub": "Automatically save your reading position",
 

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -140,11 +140,40 @@
   "settings.subtitle": "管理你的阅读偏好和 AI 配置",
   "settings.saved": "设置已保存",
 
+  "settings.general.title": "通用",
+  "settings.general.subtitle": "语言与外观",
+  "settings.general.displayName": "显示名称",
+  "settings.general.displayNameHint": "你的本地身份 — 用于高亮和笔记",
+  "settings.general.edit": "编辑",
+  "settings.general.languageHint": "界面语言",
+  "settings.general.themeHint": "选择你偏好的配色方案",
+
   "settings.language": "语言",
   "settings.languageSub": "选择你的首选语言",
 
+  "settings.reading.title": "阅读",
+  "settings.reading.subtitle": "字体、间距与排版",
+  "settings.reading.fontHint": "默认阅读字体",
+  "settings.reading.autoSaveHint": "自动保存阅读进度",
+
+  "settings.ai.shortTitle": "AI 助手",
+  "settings.ai.shortSubtitle": "服务商与模型配置",
+
+  "settings.icloud.title": "iCloud",
+  "settings.icloud.subtitle": "跨设备同步",
+
+  "settings.about.title": "关于",
+  "settings.about.subtitle": "版本与更新",
+  "settings.about.version": "版本",
+  "settings.about.description": "一个优雅的电子书阅读器",
+  "settings.about.checkUpdates": "检查更新",
+  "settings.about.lastChecked": "上次检查",
+  "settings.about.checkNow": "立即检查",
+  "settings.about.buildInfo": "构建信息",
+
   "settings.lookup.title": "查词",
   "settings.lookup.sub": "自定义查词显示方式",
+  "settings.lookup.shortSub": "翻译与词典",
   "settings.lookup.nativeLanguage": "母语",
   "settings.lookup.nativeLanguageHint": "查词时的翻译语言",
   "settings.lookup.showTranslation": "显示翻译",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Search, LayoutGrid, List, Settings, Plus, Upload, BookOpen, Loader } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { Search, LayoutGrid, List, Plus, Upload, BookOpen, Loader } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import Sidebar from "../components/Sidebar";
@@ -9,6 +8,7 @@ import BookGrid from "../components/BookGrid";
 import BookList from "../components/BookList";
 import DictionaryContent from "../components/DictionaryContent";
 import ChatsContent from "../components/ChatsContent";
+import SettingsModal from "../components/SettingsModal";
 import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
 import { useBooks, importBookDialog, type Book } from "../hooks/useBooks";
@@ -21,8 +21,28 @@ export default function Home() {
   const [searchQuery, setSearchQuery] = useState("");
   const [isDragging, setIsDragging] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [userName, setUserName] = useState("");
   const collections = useCollections();
-  const navigate = useNavigate();
+
+  // Load user name
+  useEffect(() => {
+    invoke<Record<string, string>>("get_all_settings")
+      .then((s) => setUserName(s.user_name ?? ""))
+      .catch(() => {});
+  }, []);
+
+  // Cmd+, to open settings
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === ",") {
+        e.preventDefault();
+        setSettingsOpen(true);
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
 
   // For collection filters, we need to fetch the book IDs in the collection
   // then filter client-side
@@ -149,6 +169,8 @@ export default function Home() {
         onFilterChange={setActiveFilter}
         books={allBooks.books}
         collections={collections}
+        userName={userName}
+        onOpenSettings={() => setSettingsOpen(true)}
       />
 
       {activeFilter === "vocab" ? (
@@ -179,14 +201,6 @@ export default function Home() {
                   onClick={() => setViewMode("list")}
                 >
                   <List size={16} />
-                </Button>
-                <div className="w-px h-6 bg-border mx-2" />
-                <Button
-                  variant="icon"
-                  size="md"
-                  onClick={() => navigate("/settings")}
-                >
-                  <Settings size={16} />
                 </Button>
               </div>
             </div>
@@ -262,6 +276,17 @@ export default function Home() {
           </div>
         </div>
       )}
+
+      <SettingsModal
+        open={settingsOpen}
+        onClose={() => {
+          setSettingsOpen(false);
+          // Reload user name in case it changed
+          invoke<Record<string, string>>("get_all_settings")
+            .then((s) => setUserName(s.user_name ?? ""))
+            .catch(() => {});
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace full-page settings route with an Obsidian-style modal dialog
- Sidebar nav (6 sections) + scrollable content panel
- User profile (initials + name) at sidebar bottom opens the modal
- Cmd+, keyboard shortcut to open settings
- Removed old SettingsPage, settings gear buttons from toolbar/dictionary/chats

### Sections
- **General**: display name, language, theme, auto-save
- **Reading**: font family, size, line/word spacing, margins (number inputs)
- **AI Assistant**: provider, auth, model, temperature with header "Save" button
- **Lookup**: native language, translation toggle, preview card
- **iCloud**: sync toggle with contextual hints
- **About**: version from Tauri API

Closes #59

## Test plan
- [ ] Cmd+, opens settings from Home
- [ ] Click user profile in sidebar opens settings
- [ ] All 6 sections render correctly
- [ ] Settings save and persist across modal open/close
- [ ] AI config dirty state shows/hides Save button in header
- [ ] Escape and backdrop click close the modal
- [ ] Old /settings route removed, no broken navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)