### PR TITLE
fix: unify font settings between reader and app Settings

### DIFF
--- a/src/components/ReaderSettings.tsx
+++ b/src/components/ReaderSettings.tsx
@@ -13,7 +13,10 @@ const themes = [
   { id: "night", label: "Night", color: "bg-[#18181b] border border-[#3f3f46]", pdf: true },
 ] as const;
 
-const fonts = [
+export const FONT_SIZE_MIN = 12;
+export const FONT_SIZE_MAX = 48;
+
+export const fonts = [
   { id: "system", label: "System", family: "Inter, system-ui, sans-serif" },
   { id: "georgia", label: "Georgia", family: "Georgia, serif" },
   { id: "palatino", label: "Palatino", family: "Palatino, serif" },
@@ -123,7 +126,7 @@ export default function ReaderSettings({ open, onClose, anchorRef, settings, onS
       {/* Font size toggle */}
       {bookFormat !== "pdf" && (<div className="flex items-center h-[60px] px-4 border-b border-border-light">
         <button
-          onClick={() => update({ fontSize: Math.max(12, settings.fontSize - 2) })}
+          onClick={() => update({ fontSize: Math.max(FONT_SIZE_MIN, settings.fontSize - 2) })}
           className="flex-1 flex items-center justify-center h-7 border-r border-border cursor-pointer text-text-primary hover:bg-bg-input"
         >
           <span className="text-[14px] font-medium">A-</span>
@@ -132,7 +135,7 @@ export default function ReaderSettings({ open, onClose, anchorRef, settings, onS
           {settings.fontSize}px
         </span>
         <button
-          onClick={() => update({ fontSize: Math.min(28, settings.fontSize + 2) })}
+          onClick={() => update({ fontSize: Math.min(FONT_SIZE_MAX, settings.fontSize + 2) })}
           className="flex-1 flex items-center justify-center h-9 border-l border-border cursor-pointer text-text-primary hover:bg-bg-input"
         >
           <span className="text-[20px] font-medium tracking-[-0.45px]">A+</span>

--- a/src/components/settings/ReadingSettings.tsx
+++ b/src/components/settings/ReadingSettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import Select from "../ui/Select";
+import { fonts, FONT_SIZE_MIN, FONT_SIZE_MAX } from "../ReaderSettings";
 import type { SettingsProps } from "./types";
 
 function NumberInput({ value, onChange, onBlur, suffix, min, max }: {
@@ -60,13 +61,7 @@ export default function ReadingSettings({ settings, loading, save, showSavedToas
           className="w-[160px] shrink-0"
           value={fontFamily}
           onChange={(v) => { setFontFamily(v); save("font_family", v); showSavedToast(); }}
-          options={[
-            { value: "georgia", label: "Georgia" },
-            { value: "palatino", label: "Palatino" },
-            { value: "times", label: "Times New Roman" },
-            { value: "system-ui", label: "System" },
-            { value: "sans-serif", label: "Sans Serif" },
-          ]}
+          options={fonts.map((f) => ({ value: f.id, label: f.label }))}
         />
       </div>
       <div className="h-px bg-black/10" />
@@ -77,7 +72,7 @@ export default function ReadingSettings({ settings, loading, save, showSavedToas
           <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.layout.fontSize")}</p>
           <p className="text-[12px] text-text-muted mt-0.5">{t("settings.layout.fontSizeHint")}</p>
         </div>
-        <NumberInput value={fontSize} onChange={setFontSize} onBlur={() => save("font_size", String(fontSize))} suffix="px" min={8} max={48} />
+        <NumberInput value={fontSize} onChange={setFontSize} onBlur={() => save("font_size", String(fontSize))} suffix="px" min={FONT_SIZE_MIN} max={FONT_SIZE_MAX} />
       </div>
       <div className="h-px bg-black/10" />
 


### PR DESCRIPTION
## Summary
- Export shared `fonts` array and `FONT_SIZE_MIN`/`FONT_SIZE_MAX` constants from `ReaderSettings.tsx`
- `ReadingSettings.tsx` now uses the same font list — fixes `"system"` vs `"system-ui"` enum mismatch
- In-reader font size cap raised from 28px to 48px to match app Settings

Closes #92

## Test plan
- [ ] Set font to "System" in app Settings → open reader → font selector shows "System" as active
- [ ] Set font to "System" in reader → open app Settings → shows "System" selected
- [ ] Increase font size past 28px in reader popover — now goes up to 48px
- [ ] Font size limits match in both UIs (12–48px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)