### PR TITLE
fix: update sepia theme colors to match iBooks

### DIFF
--- a/src/components/ReaderSettings.tsx
+++ b/src/components/ReaderSettings.tsx
@@ -8,7 +8,7 @@ const sliderClass =
 
 const themes = [
   { id: "original", label: "Original", color: "bg-white border border-[#d4d4d8]", pdf: true },
-  { id: "paper", label: "Sepia", color: "bg-[#f5e6c8]", pdf: true },
+  { id: "paper", label: "Sepia", color: "bg-[#F2E2C9]", pdf: true },
   { id: "quiet", label: "Gray", color: "bg-[#71717b]", pdf: true },
   { id: "night", label: "Night", color: "bg-[#18181b] border border-[#3f3f46]", pdf: true },
 ] as const;
@@ -59,7 +59,7 @@ export function getFontFamily(fontId: ReaderFont): string {
 export function getThemeStyles(themeId: ReaderTheme) {
   switch (themeId) {
     case "paper":
-      return { body: "#fef3c6", text: "#1c1917" };
+      return { body: "#F2E2C9", text: "#34271B" };
     case "quiet":
       return { body: "#71717b", text: "#fafafa" };
     case "night":

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -276,7 +276,7 @@ export default function Reader() {
         if (mainEl) {
           const pdfFilter = (() => {
             switch (readerSettings.theme) {
-              case "paper": return "sepia(100%) saturate(70%) brightness(0.92)";
+              case "paper": return "sepia(40%) saturate(60%) brightness(0.97)";
               case "quiet": return "grayscale(30%) brightness(0.75) contrast(1.1)";
               case "night": return "invert(0.9) hue-rotate(180deg) contrast(0.9)";
               default: return "";
@@ -533,7 +533,7 @@ export default function Reader() {
     if (mainEl && book?.format === "pdf") {
       const pdfFilter = (() => {
         switch (readerSettings.theme) {
-          case "paper": return "sepia(100%) saturate(70%) brightness(0.92)";
+          case "paper": return "sepia(40%) saturate(60%) brightness(0.97)";
           case "quiet": return "grayscale(30%) brightness(0.75) contrast(1.1)";
           case "night": return "invert(0.9) hue-rotate(180deg) contrast(0.9)";
           default: return "";


### PR DESCRIPTION
## Summary
- Background: `#fef3c6` → `#F2E2C9`
- Text: `#1c1917` → `#34271B`
- PDF sepia filter toned down to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)