### PR TITLE
fix: reader theme persistence race condition

### DIFF
--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -188,16 +188,15 @@ export default function Reader() {
         wordSpacing: s.word_spacing ? parseInt(s.word_spacing) : prev.wordSpacing,
         margins: s.margins ? parseInt(s.margins) : prev.margins,
       }));
+      dbSettingsLoaded.current = true;
     }).catch(() => {});
   }, [bookId]);
 
-  // Persist reader settings to DB when they change
-  const settingsLoaded = useRef(false);
+  // Persist reader settings to DB when they change — only after DB load completes
+  // to avoid overwriting saved values with defaults during initialization
+  const dbSettingsLoaded = useRef(false);
   useEffect(() => {
-    if (!settingsLoaded.current) {
-      settingsLoaded.current = true;
-      return;
-    }
+    if (!dbSettingsLoaded.current) return;
     const { theme, brightness, pageColumns, font, fontSize, readingMode, lineSpacing, charSpacing, wordSpacing, margins } = readerSettings;
     invoke("set_settings_bulk", {
       settings: {


### PR DESCRIPTION
## Summary
- Replace single-skip `settingsLoaded` guard with `dbSettingsLoaded` ref that only enables persistence **after** DB settings are loaded
- Prevents default theme values from overwriting saved settings during initialization race

Closes #93

## Test plan
- [ ] Set reader theme to Original (light), close and reopen book — theme persists
- [ ] Set reader theme to Night, close and reopen — theme persists
- [ ] Switch between themes multiple times, reopen — last selection sticks
- [ ] Test in both light and dark app modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)