### PR TITLE
fix: apply reader theme to EPUB content on first open

### DIFF
--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -638,7 +638,9 @@ export default function Reader() {
       viewerRef.current.style.filter = `brightness(${readerSettings.brightness / 100})`;
     }
     // PDF theming is handled by the overlay div in the JSX
-  }, [readerSettings, book?.format]);
+    // bookReady is in deps so this re-runs once foliate finishes init —
+    // fixes a race where DB-loaded settings arrive before view.renderer exists.
+  }, [readerSettings, book?.format, bookReady]);
 
   // Prepare renderer for GPU-accelerated zoom transforms
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Fixes #143 — on first cold-launch into a book, the saved sepia (or any non-default) theme was applied to the chrome but not to the foliate-js iframe content.
- Root cause was a race in `src/pages/Reader.tsx`: the foliate-init effect captured `readerSettings` in its closure as the default before the DB-loaded value arrived, and the reactive style-apply effect bailed when `view.renderer` was still undefined — leaving the iframe stuck with default styles.
- Adds `bookReady` to the reactive effect's deps so it re-runs once foliate finishes initializing and applies the now-current settings.

## Test plan

- [ ] Set reader theme to Sepia, quit the app
- [ ] Cold-launch and open a book — content should render in sepia immediately, no toggling required
- [ ] Repeat with Gray and Dark themes
- [ ] Toggling themes mid-session still works (no regression in the reactive effect)
- [ ] Font / line spacing / margins / brightness still apply correctly on first open

🤖 Generated with [Claude Code](https://claude.com/claude-code)