### PR TITLE
chore: release v0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quill",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "0.6.3"
+version = "0.6.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "0.6.3"
+version = "0.6.2"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quill",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.wycstudios.quill",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
Bump version to v0.6.2 (fixes version sync across all three files).

### Changes since v0.6.0
- **Settings modal** — Obsidian-style modal replaces full-page settings
- **User profile** — initials + name at sidebar bottom, Cmd+, shortcut
- **Windows support** — NSIS installer, Windows build job in release workflow
- iCloud settings hidden on non-macOS platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)