### PR TITLE
chore: release v0.6.3

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "0.6.2"
+version = "0.6.3"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"


### PR DESCRIPTION
## Summary
Bump version to v0.6.3.

### Changes since v0.6.2
- **Windows support** — NSIS installer, Windows build job in release workflow
- iCloud settings hidden on non-macOS platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)