### PR TITLE
feat: open ebook by dragging file onto dock icon (#134)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 
 use db::Db;
 use secrets::Secrets;
+#[cfg(target_os = "macos")]
+use tauri::Emitter;
 use tauri::Manager;
 
 /// The resolved local app data directory, accounting for dev-mode isolation.
@@ -145,18 +147,34 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    app.run(|app_handle, event| {
-        if let tauri::RunEvent::WindowEvent {
+    app.run(|app_handle, event| match &event {
+        #[cfg(target_os = "macos")]
+        tauri::RunEvent::Opened { urls } => {
+            // Files dropped on dock icon or opened via file association
+            let paths: Vec<String> = urls
+                .iter()
+                .filter_map(|url| url.to_file_path().ok())
+                .filter(|p: &PathBuf| {
+                    let ext = p.extension().and_then(|e| e.to_str()).unwrap_or("");
+                    ext.eq_ignore_ascii_case("epub") || ext.eq_ignore_ascii_case("pdf")
+                })
+                .filter_map(|p: PathBuf| p.to_str().map(String::from))
+                .collect();
+            if !paths.is_empty() {
+                let _ = app_handle.emit("file-open", paths);
+            }
+        }
+        tauri::RunEvent::WindowEvent {
             label,
             event: tauri::WindowEvent::Destroyed,
             ..
-        } = &event
-        {
+        } => {
             if label == "main" {
                 for (_, window) in app_handle.webview_windows() {
                     let _ = window.close();
                 }
             }
         }
+        _ => {}
     });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,6 +46,18 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "fileAssociations": [
+      {
+        "ext": ["epub"],
+        "mimeType": "application/epub+zip",
+        "description": "EPUB Ebook"
+      },
+      {
+        "ext": ["pdf"],
+        "mimeType": "application/pdf",
+        "description": "PDF Document"
+      }
+    ],
     "macOS": {
       "signingIdentity": null,
       "entitlements": "Entitlements.plist",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Search, LayoutGrid, List, Plus, Upload, BookOpen, Loader } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import Sidebar from "../components/Sidebar";
 import BookGrid from "../components/BookGrid";
@@ -149,6 +150,42 @@ export default function Home() {
       cancelled = true;
       unlisten.then((fn) => fn());
     };
+  }, []);
+
+  // Listen for files opened via dock icon drop or file association
+  useEffect(() => {
+    const unlisten = listen<string[]>("file-open", async (event) => {
+      const paths = event.payload;
+      if (paths.length === 0) return;
+      setImporting(true);
+      try {
+        for (const filePath of paths) {
+          try {
+            if (filePath.toLowerCase().endsWith(".pdf")) {
+              const { extractPdfMetadata } = await import("../utils/pdfMetadata");
+              const meta = await extractPdfMetadata(filePath);
+              await invoke<Book>("import_pdf", {
+                sourcePath: filePath,
+                title: meta.title,
+                author: meta.author,
+                description: meta.description,
+                pages: meta.pages,
+                coverData: meta.coverData ? Array.from(meta.coverData) : null,
+              });
+            } else {
+              await invoke<Book>("import_book", { filePath });
+            }
+          } catch (err) {
+            console.error("Failed to import file-open book:", err);
+          }
+        }
+        refreshRef.current();
+        allBooksRefreshRef.current();
+      } finally {
+        setImporting(false);
+      }
+    });
+    return () => { unlisten.then((fn) => fn()); };
   }, []);
 
   const displayBooks = isCollectionFilter


### PR DESCRIPTION
## Summary
- Register `.epub` and `.pdf` file associations in `tauri.conf.json`
- Handle `RunEvent::Opened` in Rust to emit `file-open` event to frontend
- Frontend listens for `file-open` and imports using existing drag-drop flow
- Closes #134

## Test plan
- [ ] Debug build, drag `.epub` onto dock icon — book imports
- [ ] Drag `.pdf` onto dock icon — book imports
- [ ] Drag non-ebook file — ignored
- [ ] Existing drag-into-library still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)