### PR TITLE
fix: collections list scrolls independently in sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -129,7 +129,7 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
   }, [contextMenu]);
 
   return (
-    <aside className="w-[224px] shrink-0 bg-bg-muted border-r border-border h-full flex flex-col gap-6 px-4 relative select-none">
+    <aside className="w-[224px] shrink-0 bg-bg-muted border-r border-border h-full flex flex-col gap-6 px-4 relative select-none overflow-hidden">
       <div data-tauri-drag-region className="absolute top-0 left-0 right-0 h-11" />
       <div className="flex items-center gap-2.5 pb-2 pt-11">
         <QuillLogo size={28} />
@@ -210,8 +210,8 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
         </div>
       </div>
 
-      <div className="flex flex-col gap-3">
-        <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 min-h-0 flex-1">
+        <div className="flex items-center justify-between shrink-0">
           <h2 className="text-[12px] font-semibold uppercase tracking-[0.3px] text-text-muted">
             {t("sidebar.collections")}
           </h2>
@@ -252,7 +252,7 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
           </form>
         )}
 
-        <div ref={collectionListRef} className="flex flex-col gap-1">
+        <div ref={collectionListRef} className="flex flex-col gap-1 overflow-y-auto min-h-0">
           {displayCollections.map((collection) => {
             const isActive = activeFilter === `collection:${collection.id}`;
             if (renamingId === collection.id) {
@@ -312,9 +312,6 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
           })}
         </div>
       </div>
-      {/* Spacer */}
-      <div className="flex-1" />
-
       {/* User profile */}
       <div className="border-t border-border pt-3 pb-3">
         <button


### PR DESCRIPTION
## Summary
- Add `overflow-hidden` to the sidebar `<aside>` to prevent window scrolling
- Make collections section `flex-1 min-h-0` so it shrinks within the flex layout
- Add `overflow-y-auto` to the collections list for independent scrolling

Closes #109

## Test plan
- [ ] Create 15+ collections — only the collections list scrolls, not the window
- [ ] User profile section stays pinned at the bottom
- [ ] Main content area is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)