### PR TITLE
feat: AI passage translation (#73)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,3 +42,4 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
       - run: cargo clippy -- -D warnings
       - run: cargo check
+      - run: cargo test --lib

--- a/docs/impls/15-ai-translation.md
+++ b/docs/impls/15-ai-translation.md
@@ -61,6 +61,7 @@ Add `sha2 = "0.10"` to `Cargo.toml` dependencies.
 #[tauri::command]
 pub async fn ai_translate_passage(
     text: String,
+    context: Option<String>,  // surrounding paragraph for short selections
     book_id: String,
     section_index: Option<i64>,
     target_language: Option<String>,
@@ -77,12 +78,36 @@ Logic:
 2. Compute `source_hash` = SHA-256 hex of `text`.
 3. Query `translations` for a hit on `(book_id, section_index, source_hash, target_language)`.
 4. **Cache hit**: emit cached `translated_text` as `AiStreamChunk` events on `ai-translate-chunk-{request_id}`. Return the row `id` so the frontend knows it already exists.
-5. **Cache miss**: read AI provider settings (same pattern as `ai_lookup` in `commands/ai.rs:34-54`), build translation system prompt, spawn async streaming task. Accumulate full response, insert into `translations` with `saved = 0` on completion. Return `null`.
+5. **Cache miss**: read AI provider settings (same pattern as `ai_lookup` in `commands/ai.rs:34-54`), build context-aware translation prompt, spawn async streaming task. Accumulate full response, insert into `translations` with `saved = 0` on completion. Return `null`.
 
-System prompt:
+**Context-aware prompt design:**
+
+When `context` is provided and differs from `text` (short selection within a paragraph):
 ```
-You are a translator. Translate the following passage into {target_language}.
-Produce only the translation — no commentary, no labels, no original text.
+You are a translator embedded in an ebook reader. The user selected a portion
+of text they want translated into {target_language}.
+
+Full paragraph for context:
+"{context}"
+
+Translate ONLY the selected portion below — not the full paragraph. Use the
+surrounding context to ensure accuracy of meaning, tone, and any pronouns
+or references.
+
+Selected text:
+"{text}"
+
+Produce only the translation. No commentary, no labels, no original text.
+```
+
+When `context` is absent or same as `text` (full paragraph or long selection):
+```
+You are a translator embedded in an ebook reader. Translate the following
+passage into {target_language}.
+
+"{text}"
+
+Produce only the translation. No commentary, no labels, no original text.
 Preserve paragraph structure and tone.
 ```
 
@@ -173,6 +198,7 @@ interface TranslationPopoverProps {
   x: number;
   y: number;
   text: string;
+  context?: string;  // surrounding paragraph for short selections
   bookId: string;
   sectionIndex?: number;
   cfi?: string;
@@ -232,6 +258,7 @@ Full-page translations view in the main window. Same pattern as `DictionaryConte
    ```typescript
    const [translation, setTranslation] = useState<{
      x: number; y: number; text: string;
+     context?: string;  // surrounding paragraph for short selections
      sectionIndex?: number; cfi?: string;
    } | null>(null);
    ```
@@ -242,6 +269,7 @@ Full-page translations view in the main window. Same pattern as `DictionaryConte
      setTranslation({
        x: contextMenu.x, y: contextMenu.y,
        text: contextMenu.text,
+       context: contextMenu.sentence,  // block-level surrounding text
        sectionIndex: currentChapterIndex >= 0 ? currentChapterIndex : undefined,
        cfi: contextMenu.cfiRange,
      });

--- a/src-tauri/migrations/006_translations.sql
+++ b/src-tauri/migrations/006_translations.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS translations (
+    id TEXT PRIMARY KEY,
+    book_id TEXT NOT NULL,
+    source_text TEXT NOT NULL,
+    translated_text TEXT NOT NULL,
+    target_language TEXT NOT NULL,
+    cfi TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_translations_book
+    ON translations (book_id);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,4 +6,5 @@ pub mod collections;
 pub mod icloud;
 pub mod oauth;
 pub mod settings;
+pub mod translation;
 pub mod vocab;

--- a/src-tauri/src/commands/translation.rs
+++ b/src-tauri/src/commands/translation.rs
@@ -1,0 +1,225 @@
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, State};
+
+use crate::commands::ai::{AiStreamChunk, ChatMessage};
+use crate::db::Db;
+use crate::error::{AppError, AppResult};
+use crate::secrets::Secrets;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Translation {
+    pub id: String,
+    pub book_id: String,
+    pub source_text: String,
+    pub translated_text: String,
+    pub target_language: String,
+    pub cfi: Option<String>,
+    pub created_at: String,
+    pub book_title: Option<String>,
+}
+
+fn lang_display_name(code: &str) -> &str {
+    match code {
+        "en" => "English",
+        "zh" => "Chinese (Simplified)",
+        "ja" => "Japanese",
+        "ko" => "Korean",
+        "es" => "Spanish",
+        "fr" => "French",
+        "de" => "German",
+        "pt" => "Portuguese",
+        "ru" => "Russian",
+        "ar" => "Arabic",
+        "it" => "Italian",
+        _ => code,
+    }
+}
+
+/// Stream a translation from the AI provider. Does NOT persist — the frontend
+/// calls `save_translation` explicitly when the user clicks Save.
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub async fn ai_translate_passage(
+    text: String,
+    context: Option<String>,
+    #[allow(unused_variables)]
+    book_id: String,
+    target_language: Option<String>,
+    request_id: String,
+    app: AppHandle,
+    db: State<'_, Db>,
+    secrets: State<'_, Secrets>,
+) -> AppResult<()> {
+    // Read target language setting
+    let (target_lang, provider, model, base_url, keep_alive, auth_mode) = {
+        let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+        let get = |key: &str| -> Option<String> {
+            conn.query_row(
+                "SELECT value FROM settings WHERE key = ?1",
+                rusqlite::params![key],
+                |row| row.get(0),
+            )
+            .ok()
+        };
+        let tl = target_language.unwrap_or_else(|| {
+            get("native_language").unwrap_or_else(|| "en".to_string())
+        });
+        (
+            tl,
+            get("ai_provider").unwrap_or_else(|| "ollama".to_string()),
+            get("ai_model").unwrap_or_else(|| "llama3.2".to_string()),
+            get("ai_base_url"),
+            get("ai_keep_alive").unwrap_or_else(|| "30m".to_string()),
+            get("ai_auth_mode").unwrap_or_else(|| "api_key".to_string()),
+        )
+    };
+
+    let api_key = secrets.get("ai_api_key").unwrap_or_default();
+
+    let (api_key, oauth_account_id) = if auth_mode == "oauth" && provider == "openai" {
+        let (token, acct_id) = crate::ai::oauth::get_valid_token(&secrets).await?;
+        (token, acct_id)
+    } else {
+        if api_key.is_empty() && provider != "ollama" {
+            return Err(AppError::Other("AI_NOT_CONFIGURED".to_string()));
+        }
+        (api_key, None)
+    };
+
+    let target_name = lang_display_name(&target_lang);
+
+    // Context-aware prompt: if selection is shorter than surrounding paragraph,
+    // provide the paragraph as context but only translate the selection
+    let has_context = context.as_ref().is_some_and(|c| c != &text && c.len() > text.len());
+    let system_prompt = if has_context {
+        format!(
+            "You are a translator embedded in an ebook reader. The user selected a portion of text they want translated into {}.\n\n\
+            Full paragraph for context:\n\"{}\"\n\n\
+            Translate ONLY the selected portion below — not the full paragraph. Use the surrounding context to ensure accuracy of meaning, tone, and any pronouns or references.\n\n\
+            Produce only the translation. No commentary, no labels, no original text.",
+            target_name,
+            context.as_deref().unwrap_or("")
+        )
+    } else {
+        format!(
+            "You are a translator embedded in an ebook reader. Translate the following passage into {}.\n\n\
+            Produce only the translation. No commentary, no labels, no original text. Preserve paragraph structure and tone.",
+            target_name
+        )
+    };
+
+    let messages = vec![
+        ChatMessage {
+            role: "system".to_string(),
+            content: system_prompt,
+        },
+        ChatMessage {
+            role: "user".to_string(),
+            content: text.clone(),
+        },
+    ];
+
+    let event_name = format!("ai-translate-chunk-{}", request_id);
+    let use_responses_api = auth_mode == "oauth" && provider == "openai";
+    let app_clone = app.clone();
+
+    tauri::async_runtime::spawn(async move {
+        let result = match provider.as_str() {
+            "anthropic" => {
+                let url = base_url.unwrap_or_else(|| "https://api.anthropic.com".to_string());
+                crate::ai::anthropic::stream_chat(&app_clone, &url, &api_key, &model, 0.3, &messages, false, &event_name, None).await
+            }
+            "minimax" => {
+                let url = base_url.unwrap_or_else(|| "https://api.minimax.io/anthropic".to_string());
+                crate::ai::anthropic::stream_chat(&app_clone, &url, &api_key, &model, 0.3, &messages, true, &event_name, None).await
+            }
+            _ if use_responses_api => {
+                let url = "https://chatgpt.com/backend-api/codex".to_string();
+                crate::ai::openai_responses::stream_chat(&app_clone, &url, &api_key, &model, &messages, oauth_account_id.as_deref(), &event_name).await
+            }
+            _ => {
+                let url = base_url.unwrap_or_else(|| "http://localhost:11434".to_string());
+                let ka = if provider == "ollama" { Some(keep_alive.clone()) } else { None };
+                crate::ai::openai_compat::stream_chat(&app_clone, &url, &api_key, &model, 0.3, &messages, ka.as_deref(), &event_name, None).await
+            }
+        };
+        if let Err(e) = result {
+            let _ = app_clone.emit(&event_name, AiStreamChunk {
+                delta: format!("Error: {}", e),
+                done: false,
+            });
+            let _ = app_clone.emit(&event_name, AiStreamChunk {
+                delta: String::new(),
+                done: true,
+            });
+        }
+    });
+
+    Ok(())
+}
+
+/// Persist a translation the user explicitly chose to save.
+#[tauri::command]
+pub fn save_translation(
+    book_id: String,
+    source_text: String,
+    translated_text: String,
+    target_language: String,
+    cfi: Option<String>,
+    db: State<'_, Db>,
+) -> AppResult<String> {
+    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO translations (id, book_id, source_text, translated_text, target_language, cfi, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        rusqlite::params![id, book_id, source_text, translated_text, target_language, cfi, now],
+    )?;
+    Ok(id)
+}
+
+#[tauri::command]
+pub fn remove_saved_translation(id: String, db: State<'_, Db>) -> AppResult<()> {
+    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    conn.execute(
+        "DELETE FROM translations WHERE id = ?1",
+        rusqlite::params![id],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn list_translations(
+    book_id: Option<String>,
+    db: State<'_, Db>,
+) -> AppResult<Vec<Translation>> {
+    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+
+    let mut sql = "SELECT t.id, t.book_id, t.source_text, t.translated_text, t.target_language, t.cfi, t.created_at, b.title FROM translations t LEFT JOIN books b ON t.book_id = b.id".to_string();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+    if let Some(ref bid) = book_id {
+        sql.push_str(" WHERE t.book_id = ?1");
+        params.push(Box::new(bid.clone()));
+    }
+    sql.push_str(" ORDER BY t.created_at DESC");
+
+    let mut stmt = conn.prepare(&sql)?;
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+
+    let rows = stmt.query_map(param_refs.as_slice(), |row| {
+        Ok(Translation {
+            id: row.get(0)?,
+            book_id: row.get(1)?,
+            source_text: row.get(2)?,
+            translated_text: row.get(3)?,
+            target_language: row.get(4)?,
+            cfi: row.get(5)?,
+            created_at: row.get(6)?,
+            book_title: row.get(7)?,
+        })
+    })?;
+
+    let translations: Vec<Translation> = rows.filter_map(|r| r.ok()).collect();
+    Ok(translations)
+}

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -11,6 +11,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (3, include_str!("../migrations/003_chats.sql")),
     (4, include_str!("../migrations/004_pdf_support.sql")),
     (5, include_str!("../migrations/005_collection_sort_order.sql")),
+    (6, include_str!("../migrations/006_translations.sql")),
 ];
 
 pub struct Db {
@@ -143,7 +144,7 @@ mod tests {
         let conn = db.conn.lock().unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 4);
+        assert_eq!(version, 6);
     }
 
     #[test]
@@ -163,6 +164,7 @@ mod tests {
         assert!(tables.contains(&"vocab_words".to_string()));
         assert!(tables.contains(&"chats".to_string()));
         assert!(tables.contains(&"chat_messages".to_string()));
+        assert!(tables.contains(&"translations".to_string()));
         assert!(tables.contains(&"schema_version".to_string()));
     }
 
@@ -174,7 +176,7 @@ mod tests {
         Db::run_migrations_on(&conn).unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 4);
+        assert_eq!(version, 6);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -129,6 +129,11 @@ pub fn run() {
             commands::chats::rename_chat,
             commands::chats::list_chat_messages,
             commands::chats::save_chat_message,
+            // Translation
+            commands::translation::ai_translate_passage,
+            commands::translation::save_translation,
+            commands::translation::remove_saved_translation,
+            commands::translation::list_translations,
             // iCloud
             commands::icloud::icloud_status,
             commands::icloud::icloud_enable,

--- a/src/components/DictionaryPanel.tsx
+++ b/src/components/DictionaryPanel.tsx
@@ -1,155 +1,267 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { BookOpen, Search, Trash2, Clock, FileText, ArrowRight, Sparkles } from "lucide-react";
+import { BookOpen, Search, Trash2, Clock, FileText, ArrowRight, Languages } from "lucide-react";
 import { useDictionary } from "../hooks/useDictionary";
+import { useTranslations } from "../hooks/useTranslations";
 import { timeAgo } from "../utils/timeAgo";
 
 interface DictionaryPanelProps {
   bookId: string;
+  initialTab?: "dictionary" | "translations";
   onNavigate?: (cfi: string) => void;
   getPageFromCfi?: (cfi: string) => number | null;
 }
 
-export default function DictionaryPanel({ bookId, onNavigate, getPageFromCfi }: DictionaryPanelProps) {
-  const { t } = useTranslation();
-  const [search, setSearch] = useState("");
-  const { words, remove } = useDictionary(bookId);
+type Tab = "dictionary" | "translations";
 
-  const filtered = words.filter((w) => {
-    if (!search) return true;
-    return w.word.toLowerCase().startsWith(search.toLowerCase());
+export default function DictionaryPanel({ bookId, initialTab = "dictionary", onNavigate, getPageFromCfi }: DictionaryPanelProps) {
+  const { t } = useTranslation();
+  const [tab, setTab] = useState<Tab>(initialTab);
+  const [dictSearch, setDictSearch] = useState("");
+  const [transSearch, setTransSearch] = useState("");
+  const { words, remove: removeWord } = useDictionary(bookId);
+  const { translations, remove: removeTranslation } = useTranslations(bookId);
+
+  const filteredWords = words.filter((w) => {
+    if (!dictSearch) return true;
+    return w.word.toLowerCase().startsWith(dictSearch.toLowerCase());
+  });
+
+  const filteredTranslations = translations.filter((tr) => {
+    if (!transSearch) return true;
+    const q = transSearch.toLowerCase();
+    return tr.source_text.toLowerCase().includes(q) || tr.translated_text.toLowerCase().includes(q);
   });
 
   return (
     <div className="flex flex-col h-full bg-bg-muted">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 h-[45px] shrink-0">
-        <div className="flex items-center gap-2">
-          <div
-            className="size-5 rounded-md flex items-center justify-center"
-            style={{ background: "linear-gradient(135deg, #AD46FF, #7F22FE)" }}
-          >
-            <Sparkles size={12} className="text-white" />
-          </div>
-          <span className="text-[14px] font-semibold text-text-primary tracking-[-0.15px]">
-            {t("vocab.title")}
-          </span>
-        </div>
-        <span className="text-[11px] text-text-muted tracking-[0.06px]">
-          {t("vocab.wordCount", { count: words.length })}
-        </span>
+      {/* Tab bar */}
+      <div className="flex border-b border-border shrink-0">
+        <button
+          onClick={() => setTab("dictionary")}
+          className={`flex-1 h-[45px] text-[14px] font-medium tracking-[-0.15px] cursor-pointer transition-colors ${
+            tab === "dictionary"
+              ? "text-text-primary border-b-2 border-accent"
+              : "text-text-muted hover:text-text-body"
+          }`}
+        >
+          {t("vocab.title")}
+        </button>
+        <button
+          onClick={() => setTab("translations")}
+          className={`flex-1 h-[45px] text-[14px] font-medium tracking-[-0.15px] cursor-pointer transition-colors ${
+            tab === "translations"
+              ? "text-text-primary border-b-2 border-accent"
+              : "text-text-muted hover:text-text-body"
+          }`}
+        >
+          {t("translation.title")}
+        </button>
       </div>
 
-      {/* Search */}
-      <div className="px-4 pb-2 shrink-0">
-        <div className="flex items-center gap-1.5 h-[28px] px-2 rounded-lg bg-bg-input border border-border">
-          <Search size={12} className="text-text-muted shrink-0" />
-          <input
-            type="search"
-            placeholder={t("vocab.searchPanel")}
-            defaultValue=""
-            onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
-            onKeyDown={(e) => e.stopPropagation()}
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            className="flex-1 text-[12px] text-text-primary bg-transparent outline-none placeholder:text-text-placeholder [&::-webkit-search-cancel-button]:hidden"
-          />
-        </div>
-      </div>
-
-      {/* Word list */}
-      <div className="flex-1 overflow-auto">
-        {filtered.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full px-4">
-            <div className="size-12 rounded-full bg-bg-input flex items-center justify-center mb-3">
-              <BookOpen size={20} className="text-text-muted" />
+      {/* Dictionary tab */}
+      {tab === "dictionary" && (
+        <>
+          {/* Search */}
+          <div className="px-4 pt-2 pb-2 shrink-0">
+            <div className="flex items-center gap-1.5 h-[28px] px-2 rounded-lg bg-bg-input border border-border">
+              <Search size={12} className="text-text-muted shrink-0" />
+              <input
+                type="search"
+                placeholder={t("vocab.searchPanel")}
+                defaultValue=""
+                onInput={(e) => setDictSearch((e.target as HTMLInputElement).value)}
+                onKeyDown={(e) => e.stopPropagation()}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                className="flex-1 text-[12px] text-text-primary bg-transparent outline-none placeholder:text-text-placeholder [&::-webkit-search-cancel-button]:hidden"
+              />
             </div>
-            <p className="text-[14px] text-text-muted text-center">
-              {words.length === 0 ? t("vocab.panelEmpty") : t("vocab.noMatches")}
-            </p>
-            {words.length === 0 && (
-              <p className="text-[12px] text-text-muted text-center mt-1">
-                {t("vocab.panelEmptySub")}
-              </p>
-            )}
           </div>
-        ) : (
-          filtered.map((word) => {
-            const page = getPageFromCfi && word.cfi ? getPageFromCfi(word.cfi) : null;
-            // Split definition into main definition + AI context (joined by \n\n on save)
-            const parts = word.definition.split("\n\n");
-            const defText = parts[0] || "";
-            const ctxText = parts.length > 1 ? parts.slice(1).join(" ") : null;
-            return (
-              <div
-                key={word.id}
-                className="group relative border-l-[3px] border-accent bg-bg-surface mx-3 mb-2 rounded-r-lg px-4 pt-3 pb-3"
-              >
-                {/* Trash — top right */}
-                <button
-                  onClick={() => remove(word.id)}
-                  className="absolute top-3 right-3 p-1 rounded hover:bg-bg-input cursor-pointer"
-                >
-                  <Trash2 size={15} className="text-text-muted" />
-                </button>
 
-                {/* Word */}
-                <div className="flex items-center gap-2 pr-8">
-                  <span className="text-[16px] font-bold text-text-primary leading-5">
-                    {word.word}
-                  </span>
+          {/* Word list */}
+          <div className="flex-1 overflow-auto">
+            {filteredWords.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-full px-4">
+                <div className="size-12 rounded-full bg-bg-input flex items-center justify-center mb-3">
+                  <BookOpen size={20} className="text-text-muted" />
                 </div>
-
-                {/* Definition — clamped */}
-                <p className="text-[14px] text-text-primary leading-[1.5] mt-2 pr-6 line-clamp-3">
-                  {defText}
+                <p className="text-[14px] text-text-muted text-center">
+                  {words.length === 0 ? t("vocab.panelEmpty") : t("vocab.noMatches")}
                 </p>
-
-                {/* AI context — italic, clamped */}
-                {ctxText && (
-                  <p className="text-[13px] italic text-text-muted leading-[1.45] mt-1 line-clamp-2">
-                    {ctxText}
+                {words.length === 0 && (
+                  <p className="text-[12px] text-text-muted text-center mt-1">
+                    {t("vocab.panelEmptySub")}
                   </p>
                 )}
-
-                {/* Metadata row */}
-                <div className="flex items-center justify-between mt-2.5">
-                  <div className="flex items-center gap-3">
-                    {page != null && (
-                      <span className="flex items-center gap-1 text-[11px] text-text-muted tracking-[0.06px]">
-                        <FileText size={12} />
-                        p. {page}
-                      </span>
-                    )}
-                    <span className="flex items-center gap-1 text-[11px] text-text-muted tracking-[0.06px]">
-                      <Clock size={12} />
-                      {timeAgo(word.created_at)}
-                    </span>
-                  </div>
-                  {word.cfi && (
-                    <button
-                      onClick={() => onNavigate?.(word.cfi!)}
-                      className="flex items-center gap-1 text-[12px] font-medium text-accent-text cursor-pointer hover:opacity-70"
-                    >
-                      {page != null ? t("vocab.goToPage", { page }) : t("vocab.goToLocation")}
-                      <ArrowRight size={12} />
-                    </button>
-                  )}
-                </div>
               </div>
-            );
-          })
-        )}
-      </div>
+            ) : (
+              filteredWords.map((word) => {
+                const page = getPageFromCfi && word.cfi ? getPageFromCfi(word.cfi) : null;
+                const parts = word.definition.split("\n\n");
+                const defText = parts[0] || "";
+                const ctxText = parts.length > 1 ? parts.slice(1).join(" ") : null;
+                return (
+                  <div
+                    key={word.id}
+                    className="group relative border-l-[3px] border-accent bg-bg-surface mx-3 mb-2 rounded-r-lg px-4 pt-3 pb-3"
+                  >
+                    <button
+                      onClick={() => removeWord(word.id)}
+                      className="absolute top-3 right-3 p-1 rounded hover:bg-bg-input cursor-pointer"
+                    >
+                      <Trash2 size={15} className="text-text-muted" />
+                    </button>
+                    <div className="flex items-center gap-2 pr-8">
+                      <span className="text-[16px] font-bold text-text-primary leading-5">
+                        {word.word}
+                      </span>
+                    </div>
+                    <p className="text-[14px] text-text-primary leading-[1.5] mt-2 pr-6 line-clamp-3">
+                      {defText}
+                    </p>
+                    {ctxText && (
+                      <p className="text-[13px] italic text-text-muted leading-[1.45] mt-1 line-clamp-2">
+                        {ctxText}
+                      </p>
+                    )}
+                    <div className="flex items-center justify-between mt-2.5">
+                      <div className="flex items-center gap-3">
+                        {page != null && (
+                          <span className="flex items-center gap-1 text-[11px] text-text-muted tracking-[0.06px]">
+                            <FileText size={12} />
+                            p. {page}
+                          </span>
+                        )}
+                        <span className="flex items-center gap-1 text-[11px] text-text-muted tracking-[0.06px]">
+                          <Clock size={12} />
+                          {timeAgo(word.created_at)}
+                        </span>
+                      </div>
+                      {word.cfi && (
+                        <button
+                          onClick={() => onNavigate?.(word.cfi!)}
+                          className="flex items-center gap-1 text-[12px] font-medium text-accent-text cursor-pointer hover:opacity-70"
+                        >
+                          {page != null ? t("vocab.goToPage", { page }) : t("vocab.goToLocation")}
+                          <ArrowRight size={12} />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
 
-      {/* Footer */}
-      <div className="border-t border-border px-4 pt-[11px] pb-3 shrink-0">
-        <p className="text-[11px] text-text-muted tracking-[0.06px] text-center">
-          {t("vocab.wordCount", { count: filtered.length })}
-        </p>
-      </div>
+          {/* Footer */}
+          <div className="border-t border-border px-4 pt-[11px] pb-3 shrink-0">
+            <p className="text-[11px] text-text-muted tracking-[0.06px] text-center">
+              {t("vocab.wordCount", { count: filteredWords.length })}
+            </p>
+          </div>
+        </>
+      )}
+
+      {/* Translations tab */}
+      {tab === "translations" && (
+        <>
+          {/* Search */}
+          <div className="px-4 pt-2 pb-2 shrink-0">
+            <div className="flex items-center gap-1.5 h-[28px] px-2 rounded-lg bg-bg-input border border-border">
+              <Search size={12} className="text-text-muted shrink-0" />
+              <input
+                type="search"
+                placeholder={t("translation.search")}
+                defaultValue=""
+                onInput={(e) => setTransSearch((e.target as HTMLInputElement).value)}
+                onKeyDown={(e) => e.stopPropagation()}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                className="flex-1 text-[12px] text-text-primary bg-transparent outline-none placeholder:text-text-placeholder [&::-webkit-search-cancel-button]:hidden"
+              />
+            </div>
+          </div>
+
+          {/* Translation list */}
+          <div className="flex-1 overflow-auto">
+            {filteredTranslations.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-full px-4">
+                <div className="size-12 rounded-full bg-bg-input flex items-center justify-center mb-3">
+                  <Languages size={20} className="text-text-muted" />
+                </div>
+                <p className="text-[14px] text-text-muted text-center">
+                  {translations.length === 0
+                    ? t("translation.panelEmpty")
+                    : t("translation.noMatches")}
+                </p>
+                {translations.length === 0 && (
+                  <p className="text-[12px] text-text-muted text-center mt-1">
+                    {t("translation.panelEmptySub")}
+                  </p>
+                )}
+              </div>
+            ) : (
+              filteredTranslations.map((tr) => {
+                const page = getPageFromCfi && tr.cfi ? getPageFromCfi(tr.cfi) : null;
+                return (
+                  <div
+                    key={tr.id}
+                    className="group relative border-l-[3px] border-accent bg-bg-surface mx-3 mb-2 rounded-r-lg px-4 pt-3 pb-3"
+                  >
+                    <button
+                      onClick={() => removeTranslation(tr.id)}
+                      className="absolute top-3 right-3 p-1 rounded hover:bg-bg-input cursor-pointer"
+                    >
+                      <Trash2 size={15} className="text-text-muted" />
+                    </button>
+                    <p className="text-[14px] text-text-primary leading-[1.5] pr-6 line-clamp-3">
+                      {tr.translated_text}
+                    </p>
+                    <p className="text-[12px] italic text-text-muted leading-[1.45] mt-1.5 line-clamp-2">
+                      {tr.source_text}
+                    </p>
+                    <div className="flex items-center justify-between mt-2.5">
+                      <div className="flex items-center gap-3">
+                        {page != null && (
+                          <span className="flex items-center gap-1 text-[11px] text-text-muted tracking-[0.06px]">
+                            <FileText size={12} />
+                            p. {page}
+                          </span>
+                        )}
+                        <span className="flex items-center gap-1 text-[11px] text-text-muted tracking-[0.06px]">
+                          <Clock size={12} />
+                          {timeAgo(tr.created_at)}
+                        </span>
+                      </div>
+                      {tr.cfi && (
+                        <button
+                          onClick={() => onNavigate?.(tr.cfi!)}
+                          className="flex items-center gap-1 text-[12px] font-medium text-accent-text cursor-pointer hover:opacity-70"
+                        >
+                          {page != null ? t("vocab.goToPage", { page }) : t("vocab.goToLocation")}
+                          <ArrowRight size={12} />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="border-t border-border px-4 pt-[11px] pb-3 shrink-0">
+            <p className="text-[11px] text-text-muted tracking-[0.06px] text-center">
+              {t("translation.count", { count: filteredTranslations.length })}
+            </p>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/ReaderContextMenu.tsx
+++ b/src/components/ReaderContextMenu.tsx
@@ -4,6 +4,7 @@ import {
   Bot,
   Sparkles,
   Highlighter,
+  Languages,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -23,6 +24,7 @@ interface ReaderContextMenuProps {
   onCopy: () => void;
   onAskAI: () => void;
   onLookup: () => void;
+  onTranslate: () => void;
   onHighlight?: (color: string) => void;
 }
 
@@ -34,6 +36,7 @@ export default function ReaderContextMenu({
   onCopy,
   onAskAI,
   onLookup,
+  onTranslate,
   onHighlight,
 }: ReaderContextMenuProps) {
   const { t } = useTranslation();
@@ -99,6 +102,17 @@ export default function ReaderContextMenu({
         <Bot size={16} className="text-text-muted" />
         <span className="flex-1 text-[13px] font-medium text-text-primary tracking-[-0.08px]">
           {t("contextMenu.askAI")}
+        </span>
+      </button>
+
+      {/* Translate */}
+      <button
+        onClick={onTranslate}
+        className="flex items-center gap-3 w-[calc(100%-8px)] mx-1 px-3 h-[31.5px] rounded-sm text-left cursor-pointer hover:bg-accent-bg transition-colors"
+      >
+        <Languages size={16} className="text-text-muted" />
+        <span className="flex-1 text-[13px] font-medium text-text-primary tracking-[-0.08px]">
+          {t("contextMenu.translate")}
         </span>
       </button>
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,15 +1,16 @@
 import { useState, useEffect, useRef, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { Globe, BookOpen, Bot, Search, Cloud, Info, X, ChevronRight } from "lucide-react";
+import { Globe, BookOpen, Bot, Search, Languages, Cloud, Info, X, ChevronRight } from "lucide-react";
 import GeneralSettings from "./settings/GeneralSettings";
 import ReadingSettings from "./settings/ReadingSettings";
 import AiSettings from "./settings/AiSettings";
+import LanguageSettings from "./settings/LanguageSettings";
 import LookupSettings from "./settings/LookupSettings";
 import ICloudSettings from "./settings/ICloudSettings";
 import AboutSettings from "./settings/AboutSettings";
 import { useSettings } from "../hooks/useSettings";
 
-type Section = "general" | "reading" | "ai" | "lookup" | "icloud" | "about";
+type Section = "general" | "language" | "reading" | "ai" | "lookup" | "icloud" | "about";
 
 interface SettingsModalProps {
   open: boolean;
@@ -57,6 +58,7 @@ export default function SettingsModal({ open, onClose, initialSection = "general
 
   const allSections: { id: Section; label: string; subtitle: string; icon: typeof Globe }[] = [
     { id: "general", label: t("settings.general.title"), subtitle: t("settings.general.subtitle"), icon: Globe },
+    { id: "language", label: t("settings.language"), subtitle: t("settings.language.subtitle"), icon: Languages },
     { id: "reading", label: t("settings.reading.title"), subtitle: t("settings.reading.subtitle"), icon: BookOpen },
     { id: "ai", label: t("settings.ai.shortTitle"), subtitle: t("settings.ai.shortSubtitle"), icon: Bot },
     { id: "lookup", label: t("settings.lookup.title"), subtitle: t("settings.lookup.shortSub"), icon: Search },
@@ -71,6 +73,7 @@ export default function SettingsModal({ open, onClose, initialSection = "general
   const renderContent = (): ReactNode => {
     switch (activeSection) {
       case "general": return <GeneralSettings {...settingsProps} />;
+      case "language": return <LanguageSettings {...settingsProps} />;
       case "reading": return <ReadingSettings {...settingsProps} />;
       case "ai": return <AiSettings {...settingsProps} onDirtyChange={setAiDirty} onSaveRef={(fn) => { aiSaveRef.current = fn; }} />;
       case "lookup": return <LookupSettings {...settingsProps} />;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Library, BookOpen, CheckCircle2, Sparkles, BookA, Plus, MessageSquare, Pencil, Trash2, GripVertical } from "lucide-react";
+import { Library, BookOpen, CheckCircle2, Sparkles, BookA, Plus, MessageSquare, Globe, Pencil, Trash2, GripVertical } from "lucide-react";
 import Button from "./ui/Button";
 import QuillLogo from "./QuillLogo";
 import type { Book } from "../hooks/useBooks";
@@ -205,6 +205,19 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
               activeFilter === "chats" ? "text-accent-text" : "text-text-secondary"
             }`}>
               {t("sidebar.chats")}
+            </span>
+          </button>
+          <button
+            onClick={() => onFilterChange("translations")}
+            className={`flex items-center gap-2 px-3 h-9 rounded-lg w-full cursor-pointer ${
+              activeFilter === "translations" ? "bg-accent-bg" : "hover:bg-bg-input"
+            }`}
+          >
+            <Globe size={16} className={activeFilter === "translations" ? "text-accent-text" : "text-text-muted"} />
+            <span className={`text-[14px] font-medium tracking-[-0.15px] ${
+              activeFilter === "translations" ? "text-accent-text" : "text-text-secondary"
+            }`}>
+              {t("sidebar.translations")}
             </span>
           </button>
         </div>

--- a/src/components/TranslationPopover.tsx
+++ b/src/components/TranslationPopover.tsx
@@ -1,0 +1,327 @@
+import { useState, useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import {
+  X,
+  Loader2,
+  Languages,
+  BookmarkPlus,
+  Check,
+  Copy,
+  ChevronDown,
+  ChevronUp,
+  Settings,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface TranslationPopoverProps {
+  x: number;
+  y: number;
+  text: string;
+  context?: string;
+  bookId: string;
+  cfi?: string;
+  onClose: () => void;
+}
+
+const LANG_NAMES: Record<string, string> = {
+  en: "English",
+  zh: "Chinese",
+  ja: "Japanese",
+  ko: "Korean",
+  es: "Spanish",
+  fr: "French",
+  de: "German",
+  pt: "Portuguese",
+  ru: "Russian",
+  ar: "Arabic",
+  it: "Italian",
+};
+
+function useStreamingTranslation(
+  text: string,
+  context: string | undefined,
+  bookId: string,
+  cfi: string | undefined
+) {
+  const contentRef = useRef("");
+  const [content, setContent] = useState("");
+  const [streaming, setStreaming] = useState(true);
+  const [notConfigured, setNotConfigured] = useState(false);
+  const [targetLang, setTargetLang] = useState("");
+  const unlistenRef = useRef<UnlistenFn | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    contentRef.current = "";
+
+    // Fetch target language for display
+    invoke<Record<string, string>>("get_all_settings").then((s) => {
+      if (cancelled) return;
+      const lang = s.native_language || "en";
+      setTargetLang(lang);
+    }).catch(() => {});
+
+    const run = async () => {
+      const requestId = crypto.randomUUID();
+
+      unlistenRef.current = await listen<{ delta: string; done: boolean }>(
+        `ai-translate-chunk-${requestId}`,
+        (event) => {
+          if (cancelled) return;
+          if (event.payload.done) {
+            setStreaming(false);
+            unlistenRef.current?.();
+            unlistenRef.current = null;
+            return;
+          }
+          contentRef.current += event.payload.delta;
+          setContent(contentRef.current);
+        }
+      );
+
+      try {
+        await invoke("ai_translate_passage", {
+          text,
+          context: context || null,
+          bookId,
+          targetLanguage: null,
+          requestId,
+        });
+      } catch (err) {
+        if (!cancelled) {
+          const msg = String(err);
+          if (msg.includes("AI_NOT_CONFIGURED")) {
+            setNotConfigured(true);
+          } else {
+            setContent(`Error: ${msg}`);
+          }
+          setStreaming(false);
+        }
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      unlistenRef.current?.();
+      unlistenRef.current = null;
+    };
+  }, [text, context, bookId, cfi]);
+
+  return { content, contentRef, streaming, notConfigured, targetLang };
+}
+
+export default function TranslationPopover({
+  x,
+  y,
+  text,
+  context,
+  bookId,
+  cfi,
+  onClose,
+}: TranslationPopoverProps) {
+  const { t } = useTranslation();
+  const [saved, setSaved] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const { content, contentRef, streaming, notConfigured, targetLang } =
+    useStreamingTranslation(text, context, bookId, cfi);
+
+  const allDone = !streaming;
+  const hasContent = !!content;
+
+  // Position clamping
+  const [pos, setPos] = useState({ left: x, top: y });
+
+  useEffect(() => {
+    const el = popoverRef.current;
+    if (!el) return;
+    const clamp = () => {
+      const rect = el.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      let left = x;
+      let top = y;
+      if (left + rect.width > vw - 16) left = vw - rect.width - 16;
+      if (left < 16) left = 16;
+      if (top + rect.height > vh - 16) top = y - rect.height - 8;
+      if (top < 16) top = 16;
+      setPos({ left, top });
+    };
+    const observer = new ResizeObserver(clamp);
+    observer.observe(el);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSave = async () => {
+    try {
+      await invoke("save_translation", {
+        bookId,
+        sourceText: text,
+        translatedText: contentRef.current,
+        targetLanguage: targetLang || "en",
+        cfi: cfi || null,
+      });
+      setSaved(true);
+    } catch (err) {
+      console.error("Failed to save translation:", err);
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(contentRef.current);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  // Dismiss on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  // Dismiss on click outside
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const id = requestAnimationFrame(() => {
+      document.addEventListener("mousedown", handler);
+    });
+    return () => {
+      cancelAnimationFrame(id);
+      document.removeEventListener("mousedown", handler);
+    };
+  }, [onClose]);
+
+  const langName = LANG_NAMES[targetLang] || targetLang;
+
+  return (
+    <div
+      ref={popoverRef}
+      className="fixed z-50 w-[520px] bg-bg-surface border border-border/80 rounded-xl shadow-context"
+      style={{ left: pos.left, top: pos.top }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 pt-3 pb-2.5 bg-accent-bg rounded-t-xl border-b border-border/40">
+        <div className="flex items-center gap-2">
+          <Languages size={16} className="text-accent-text" />
+          <span className="text-[14px] font-medium text-accent-text tracking-[-0.15px]">
+            {t("translation.title")}
+          </span>
+          {langName && (
+            <span className="text-[13px] text-accent-text/60">{langName}</span>
+          )}
+        </div>
+        <button
+          onClick={onClose}
+          className="size-6 flex items-center justify-center rounded hover:bg-bg-surface/60 cursor-pointer"
+        >
+          <X size={14} className="text-text-muted" />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="px-4 pb-2 max-h-[420px] overflow-auto">
+        {/* Original text — collapsible, collapsed by default */}
+        <div className="relative pt-3 pb-2">
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="absolute top-3 right-0 size-6 flex items-center justify-center rounded hover:bg-bg-muted cursor-pointer"
+          >
+            {expanded ? (
+              <ChevronUp size={14} className="text-text-muted" />
+            ) : (
+              <ChevronDown size={14} className="text-text-muted" />
+            )}
+          </button>
+          {expanded ? (
+            <div className="pr-7 max-h-[120px] overflow-auto">
+              <p className="text-[13px] text-text-muted italic leading-[1.55]">
+                {text}
+              </p>
+            </div>
+          ) : (
+            <p className="text-[13px] text-text-muted italic leading-[1.55] line-clamp-2 pr-7">
+              {text}
+            </p>
+          )}
+        </div>
+
+        <div className="h-px bg-border/60 mb-3" />
+
+        {/* Not configured state */}
+        {notConfigured ? (
+          <div className="flex flex-col items-center gap-2 py-4 text-center">
+            <p className="text-[13px] text-text-muted">{t("ai.notConfigured")}</p>
+            <button
+              onClick={async () => {
+                onClose();
+                await invoke("open_settings_on_main", { section: "ai" });
+                const main = await WebviewWindow.getByLabel("main");
+                await main?.setFocus();
+              }}
+              className="flex items-center gap-1.5 text-[13px] font-medium text-accent-text hover:opacity-70 cursor-pointer"
+            >
+              <Settings size={14} />
+              {t("ai.openSettings")}
+            </button>
+          </div>
+        ) : null}
+
+        {/* Translation body */}
+        {!notConfigured &&
+          (streaming && !content ? (
+            <div className="flex items-center gap-1.5 py-1">
+              <Loader2 size={14} className="animate-spin text-text-muted" />
+              <span className="text-[13px] text-text-muted">
+                {t("translation.translating")}
+              </span>
+            </div>
+          ) : (
+            <p className="text-[13px] text-text-primary leading-[1.55]">
+              {content}
+              {streaming && (
+                <Loader2
+                  size={12}
+                  className="inline-block ml-0.5 animate-spin text-text-muted"
+                />
+              )}
+            </p>
+          ))}
+      </div>
+
+      {/* Footer — Save & Copy */}
+      {allDone && hasContent && (
+        <div className="flex items-center justify-between px-4 py-2.5 border-t border-border/40">
+          <button
+            onClick={handleSave}
+            disabled={saved}
+            className="flex items-center gap-1.5 text-[13px] font-medium cursor-pointer text-accent-text hover:opacity-70 disabled:opacity-50 disabled:cursor-default"
+          >
+            {saved ? <Check size={14} /> : <BookmarkPlus size={14} />}
+            {saved ? t("translation.saved") : t("translation.save")}
+          </button>
+          <button
+            onClick={handleCopy}
+            className="flex items-center gap-1.5 text-[13px] font-medium cursor-pointer text-text-muted hover:opacity-70"
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+            {copied ? t("translation.copied") : t("translation.copy")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TranslationsContent.tsx
+++ b/src/components/TranslationsContent.tsx
@@ -1,0 +1,269 @@
+import { useState, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ArrowRight,
+  Languages,
+  Search,
+  BookOpen,
+  Clock,
+  Trash2,
+  ArrowDownWideNarrow,
+  ArrowUpWideNarrow,
+} from "lucide-react";
+import { useAllTranslations, type SavedTranslation } from "../hooks/useTranslations";
+import { timeAgo } from "../utils/timeAgo";
+import { openReaderWindow } from "../utils/openReaderWindow";
+
+type SortMode = "newest" | "oldest";
+
+export default function TranslationsContent() {
+  const { t } = useTranslation();
+  const { translations, remove } = useAllTranslations();
+  const [sort, setSort] = useState<SortMode>("newest");
+  const [search, setSearch] = useState("");
+  const [bookFilter, setBookFilter] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    let result = translations;
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (tr) =>
+          tr.source_text.toLowerCase().includes(q) ||
+          tr.translated_text.toLowerCase().includes(q)
+      );
+    }
+    if (bookFilter) {
+      result = result.filter((tr) => tr.book_id === bookFilter);
+    }
+    return result;
+  }, [translations, search, bookFilter]);
+
+  const sorted = useMemo(() => {
+    const copy = [...filtered];
+    if (sort === "oldest") {
+      copy.sort((a, b) => a.created_at.localeCompare(b.created_at));
+    }
+    return copy;
+  }, [filtered, sort]);
+
+  const groupedByBook = useMemo(() => {
+    const map = new Map<string, { title: string; translations: SavedTranslation[] }>();
+    for (const tr of sorted) {
+      if (!map.has(tr.book_id)) {
+        map.set(tr.book_id, {
+          title: tr.book_title || t("common.unknownBook"),
+          translations: [],
+        });
+      }
+      map.get(tr.book_id)!.translations.push(tr);
+    }
+    return Array.from(map.values());
+  }, [sorted, t]);
+
+  const bookPills = useMemo(() => {
+    const map = new Map<string, { title: string; count: number }>();
+    for (const tr of translations) {
+      if (!map.has(tr.book_id)) {
+        map.set(tr.book_id, {
+          title: tr.book_title || t("common.unknownBook"),
+          count: 0,
+        });
+      }
+      map.get(tr.book_id)!.count++;
+    }
+    return Array.from(map.entries()).map(([id, { title, count }]) => ({
+      id,
+      title,
+      count,
+    }));
+  }, [translations, t]);
+
+  const isEmpty = translations.length === 0;
+
+  return (
+    <div className="flex-1 flex flex-col min-w-0">
+      {/* Header */}
+      <div className="px-page pb-2 relative select-none">
+        <div data-tauri-drag-region className="absolute top-0 left-0 right-0 h-11" />
+        <div className="pt-11 flex items-center justify-between mb-6">
+          <h1 className="text-[24px] font-semibold text-text-primary tracking-[0.07px]">
+            {t("translation.title")}
+          </h1>
+        </div>
+
+        <div className="flex items-center gap-2 h-9 px-3 rounded-lg bg-bg-input max-w-[448px]">
+          <Search size={16} className="text-text-muted shrink-0" />
+          <input
+            type="search"
+            placeholder={t("translation.search")}
+            defaultValue=""
+            onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            className="flex-1 text-[14px] text-text-primary bg-transparent outline-none placeholder:text-text-placeholder [&::-webkit-search-cancel-button]:hidden"
+          />
+        </div>
+      </div>
+
+      {/* Book filter pills + sort */}
+      {!isEmpty && (
+        <div className="flex items-center gap-2 px-page pt-2 pb-4 overflow-x-auto border-b border-border">
+          <button
+            onClick={() => setBookFilter(null)}
+            className={`flex items-center gap-1.5 h-8 px-[13px] rounded-full text-[12px] font-medium cursor-pointer shrink-0 transition-colors border ${
+              bookFilter === null
+                ? "bg-accent-bg border-accent/30 text-accent-text"
+                : "bg-bg-surface border-border text-text-secondary hover:bg-bg-muted"
+            }`}
+          >
+            <BookOpen
+              size={12}
+              className={bookFilter === null ? "text-accent-text" : ""}
+            />
+            {t("common.allBooks")}
+            <span
+              className={`text-[11px] ${bookFilter === null ? "text-accent-text" : "text-text-muted"}`}
+            >
+              {translations.length}
+            </span>
+          </button>
+          {bookPills.map((pill) => (
+            <button
+              key={pill.id}
+              onClick={() =>
+                setBookFilter(bookFilter === pill.id ? null : pill.id)
+              }
+              className={`flex items-center gap-1.5 h-8 px-[13px] rounded-full text-[12px] font-medium cursor-pointer shrink-0 transition-colors border ${
+                bookFilter === pill.id
+                  ? "bg-accent-bg border-accent/30 text-accent-text"
+                  : "bg-bg-surface border-border text-text-secondary hover:bg-bg-muted"
+              }`}
+            >
+              <BookOpen
+                size={12}
+                className={bookFilter === pill.id ? "text-accent-text" : ""}
+              />
+              <span className="truncate max-w-[120px]">{pill.title}</span>
+              <span
+                className={`text-[11px] ${bookFilter === pill.id ? "text-accent-text" : "text-text-muted"}`}
+              >
+                {pill.count}
+              </span>
+            </button>
+          ))}
+
+          <div className="ml-auto flex items-center gap-1 shrink-0">
+            <button
+              onClick={() => setSort("newest")}
+              className={`flex items-center gap-1 h-7 px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
+                sort === "newest"
+                  ? "text-accent-text"
+                  : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              <ArrowDownWideNarrow size={12} />
+              {t("translation.newest")}
+            </button>
+            <button
+              onClick={() => setSort("oldest")}
+              className={`flex items-center gap-1 h-7 px-2.5 rounded-lg text-[11px] font-medium cursor-pointer transition-colors ${
+                sort === "oldest"
+                  ? "text-accent-text"
+                  : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              <ArrowUpWideNarrow size={12} />
+              {t("translation.oldest")}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-page pb-20">
+        {isEmpty ? (
+          <div className="flex flex-col items-center justify-center h-full">
+            <div className="size-16 rounded-full bg-bg-input flex items-center justify-center mb-4">
+              <Languages size={28} className="text-text-muted" />
+            </div>
+            <h2 className="text-[18px] font-medium text-text-primary mb-2">
+              {t("translation.empty")}
+            </h2>
+            <p className="text-[14px] text-text-muted text-center max-w-[296px]">
+              {t("translation.emptySub")}
+            </p>
+          </div>
+        ) : (
+          <div className="max-w-[525px] space-y-6">
+            {groupedByBook.map((group) => (
+              <div key={group.title}>
+                <div className="flex items-center gap-2 mb-3">
+                  <BookOpen size={14} className="text-text-muted" />
+                  <span className="text-[12px] font-semibold uppercase text-text-muted tracking-[0.3px]">
+                    {group.title}
+                  </span>
+                  <span className="text-[11px] text-text-muted">
+                    ({group.translations.length})
+                  </span>
+                </div>
+                <div className="space-y-3">
+                  {group.translations.map((tr) => (
+                    <div
+                      key={tr.id}
+                      className="group relative bg-bg-muted border border-border rounded-[14px] p-[17px] flex flex-col gap-2"
+                    >
+                      <button
+                        onClick={() => remove(tr.id)}
+                        className="absolute top-4 right-4 p-1 rounded hover:bg-bg-surface/80 cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+                      >
+                        <Trash2 size={15} className="text-text-muted" />
+                      </button>
+
+                      {/* Translated text */}
+                      <p className="text-[13px] text-text-primary leading-[20.15px] tracking-[-0.08px] line-clamp-3 w-[460px] max-w-full">
+                        {tr.translated_text}
+                      </p>
+
+                      {/* Source text */}
+                      <div className="border-l-2 border-accent/30 pl-2 overflow-hidden">
+                        <p className="text-[11px] italic text-text-muted leading-[16.5px] tracking-[0.06px] line-clamp-2">
+                          {tr.source_text}
+                        </p>
+                      </div>
+
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <span className="text-[10px] font-medium text-text-muted bg-bg-input px-1.5 py-0.5 rounded">
+                            {tr.target_language.toUpperCase()}
+                          </span>
+                          <span className="flex items-center gap-1 text-[11px] text-text-muted tracking-[0.06px]">
+                            <Clock size={12} />
+                            {timeAgo(tr.created_at)}
+                          </span>
+                        </div>
+                        {tr.cfi && (
+                          <button
+                            onClick={() =>
+                              openReaderWindow(tr.book_id, { cfi: tr.cfi })
+                            }
+                            className="flex items-center gap-1 h-[24.5px] px-2.5 rounded-[10px] bg-accent-bg text-[11px] font-medium text-accent-text tracking-[0.06px] cursor-pointer hover:opacity-70"
+                          >
+                            {t("chats.openInReader")}
+                            <ArrowRight size={12} />
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TranslationsPanel.tsx
+++ b/src/components/TranslationsPanel.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Languages, Search, Trash2, Clock, FileText, ArrowRight } from "lucide-react";
+import { useTranslations } from "../hooks/useTranslations";
+import { timeAgo } from "../utils/timeAgo";
+
+interface TranslationsPanelProps {
+  bookId: string;
+  onNavigate?: (cfi: string) => void;
+  getPageFromCfi?: (cfi: string) => number | null;
+}
+
+export default function TranslationsPanel({
+  bookId,
+  onNavigate,
+  getPageFromCfi,
+}: TranslationsPanelProps) {
+  const { t } = useTranslation();
+  const [search, setSearch] = useState("");
+  const { translations, remove } = useTranslations(bookId);
+
+  const filtered = translations.filter((tr) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      tr.source_text.toLowerCase().includes(q) ||
+      tr.translated_text.toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div className="flex flex-col h-full bg-bg-muted">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 h-[45px] shrink-0">
+        <div className="flex items-center gap-2">
+          <div
+            className="size-5 rounded-md flex items-center justify-center"
+            style={{ background: "linear-gradient(135deg, #3B82F6, #1D4ED8)" }}
+          >
+            <Languages size={12} className="text-white" />
+          </div>
+          <span className="text-[14px] font-semibold text-text-primary tracking-[-0.15px]">
+            {t("translation.title")}
+          </span>
+        </div>
+        <span className="text-[11px] text-text-muted tracking-[0.06px]">
+          {t("translation.count", { count: translations.length })}
+        </span>
+      </div>
+
+      {/* Search */}
+      <div className="px-4 pb-2 shrink-0">
+        <div className="flex items-center gap-1.5 h-[28px] px-2 rounded-lg bg-bg-input border border-border">
+          <Search size={12} className="text-text-muted shrink-0" />
+          <input
+            type="search"
+            placeholder={t("translation.search")}
+            defaultValue=""
+            onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
+            onKeyDown={(e) => e.stopPropagation()}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            className="flex-1 text-[12px] text-text-primary bg-transparent outline-none placeholder:text-text-placeholder [&::-webkit-search-cancel-button]:hidden"
+          />
+        </div>
+      </div>
+
+      {/* Translation list */}
+      <div className="flex-1 overflow-auto">
+        {filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full px-4">
+            <div className="size-12 rounded-full bg-bg-input flex items-center justify-center mb-3">
+              <Languages size={20} className="text-text-muted" />
+            </div>
+            <p className="text-[14px] text-text-muted text-center">
+              {translations.length === 0
+                ? t("translation.panelEmpty")
+                : t("translation.noMatches")}
+            </p>
+            {translations.length === 0 && (
+              <p className="text-[12px] text-text-muted text-center mt-1">
+                {t("translation.panelEmptySub")}
+              </p>
+            )}
+          </div>
+        ) : (
+          filtered.map((tr) => {
+            const page =
+              getPageFromCfi && tr.cfi ? getPageFromCfi(tr.cfi) : null;
+            return (
+              <div
+                key={tr.id}
+                className="group relative border-l-[3px] border-blue-500 bg-bg-surface mx-3 mb-2 rounded-r-lg px-4 pt-3 pb-3"
+              >
+                {/* Trash */}
+                <button
+                  onClick={() => remove(tr.id)}
+                  className="absolute top-3 right-3 p-1 rounded hover:bg-bg-input cursor-pointer"
+                >
+                  <Trash2 size={15} className="text-text-muted" />
+                </button>
+
+                {/* Translated text */}
+                <p className="text-[14px] text-text-primary leading-[1.5] pr-6 line-clamp-3">
+                  {tr.translated_text}
+                </p>
+
+                {/* Source text — muted */}
+                <p className="text-[12px] italic text-text-muted leading-[1.45] mt-1.5 line-clamp-2">
+                  {tr.source_text}
+                </p>
+
+                {/* Metadata row */}
+                <div className="flex items-center justify-between mt-2.5">
+                  <div className="flex items-center gap-3">
+                    {page != null && (
+                      <span className="flex items-center gap-1 text-[11px] text-text-muted tracking-[0.06px]">
+                        <FileText size={12} />
+                        p. {page}
+                      </span>
+                    )}
+                    <span className="flex items-center gap-1 text-[11px] text-text-muted tracking-[0.06px]">
+                      <Clock size={12} />
+                      {timeAgo(tr.created_at)}
+                    </span>
+                  </div>
+                  {tr.cfi && (
+                    <button
+                      onClick={() => onNavigate?.(tr.cfi!)}
+                      className="flex items-center gap-1 text-[12px] font-medium text-accent-text cursor-pointer hover:opacity-70"
+                    >
+                      {page != null
+                        ? t("vocab.goToPage", { page })
+                        : t("vocab.goToLocation")}
+                      <ArrowRight size={12} />
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="border-t border-border px-4 pt-[11px] pb-3 shrink-0">
+        <p className="text-[11px] text-text-muted tracking-[0.06px] text-center">
+          {t("translation.count", { count: filtered.length })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/GeneralSettings.tsx
+++ b/src/components/settings/GeneralSettings.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import i18n from "../../i18n";
 import Select from "../ui/Select";
 import Toggle from "../ui/Toggle";
 import type { SettingsProps } from "./types";
@@ -8,14 +7,12 @@ import type { SettingsProps } from "./types";
 export default function GeneralSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
   const { t } = useTranslation();
   const [displayName, setDisplayName] = useState("Reader");
-  const [language, setLanguage] = useState("en");
   const [theme, setTheme] = useState("system");
   const [autoSave, setAutoSave] = useState(true);
 
   useEffect(() => {
     if (loading) return;
     if (settings.user_name) setDisplayName(settings.user_name);
-    if (settings.language) setLanguage(settings.language);
     if (settings.theme) setTheme(settings.theme);
     if (settings.auto_save) setAutoSave(settings.auto_save === "true");
   }, [settings, loading]);
@@ -45,29 +42,6 @@ export default function GeneralSettings({ settings, loading, save, showSavedToas
           onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
           placeholder="Reader"
           className="w-[120px] shrink-0 h-8 bg-white dark:bg-bg-surface rounded-[10px] px-3 text-[13px] font-medium text-text-secondary text-center outline-none border border-border focus:border-accent transition-colors"
-        />
-      </div>
-      <div className="h-px bg-black/10" />
-
-      {/* Language */}
-      <div className="flex items-center justify-between h-[73px]">
-        <div>
-          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.language")}</p>
-          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.general.languageHint")}</p>
-        </div>
-        <Select
-          className="w-[130px] shrink-0"
-          value={language}
-          onChange={(lang) => {
-            setLanguage(lang);
-            save("language", lang);
-            i18n.changeLanguage(lang);
-            showSavedToast();
-          }}
-          options={[
-            { value: "en", label: "English" },
-            { value: "zh", label: "简体中文" },
-          ]}
         />
       </div>
       <div className="h-px bg-black/10" />

--- a/src/components/settings/LanguageSettings.tsx
+++ b/src/components/settings/LanguageSettings.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import i18n from "../../i18n";
+import Select from "../ui/Select";
+import type { SettingsProps } from "./types";
+
+export default function LanguageSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
+  const { t } = useTranslation();
+  const [language, setLanguage] = useState("en");
+  const [nativeLanguage, setNativeLanguage] = useState("en");
+
+  useEffect(() => {
+    if (loading) return;
+    if (settings.language) setLanguage(settings.language);
+    if (settings.native_language) setNativeLanguage(settings.native_language);
+  }, [settings, loading]);
+
+  return (
+    <div>
+      {/* System Language */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">
+            {t("settings.language")}
+          </p>
+          <p className="text-[12px] text-text-muted mt-0.5">
+            {t("settings.general.languageHint")}
+          </p>
+        </div>
+        <Select
+          className="w-[130px] shrink-0"
+          value={language}
+          onChange={(lang) => {
+            setLanguage(lang);
+            save("language", lang);
+            i18n.changeLanguage(lang);
+            showSavedToast();
+          }}
+          options={[
+            { value: "en", label: "English" },
+            { value: "zh", label: "简体中文" },
+          ]}
+        />
+      </div>
+      <div className="h-px bg-black/10" />
+
+      {/* Native Language */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">
+            {t("settings.lookup.nativeLanguage")}
+          </p>
+          <p className="text-[12px] text-text-muted mt-0.5">
+            {t("settings.lookup.nativeLanguageHint")}
+          </p>
+        </div>
+        <Select
+          className="w-[130px] shrink-0"
+          value={nativeLanguage}
+          onChange={(lang) => {
+            setNativeLanguage(lang);
+            save("native_language", lang);
+            showSavedToast();
+          }}
+          options={[
+            { value: "en", label: "English" },
+            { value: "zh", label: "简体中文" },
+            { value: "ja", label: "日本語" },
+            { value: "ko", label: "한국어" },
+            { value: "es", label: "Español" },
+            { value: "fr", label: "Français" },
+            { value: "de", label: "Deutsch" },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/LookupSettings.tsx
+++ b/src/components/settings/LookupSettings.tsx
@@ -1,51 +1,25 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Sparkles, X } from "lucide-react";
-import Select from "../ui/Select";
 import Toggle from "../ui/Toggle";
 import type { SettingsProps } from "./types";
 
 export default function LookupSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
   const { t, i18n } = useTranslation();
-  const [nativeLanguage, setNativeLanguage] = useState("en");
   const [showTranslation, setShowTranslation] = useState(false);
 
   const language = i18n.language;
+  const nativeLanguage = settings.native_language || "en";
 
   useEffect(() => {
     if (loading) return;
-    if (settings.native_language) setNativeLanguage(settings.native_language);
     if (settings.show_translation) setShowTranslation(settings.show_translation === "true");
   }, [settings, loading]);
 
+  if (loading) return null;
+
   return (
     <div>
-      {/* Native Language */}
-      <div className="flex items-center justify-between h-[73px]">
-        <div>
-          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">
-            {t("settings.lookup.nativeLanguage")}
-          </p>
-          <p className="text-[12px] text-text-muted mt-0.5">
-            {t("settings.lookup.nativeLanguageHint")}
-          </p>
-        </div>
-        <Select
-          className="w-[130px] shrink-0"
-          value={nativeLanguage}
-          onChange={(lang) => {
-            setNativeLanguage(lang);
-            save("native_language", lang);
-            showSavedToast();
-          }}
-          options={[
-            { value: "en", label: "English" },
-            { value: "zh", label: "简体中文" },
-          ]}
-        />
-      </div>
-      <div className="h-px bg-black/10" />
-
       {/* Show Translation */}
       <div className="flex items-center justify-between h-[73px]">
         <div>

--- a/src/hooks/useTranslations.ts
+++ b/src/hooks/useTranslations.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface SavedTranslation {
+  id: string;
+  book_id: string;
+  source_text: string;
+  translated_text: string;
+  target_language: string;
+  cfi: string | null;
+  created_at: string;
+  book_title?: string | null;
+}
+
+export function useTranslations(bookId: string) {
+  const [translations, setTranslations] = useState<SavedTranslation[]>([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const result = await invoke<SavedTranslation[]>("list_translations", {
+        bookId,
+      });
+      setTranslations(result);
+    } catch (err) {
+      console.error("Failed to load translations:", err);
+    }
+  }, [bookId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const remove = useCallback(async (id: string) => {
+    await invoke("remove_saved_translation", { id });
+    setTranslations((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return { translations, refresh, remove };
+}
+
+export function useAllTranslations() {
+  const [translations, setTranslations] = useState<SavedTranslation[]>([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const result = await invoke<SavedTranslation[]>("list_translations", {
+        bookId: null,
+      });
+      setTranslations(result);
+    } catch (err) {
+      console.error("Failed to load all translations:", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const remove = useCallback(async (id: string) => {
+    await invoke("remove_saved_translation", { id });
+    setTranslations((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return { translations, refresh, remove };
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -6,6 +6,7 @@
   "sidebar.tools": "Tools",
   "sidebar.dictionary": "Dictionary",
   "sidebar.chats": "Chats",
+  "sidebar.translations": "Translations",
   "sidebar.collections": "Collections",
   "sidebar.collectionPlaceholder": "Collection name...",
   "sidebar.renameCollection": "Rename",
@@ -109,6 +110,7 @@
 
   "contextMenu.lookUp": "Look Up",
   "contextMenu.askAI": "Ask AI Assistant",
+  "contextMenu.translate": "Translate",
   "contextMenu.highlight": "Highlight",
   "contextMenu.copy": "Copy",
 
@@ -157,6 +159,7 @@
   "settings.general.themeHint": "Choose your preferred color scheme",
 
   "settings.language": "Language",
+  "settings.language.subtitle": "System language & native language",
   "settings.languageSub": "Choose your preferred language",
 
   "settings.reading.title": "Reading",
@@ -282,6 +285,24 @@
   "common.search": "Search...",
   "common.unknownBook": "Unknown Book",
   "common.bookmark": "Bookmark",
+
+  "translation.title": "Translation",
+  "translation.original": "Original",
+  "translation.translating": "Translating...",
+  "translation.save": "Save",
+  "translation.saved": "Saved",
+  "translation.copy": "Copy",
+  "translation.copied": "Copied",
+  "translation.empty": "No Saved Translations",
+  "translation.emptySub": "Select text while reading, use \"Translate\" to see its translation, then tap \"Save\" to add it here.",
+  "translation.panelEmpty": "No saved translations yet",
+  "translation.panelEmptySub": "Use \"Translate\" on selected text and tap Save",
+  "translation.noMatches": "No matches found",
+  "translation.search": "Search translations...",
+  "translation.newest": "Newest",
+  "translation.oldest": "Oldest",
+  "translation.count_one": "{{count}} translation",
+  "translation.count_other": "{{count}} translations",
 
   "time.justNow": "Just now",
   "time.minutesAgo": "{{count}}m ago",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -6,6 +6,7 @@
   "sidebar.tools": "工具",
   "sidebar.dictionary": "词典",
   "sidebar.chats": "对话",
+  "sidebar.translations": "翻译",
   "sidebar.collections": "书单",
   "sidebar.collectionPlaceholder": "书单名称...",
   "sidebar.renameCollection": "重命名",
@@ -109,6 +110,7 @@
 
   "contextMenu.lookUp": "查词",
   "contextMenu.askAI": "询问 AI 助手",
+  "contextMenu.translate": "翻译",
   "contextMenu.highlight": "高亮",
   "contextMenu.copy": "复制",
 
@@ -157,6 +159,7 @@
   "settings.general.themeHint": "选择你偏好的配色方案",
 
   "settings.language": "语言",
+  "settings.language.subtitle": "系统语言与母语",
   "settings.languageSub": "选择你的首选语言",
 
   "settings.reading.title": "阅读",
@@ -284,6 +287,24 @@
   "common.search": "搜索...",
   "common.unknownBook": "未知书籍",
   "common.bookmark": "书签",
+
+  "translation.title": "翻译",
+  "translation.original": "原文",
+  "translation.translating": "翻译中...",
+  "translation.save": "保存",
+  "translation.saved": "已保存",
+  "translation.copy": "复制",
+  "translation.copied": "已复制",
+  "translation.empty": "暂无保存的翻译",
+  "translation.emptySub": "阅读时选中文本，使用「翻译」查看译文，然后点击「保存」将其添加到这里。",
+  "translation.panelEmpty": "暂无保存的翻译",
+  "translation.panelEmptySub": "选中文本后使用「翻译」，然后点击保存",
+  "translation.noMatches": "未找到匹配",
+  "translation.search": "搜索翻译...",
+  "translation.newest": "最新",
+  "translation.oldest": "最早",
+  "translation.count_one": "{{count}} 条翻译",
+  "translation.count_other": "{{count}} 条翻译",
 
   "time.justNow": "刚刚",
   "time.minutesAgo": "{{count}}分钟前",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import BookGrid from "../components/BookGrid";
 import BookList from "../components/BookList";
 import DictionaryContent from "../components/DictionaryContent";
 import ChatsContent from "../components/ChatsContent";
+import TranslationsContent from "../components/TranslationsContent";
 import SettingsModal from "../components/SettingsModal";
 import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
@@ -199,6 +200,8 @@ export default function Home() {
         <DictionaryContent />
       ) : activeFilter === "chats" ? (
         <ChatsContent />
+      ) : activeFilter === "translations" ? (
+        <TranslationsContent />
       ) : (
         <main className="flex-1 flex flex-col min-w-0">
           <div className="border-b border-border px-page pb-section relative select-none">

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -22,6 +22,7 @@ import ReaderContextMenu from "../components/ReaderContextMenu";
 import HighlightToolbar from "../components/HighlightToolbar";
 import LookupPopover from "../components/LookupPopover";
 import DictionaryPanel from "../components/DictionaryPanel";
+import TranslationPopover from "../components/TranslationPopover";
 import TableOfContents from "../components/TableOfContents";
 import { getBook, updateReadingProgress, checkBookAvailable, type Book } from "../hooks/useBooks";
 import { getAllSettings } from "../hooks/useSettings";
@@ -210,6 +211,13 @@ export default function Reader() {
     sentence: string;
     bookTitle?: string;
     chapter?: string;
+    cfi?: string;
+  } | null>(null);
+  const [translation, setTranslation] = useState<{
+    x: number;
+    y: number;
+    text: string;
+    context?: string;
     cfi?: string;
   } | null>(null);
   const [highlightToolbar, setHighlightToolbar] = useState<{
@@ -1245,6 +1253,16 @@ export default function Reader() {
             });
             setContextMenu(null);
           }}
+          onTranslate={() => {
+            setTranslation({
+              x: contextMenu.x,
+              y: contextMenu.y,
+              text: contextMenu.text,
+              context: contextMenu.sentence,
+              cfi: contextMenu.cfiRange,
+            });
+            setContextMenu(null);
+          }}
           onHighlight={(color) => {
             const cfiRange = contextMenu.cfiRange;
             if (cfiRange && bookId) {
@@ -1273,6 +1291,18 @@ export default function Reader() {
           bookId={bookId!}
           cfi={lookup.cfi}
           onClose={() => setLookup(null)}
+        />
+      )}
+
+      {translation && (
+        <TranslationPopover
+          x={translation.x}
+          y={translation.y}
+          text={translation.text}
+          context={translation.context}
+          bookId={bookId!}
+          cfi={translation.cfi}
+          onClose={() => setTranslation(null)}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Add passage-level translation via context menu "Translate" action with streaming AI response
- Translations are saveable (like dictionary words) and browsable in a combined Dictionary/Translations tabbed panel in the reader, plus a full-page Translations view in the main window sidebar
- New Language settings section consolidating system language and native language
- Context-aware prompts: short selections get paragraph context for accurate translation
- Added `cargo test --lib` to CI pipeline

## Changes
- **Backend**: `translation.rs` with 4 commands (translate, save, remove, list), migration 006
- **Frontend**: TranslationPopover, combined DictionaryPanel with tabs, TranslationsContent, LanguageSettings
- **Wiring**: context menu, Reader.tsx, Sidebar, Home.tsx, i18n (en/zh)

Closes #73

## Test plan
- [x] `cargo test --lib` — 53/53 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Select text → Translate → streaming popover appears
- [ ] Save translation → appears in Translations tab and main window page
- [ ] Works with Ollama, Anthropic, OpenAI providers
- [ ] Short selections get paragraph context in prompt
- [ ] Language settings: system language + native language work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)