### PR TITLE
fix: PDF theme overlay covers full content when zoomed (#135)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -118,6 +118,9 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-text-muted);
 }
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
 
 [data-tauri-drag-region] {
   cursor: default;

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -1099,27 +1099,33 @@ export default function Reader() {
       {/* Body */}
       <div
         className={`flex flex-1 ${book.format === "pdf" && zoomLevel !== 100 ? "overflow-auto" : "overflow-hidden"}`}
-        style={{ backgroundColor: book.format === "pdf" ? "#ffffff" : getThemeStyles(readerSettings.theme).body }}
+        style={{ backgroundColor: getThemeStyles(readerSettings.theme).body }}
       >
-        <div className="flex-1 flex flex-col min-w-0" style={{ backgroundColor: book.format === "pdf" ? "#ffffff" : getThemeStyles(readerSettings.theme).body }}>
+        <div className="flex-1 flex flex-col min-w-0" style={{ backgroundColor: getThemeStyles(readerSettings.theme).body }}>
           <main
             className={`flex-1 relative ${book.format === "pdf" && zoomLevel !== 100 ? "overflow-auto" : "overflow-hidden"}`}
-            style={{ backgroundColor: book.format === "pdf" ? "#ffffff" : getThemeStyles(readerSettings.theme).body }}
+            style={{ backgroundColor: getThemeStyles(readerSettings.theme).body }}
             onContextMenu={handleContextMenu}
             onClick={() => { setTocOpen(false); setSettingsOpen(false); }}
           >
             <div
               ref={viewerRef}
               className="w-full h-full"
+              style={book.format === "pdf" ? { backgroundColor: "#ffffff" } : undefined}
             />
             {book.format === "pdf" && (() => {
               const overlay = getPdfOverlays(readerSettings.theme);
               if (!overlay) return null;
+              const zoomed = zoomLevel !== 100 && viewerRef.current;
+              const overlayStyle = zoomed ? {
+                width: viewerRef.current!.style.width || "100%",
+                height: viewerRef.current!.style.height || "100%",
+              } : undefined;
               return overlay.layers.map((style, i) => (
                 <div
                   key={i}
-                  className="absolute inset-0 z-10 pointer-events-none"
-                  style={style}
+                  className={`z-10 pointer-events-none ${zoomed ? "absolute top-0 left-0" : "absolute inset-0"}`}
+                  style={zoomed ? { ...style, ...overlayStyle } : style}
                 />
               ));
             })()}


### PR DESCRIPTION
## Summary
- Theme overlay now sizes to match zoomed viewer dimensions instead of just the viewport
- Container backgrounds use theme color so scrollbar area matches the active theme
- Viewer keeps white background for correct multiply blend tinting
- Scrollbar corner styled transparent to avoid white square at intersection
- Fixes #135

## Test plan
- [ ] Open PDF, apply paper/quiet/dark theme, zoom in — overlay covers full content
- [ ] Scroll while zoomed — no white gaps
- [ ] Scrollbar gutter and corner match theme color
- [ ] At 100% zoom, themes still apply correctly
- [ ] EPUB theming unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)