### PR TITLE
fix: lookup popover cut off near bottom of reader

### DIFF
--- a/src/components/LookupPopover.tsx
+++ b/src/components/LookupPopover.tsx
@@ -119,21 +119,27 @@ export default function LookupPopover({
   const allDone = !definition.streaming && !context.streaming;
   const hasContent = definition.content || context.content;
 
-  // Position clamping — run once on mount
+  // Position clamping — re-run whenever the popover resizes (e.g. as content streams in)
   const [pos, setPos] = useState({ left: x, top: y });
 
   useEffect(() => {
-    if (!popoverRef.current) return;
-    const rect = popoverRef.current.getBoundingClientRect();
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    let left = x;
-    let top = y;
-    if (left + rect.width > vw - 16) left = vw - rect.width - 16;
-    if (left < 16) left = 16;
-    if (top + rect.height > vh - 16) top = y - rect.height - 8;
-    if (top < 16) top = 16;
-    setPos({ left, top });
+    const el = popoverRef.current;
+    if (!el) return;
+    const clamp = () => {
+      const rect = el.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      let left = x;
+      let top = y;
+      if (left + rect.width > vw - 16) left = vw - rect.width - 16;
+      if (left < 16) left = 16;
+      if (top + rect.height > vh - 16) top = y - rect.height - 8;
+      if (top < 16) top = 16;
+      setPos({ left, top });
+    };
+    const observer = new ResizeObserver(clamp);
+    observer.observe(el);
+    return () => observer.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Summary
- Replace one-shot mount position clamping with a `ResizeObserver` that re-clamps as the popover grows (content streaming in)
- When the popover would overflow the bottom, it flips above the selection

Closes #75

## Test plan
- [ ] Select a word near the bottom of the reader viewport — popover should appear above the selection
- [ ] Select a word in the middle — popover should still appear below as usual
- [ ] As AI content streams in, popover should reposition if it starts overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)