### PR TITLE
fix: reset PDF zoom on window resize (#131)

### DIFF
--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -718,6 +718,26 @@ export default function Reader() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sidePanel]);
 
+  // Reset zoom to 100% on window resize so PDF re-fits to new size
+  useEffect(() => {
+    if (book?.format !== "pdf") return;
+    const resetZoom = () => {
+      if (zoomRef.current === 100) return;
+      const view = viewRef.current;
+      const viewer = viewerRef.current;
+      if (!view?.renderer || !viewer) return;
+      const renderer = view.renderer;
+      renderer.style.width = "";
+      renderer.style.height = "";
+      renderer.style.transform = "";
+      viewer.style.width = "";
+      viewer.style.height = "";
+      setZoomLevel(100);
+    };
+    window.addEventListener("resize", resetZoom);
+    return () => window.removeEventListener("resize", resetZoom);
+  }, [book?.format]);
+
   // Keyboard navigation — parent document listener
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- When a PDF is manually zoomed and the window is resized, the page now resets to 100% zoom and re-fits to the new window width
- Fixes #131

## Test plan
- [ ] Open a PDF, zoom in (Ctrl+=), resize the window — page should re-fit
- [ ] Zoom out, resize — same behavior
- [ ] Toggle side panel while zoomed — should still re-fit at current zoom level (existing behavior preserved)
- [ ] EPUB zoom unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)