### PR TITLE
feat: per-book reader display settings

### DIFF
--- a/src-tauri/migrations/007_book_settings.sql
+++ b/src-tauri/migrations/007_book_settings.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS book_settings (
+  book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  value TEXT NOT NULL,
+  PRIMARY KEY (book_id, key)
+);

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -71,6 +71,135 @@ pub fn set_settings_bulk(settings: HashMap<String, String>, db: State<'_, Db>, s
     Ok(())
 }
 
+#[tauri::command]
+pub fn get_book_settings(book_id: String, db: State<'_, Db>) -> AppResult<HashMap<String, String>> {
+    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let mut stmt = conn.prepare("SELECT key, value FROM book_settings WHERE book_id = ?1")?;
+    let settings = stmt
+        .query_map(params![book_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?
+        .collect::<Result<HashMap<_, _>, _>>()?;
+    Ok(settings)
+}
+
+#[tauri::command]
+pub fn set_book_settings_bulk(book_id: String, settings: HashMap<String, String>, db: State<'_, Db>) -> AppResult<()> {
+    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    for (key, value) in settings {
+        conn.execute(
+            "INSERT INTO book_settings (book_id, key, value) VALUES (?1, ?2, ?3) ON CONFLICT(book_id, key) DO UPDATE SET value = ?3",
+            params![book_id, key, value],
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::Db;
+    use rusqlite::params;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn setup() -> (TempDir, Db) {
+        let dir = TempDir::new().unwrap();
+        let db = Db::init(&dir.path().to_path_buf()).unwrap();
+        let conn = db.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+             VALUES ('book1', 'Test Book', 'Author', 'books/test.epub', 'reading', 0, '2024-01-01', '2024-01-01')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+             VALUES ('book2', 'Second Book', 'Author 2', 'books/test2.epub', 'reading', 0, '2024-01-01', '2024-01-01')",
+            [],
+        ).unwrap();
+        drop(conn);
+        (dir, db)
+    }
+
+    fn get_book_settings(db: &Db, book_id: &str) -> HashMap<String, String> {
+        let conn = db.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT key, value FROM book_settings WHERE book_id = ?1").unwrap();
+        stmt.query_map(params![book_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+            .unwrap()
+            .collect::<Result<HashMap<_, _>, _>>()
+            .unwrap()
+    }
+
+    fn set_book_settings_bulk(db: &Db, book_id: &str, settings: HashMap<String, String>) {
+        let conn = db.conn.lock().unwrap();
+        for (key, value) in settings {
+            conn.execute(
+                "INSERT INTO book_settings (book_id, key, value) VALUES (?1, ?2, ?3) ON CONFLICT(book_id, key) DO UPDATE SET value = ?3",
+                params![book_id, key, value],
+            ).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_book_settings_roundtrip() {
+        let (_dir, db) = setup();
+        let mut settings = HashMap::new();
+        settings.insert("font_family".to_string(), "inter".to_string());
+        settings.insert("font_size".to_string(), "32".to_string());
+
+        set_book_settings_bulk(&db, "book1", settings);
+
+        let result = get_book_settings(&db, "book1");
+        assert_eq!(result.get("font_family").unwrap(), "inter");
+        assert_eq!(result.get("font_size").unwrap(), "32");
+    }
+
+    #[test]
+    fn test_book_settings_isolation() {
+        let (_dir, db) = setup();
+
+        let mut s1 = HashMap::new();
+        s1.insert("font_family".to_string(), "inter".to_string());
+        set_book_settings_bulk(&db, "book1", s1);
+
+        let mut s2 = HashMap::new();
+        s2.insert("font_family".to_string(), "georgia".to_string());
+        set_book_settings_bulk(&db, "book2", s2);
+
+        assert_eq!(get_book_settings(&db, "book1").get("font_family").unwrap(), "inter");
+        assert_eq!(get_book_settings(&db, "book2").get("font_family").unwrap(), "georgia");
+    }
+
+    #[test]
+    fn test_book_settings_cascade_delete() {
+        let (_dir, db) = setup();
+
+        let mut settings = HashMap::new();
+        settings.insert("font_size".to_string(), "28".to_string());
+        set_book_settings_bulk(&db, "book1", settings);
+
+        assert_eq!(get_book_settings(&db, "book1").len(), 1);
+
+        let conn = db.conn.lock().unwrap();
+        conn.execute("DELETE FROM books WHERE id = 'book1'", []).unwrap();
+        drop(conn);
+
+        assert!(get_book_settings(&db, "book1").is_empty());
+    }
+
+    #[test]
+    fn test_book_settings_upsert() {
+        let (_dir, db) = setup();
+
+        let mut s1 = HashMap::new();
+        s1.insert("font_size".to_string(), "24".to_string());
+        set_book_settings_bulk(&db, "book1", s1);
+
+        let mut s2 = HashMap::new();
+        s2.insert("font_size".to_string(), "30".to_string());
+        set_book_settings_bulk(&db, "book1", s2);
+
+        assert_eq!(get_book_settings(&db, "book1").get("font_size").unwrap(), "30");
+    }
+}
+
 /// Emit an open-settings event to the main window from any window.
 #[tauri::command]
 pub fn open_settings_on_main(section: String, app: AppHandle) -> AppResult<()> {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -12,6 +12,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (4, include_str!("../migrations/004_pdf_support.sql")),
     (5, include_str!("../migrations/005_collection_sort_order.sql")),
     (6, include_str!("../migrations/006_translations.sql")),
+    (7, include_str!("../migrations/007_book_settings.sql")),
 ];
 
 pub struct Db {
@@ -144,7 +145,7 @@ mod tests {
         let conn = db.conn.lock().unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 6);
+        assert_eq!(version, 7);
     }
 
     #[test]
@@ -165,6 +166,7 @@ mod tests {
         assert!(tables.contains(&"chats".to_string()));
         assert!(tables.contains(&"chat_messages".to_string()));
         assert!(tables.contains(&"translations".to_string()));
+        assert!(tables.contains(&"book_settings".to_string()));
         assert!(tables.contains(&"schema_version".to_string()));
     }
 
@@ -176,7 +178,7 @@ mod tests {
         Db::run_migrations_on(&conn).unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 6);
+        assert_eq!(version, 7);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,8 @@ pub fn run() {
             commands::settings::get_setting,
             commands::settings::set_setting,
             commands::settings::set_settings_bulk,
+            commands::settings::get_book_settings,
+            commands::settings::set_book_settings_bulk,
             commands::settings::open_settings_on_main,
             // Bookmarks & Highlights
             commands::bookmarks::add_bookmark,

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -261,7 +261,11 @@ export default function Reader() {
       .catch(() => setBook(null))
       .finally(() => setLoading(false));
 
-    getAllSettings().then((s) => {
+    Promise.all([
+      getAllSettings(),
+      invoke<Record<string, string>>("get_book_settings", { bookId }),
+    ]).then(([globalSettings, bookSettings]) => {
+      const s = { ...globalSettings, ...bookSettings };
       setReaderSettings((prev) => ({
         ...prev,
         theme: (s.reader_theme as ReaderSettingsState["theme"]) || prev.theme,
@@ -285,7 +289,8 @@ export default function Reader() {
   useEffect(() => {
     if (!dbSettingsLoaded.current) return;
     const { theme, brightness, pageColumns, font, fontSize, readingMode, lineSpacing, charSpacing, wordSpacing, margins } = readerSettings;
-    invoke("set_settings_bulk", {
+    invoke("set_book_settings_bulk", {
+      bookId,
       settings: {
         reader_theme: theme,
         brightness: String(brightness),


### PR DESCRIPTION
## Summary
- Adds `book_settings` table keyed on `(book_id, key)` with cascade delete
- Adds `get_book_settings` / `set_book_settings_bulk` backend commands
- Reader now loads per-book settings with global fallback and persists per-book only
- 4 unit tests: roundtrip, isolation, cascade delete, upsert

Closes #119

## Test plan
- [x] `cargo test` — 4 new tests pass
- [ ] Open Book A, change font/size → close → reopen → settings preserved
- [ ] Open Book B → shows global defaults, not Book A's settings
- [ ] Delete a book → no orphaned rows in `book_settings`
- [ ] Fresh import → falls back to global defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)