### PR TITLE
fix: add delete button to dictionary list view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@ docs/
 - **Cargo.lock:** Run `cargo check` after version bumps to sync `Cargo.lock` before committing.
 - **Version bumps & releases:** Commit directly to main (no PR needed). Tag with `v` prefix, push tag to trigger release CI.
 
+## Skills (slash commands)
+
+- `/release` — Bump version, tag, push, wait for CI, publish GitHub release with notes
+- `/feature` — Create, list, or manage feature specs (`docs/features/`) and GitHub issues
+
 ## Conventions
 
 - Settings are stored as key-value pairs in SQLite (`settings` table). Use `useSettings` hook on frontend, `commands/settings.rs` on backend.

--- a/src/components/DictionaryContent.tsx
+++ b/src/components/DictionaryContent.tsx
@@ -249,6 +249,12 @@ export default function DictionaryContent() {
                           {t("vocab.openInReader")}
                           <ArrowRight size={12} />
                         </button>
+                        <button
+                          onClick={() => remove(word.id)}
+                          className="p-1 rounded hover:bg-bg-surface/80 cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+                        >
+                          <Trash2 size={14} className="text-text-muted" />
+                        </button>
                       </div>
                     </div>
                   );


### PR DESCRIPTION
## Summary
- List view in the Dictionary page was missing a delete button — only card view had one
- Added a hover-revealed trash icon to list view rows, matching the existing card view pattern

Closes #76

## Test plan
- [ ] Open Dictionary page in list view → hover a word row → trash icon appears on the right
- [ ] Click trash icon → word is removed
- [ ] Card view delete still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)