### PR TITLE
fix: include book context in ai_chat system prompt

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -255,6 +255,9 @@ pub async fn ai_generate_title(
 #[tauri::command]
 pub async fn ai_chat(
     messages: Vec<ChatMessage>,
+    book_title: Option<String>,
+    book_author: Option<String>,
+    current_chapter: Option<String>,
     app: AppHandle,
     db: State<'_, Db>,
     secrets: State<'_, Secrets>,
@@ -295,6 +298,16 @@ pub async fn ai_chat(
 
     // Build messages: system prompt + conversation history (context is inlined by frontend)
     let mut system_content = "You are a helpful reading assistant. Help the user understand and discuss the book they are reading.".to_string();
+    if let Some(ref title) = book_title {
+        system_content.push_str(&format!("\n\nThe user is currently reading \"{}\"", title));
+        if let Some(ref author) = book_author {
+            system_content.push_str(&format!(" by {}", author));
+        }
+        system_content.push('.');
+        if let Some(ref chapter) = current_chapter {
+            system_content.push_str(&format!(" They are on: {}.", chapter));
+        }
+    }
     if language == "zh" {
         system_content.push_str(" Always respond in Chinese (Simplified).");
     }

--- a/src/components/AiPanel.tsx
+++ b/src/components/AiPanel.tsx
@@ -7,13 +7,16 @@ import { timeAgo } from "../utils/timeAgo";
 
 interface AiPanelProps {
   bookId?: string;
+  bookTitle?: string;
+  bookAuthor?: string;
+  currentChapter?: string;
   context?: { text: string; cfi?: string };
   initialChatId?: string;
   onContextConsumed?: () => void;
   onNavigateToCfi?: (cfi: string) => void;
 }
 
-export default function AiPanel({ bookId, context, initialChatId, onContextConsumed, onNavigateToCfi }: AiPanelProps) {
+export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter, context, initialChatId, onContextConsumed, onNavigateToCfi }: AiPanelProps) {
   const { t } = useTranslation();
 
   const SUGGESTED_PROMPTS = [
@@ -24,7 +27,7 @@ export default function AiPanel({ bookId, context, initialChatId, onContextConsu
   const {
     messages, streaming, send, initialize,
     chatId, chats, titling, loadChat, deleteChat, renameChat, reset,
-  } = useAiChat(bookId);
+  } = useAiChat(bookId, { title: bookTitle, author: bookAuthor, chapter: currentChapter });
 
   const [input, setInput] = useState("");
   const [pickerOpen, setPickerOpen] = useState(false);

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -105,7 +105,13 @@ function nextMsgId() {
   return `local-${Date.now()}-${++msgIdCounter}`;
 }
 
-export function useAiChat(bookId?: string) {
+interface BookContext {
+  title?: string;
+  author?: string;
+  chapter?: string;
+}
+
+export function useAiChat(bookId?: string, bookContext?: BookContext) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [streaming, setStreaming] = useState(false);
   const [titling, setTitling] = useState(false);
@@ -347,6 +353,9 @@ export function useAiChat(bookId?: string) {
       try {
         await invoke("ai_chat", {
           messages: apiMessages,
+          bookTitle: bookContext?.title ?? null,
+          bookAuthor: bookContext?.author ?? null,
+          currentChapter: bookContext?.chapter ?? null,
         });
       } catch (err) {
         setStreaming(false);

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -1112,6 +1112,9 @@ export default function Reader() {
           <div className={sidePanel === "ai" ? "h-full" : "hidden"}>
             <AiPanel
               bookId={bookId}
+              bookTitle={book.title}
+              bookAuthor={book.author}
+              currentChapter={currentChapterIndex >= 0 && currentChapterIndex < chapters.length ? chapters[currentChapterIndex].title : undefined}
               context={aiContext}
               initialChatId={initialChatId}
               onContextConsumed={() => setAiContext(undefined)}


### PR DESCRIPTION
## Summary
- Add `book_title`, `book_author`, and `current_chapter` parameters to the `ai_chat` Tauri command
- Include book metadata in the system prompt so the AI knows what the user is reading
- Pass book context from Reader → AiPanel → useAiChat → backend

Closes #107

## Test plan
- [ ] Open a book and start an AI chat
- [ ] Ask "what book am I reading?" — AI should know the title and author
- [ ] Navigate to a different chapter, ask about context — AI should reference the current chapter
- [ ] Existing chats continue to work (params are optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)