### PR TITLE
chore: release v0.6.2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "0.6.1"
+version = "0.6.2"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"


### PR DESCRIPTION
## Summary
Bump version to v0.6.2.

### Changes since v0.6.0
- **Settings modal** — Obsidian-style modal replaces full-page settings
- **User profile** — initials + name at sidebar bottom, Cmd+, shortcut
- **6 sections**: General, Reading, AI Assistant, Lookup, iCloud, About
- **UI polish** — number inputs for reading, header save button for AI, success toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)