### PR TITLE
perf: faster cold start + hide library on close

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quill",
   "private": true,
-  "version": "0.9.5",
+  "version": "0.9.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "0.9.5"
+version = "0.9.6"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,0 +1,20 @@
+use tauri::{AppHandle, Manager};
+
+use crate::error::{AppError, AppResult};
+
+/// Called by the frontend after React has mounted and painted its first frame.
+/// Shows the main window — the window starts hidden so the user sees the dock
+/// bounce → fully-rendered window instead of a beach ball over a blank webview.
+#[tauri::command]
+pub fn app_ready(app: AppHandle) -> AppResult<()> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| AppError::Other("main window not found".into()))?;
+    window
+        .show()
+        .map_err(|e| AppError::Other(e.to_string()))?;
+    window
+        .set_focus()
+        .map_err(|e| AppError::Other(e.to_string()))?;
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod ai;
+pub mod app;
 pub mod bookmarks;
 pub mod books;
 pub mod chats;

--- a/src-tauri/src/icloud.rs
+++ b/src-tauri/src/icloud.rs
@@ -34,6 +34,36 @@ pub fn icloud_data_dir() -> Option<PathBuf> {
     get_icloud_container_url().map(|p| p.join("Documents"))
 }
 
+/// Returns the iCloud Documents directory using a hardcoded path derived from
+/// the container identifier — does NOT call `URLForUbiquityContainerIdentifier`,
+/// which is the slowest call on cold start (queries the iCloud daemon).
+///
+/// The path layout is deterministic: `~/Library/Mobile Documents/<container>/Documents`,
+/// where `<container>` is the identifier with dots replaced by tildes.
+///
+/// Returns `None` if `$HOME` is unset or the directory doesn't exist on disk
+/// (e.g. user signed out of iCloud since enabling sync). Callers should fall
+/// back to the local directory in that case.
+#[cfg(target_os = "macos")]
+pub fn icloud_data_dir_fast() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let folder_name = ICLOUD_CONTAINER_ID.replace('.', "~");
+    let path = PathBuf::from(home)
+        .join("Library/Mobile Documents")
+        .join(folder_name)
+        .join("Documents");
+    if path.is_dir() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn icloud_data_dir_fast() -> Option<PathBuf> {
+    None
+}
+
 /// Check if iCloud sync is enabled by looking for the marker file in the local app dir.
 pub fn is_icloud_enabled(local_dir: &Path) -> bool {
     local_dir.join(MARKER_FILE).exists()
@@ -251,6 +281,34 @@ mod tests {
         fs::write(&placeholder, "placeholder").unwrap();
         let file = dir.path().join("book.epub");
         assert!(!is_file_downloaded(&file));
+    }
+
+    // --- icloud_data_dir_fast ---
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_icloud_data_dir_fast_path_format() {
+        // The fast path should be derived from $HOME + the container ID with
+        // dots replaced by tildes. We can't assert it returns Some without an
+        // actual iCloud directory present, but we CAN verify the derivation
+        // matches what the system NSFileManager API would produce by checking
+        // a temporary $HOME with a stub directory.
+        let tmp = TempDir::new().unwrap();
+        let stub = tmp
+            .path()
+            .join("Library/Mobile Documents/iCloud~com~wycstudios~quill/Documents");
+        fs::create_dir_all(&stub).unwrap();
+
+        // SAFETY: tests run single-threaded by default for this crate's
+        // env-mutating tests; we restore HOME after the assertion.
+        let prev = std::env::var_os("HOME");
+        std::env::set_var("HOME", tmp.path());
+        let resolved = icloud_data_dir_fast();
+        if let Some(home) = prev {
+            std::env::set_var("HOME", home);
+        }
+
+        assert_eq!(resolved, Some(stub));
     }
 
     // --- icloud_placeholder_path ---

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,26 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .on_window_event(|window, event| {
+            // On macOS, closing the main window via the red button should hide
+            // it, not quit the app — matches the standard Mac convention. The
+            // user reopens it from the dock icon (RunEvent::Reopen below) or
+            // by relaunching from Spotlight. cmd-Q still quits because that
+            // path goes through applicationShouldTerminate, not CloseRequested.
+            //
+            // Reader windows are unaffected and close normally.
+            #[cfg(target_os = "macos")]
+            if window.label() == "main" {
+                if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                    api.prevent_close();
+                    let _ = window.hide();
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = (window, event);
+            }
+        })
         .setup(|app| {
             let local_dir = {
                 let base = app
@@ -39,15 +59,18 @@ pub fn run() {
             };
             std::fs::create_dir_all(&local_dir).expect("failed to create app data dir");
 
-            // If iCloud sync is enabled and available, use the iCloud directory
+            // If iCloud sync is enabled, resolve the iCloud Documents path from
+            // the deterministic hardcoded location. This avoids calling
+            // `URLForUbiquityContainerIdentifier` on the main thread, which
+            // queries the iCloud daemon and is the slowest call on cold start
+            // (often >1s, sometimes several seconds after sleep/reboot).
+            //
+            // The actual `URLForUbiquityContainerIdentifier` call still has to
+            // happen at some point to register the container with the iCloud
+            // daemon and trigger sync — we do that in a background thread
+            // below, after setup has unblocked.
             let data_dir = if icloud::is_icloud_enabled(&local_dir) {
-                match icloud::icloud_data_dir() {
-                    Some(dir) => {
-                        let _ = icloud::ensure_downloaded(&dir);
-                        dir
-                    }
-                    None => local_dir.clone(),
-                }
+                icloud::icloud_data_dir_fast().unwrap_or_else(|| local_dir.clone())
             } else {
                 local_dir.clone()
             };
@@ -63,6 +86,21 @@ pub fn run() {
                 .migrate_from_settings(&db)
                 .expect("failed to migrate secrets");
 
+            // Establish iCloud daemon access + trigger evicted-file downloads
+            // in the background, off the main thread.
+            #[cfg(target_os = "macos")]
+            if icloud::is_icloud_enabled(&local_dir) {
+                tauri::async_runtime::spawn_blocking(|| {
+                    if let Some(icloud_dir) = icloud::icloud_data_dir() {
+                        let _ = icloud::ensure_downloaded(&icloud_dir);
+                    } else {
+                        eprintln!(
+                            "iCloud: daemon unreachable; running against the cached path. Sync will resume on next launch."
+                        );
+                    }
+                });
+            }
+
             app.manage(LocalDir(local_dir));
             app.manage(db);
             app.manage(secrets);
@@ -70,6 +108,8 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            // App lifecycle
+            commands::app::app_ready,
             // Books
             commands::books::import_book,
             commands::books::import_pdf,
@@ -164,6 +204,23 @@ pub fn run() {
                 let _ = app_handle.emit("file-open", paths);
             }
         }
+        // Dock icon click while the app is already running. If the main
+        // (library) window is hidden — including when only reader windows are
+        // visible — bring it back. The user explicitly asked for this so the
+        // library is always one dock-click away.
+        #[cfg(target_os = "macos")]
+        tauri::RunEvent::Reopen { .. } => {
+            if let Some(window) = app_handle.get_webview_window("main") {
+                if !window.is_visible().unwrap_or(true) {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            }
+        }
+        // On non-macOS, closing the main window quits the app (close-all-windows
+        // convention). On macOS the main window is hidden instead (handled above
+        // in on_window_event), so this branch is a no-op there.
+        #[cfg(not(target_os = "macos"))]
         tauri::RunEvent::WindowEvent {
             label,
             event: tauri::WindowEvent::Destroyed,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "width": 1440,
         "height": 960,
         "titleBarStyle": "Overlay",
-        "hiddenTitle": true
+        "hiddenTitle": true,
+        "visible": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quill",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "identifier": "com.wycstudios.quill",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Home from "./pages/Home";
 import Reader from "./pages/Reader";
 import { UpdateProvider } from "./contexts/UpdateContext";
 import UpdateToast from "./components/UpdateToast";
+import { reconcileLanguage } from "./i18n";
 
 const isMainWindow = getCurrentWebviewWindow().label === "main";
 
@@ -24,8 +25,25 @@ function applyTheme(theme: string) {
 export default function App() {
   useEffect(() => {
     invoke<Record<string, string>>("get_all_settings")
-      .then((settings) => applyTheme(settings.theme ?? "system"))
+      .then((settings) => {
+        const theme = settings.theme ?? "system";
+        applyTheme(theme);
+        localStorage.setItem("quill-theme", theme);
+      })
       .catch(() => applyTheme("system"));
+
+    // Reconcile the language we picked synchronously from localStorage with
+    // the persisted DB value (and persist to the DB on first launch).
+    reconcileLanguage();
+
+    // Tell the backend the UI has mounted so it can show the (currently
+    // hidden) main window. We don't wrap this in requestAnimationFrame —
+    // macOS pauses rAF for hidden windows, so the callback would never fire.
+    // useEffect runs after React commits the DOM, which is good enough; the
+    // OS composites the committed tree when window.show() is called.
+    if (isMainWindow) {
+      invoke("app_ready").catch(() => {});
+    }
 
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const handler = () => {

--- a/src/components/settings/GeneralSettings.tsx
+++ b/src/components/settings/GeneralSettings.tsx
@@ -58,6 +58,7 @@ export default function GeneralSettings({ settings, loading, save, showSavedToas
           onChange={(value) => {
             setTheme(value);
             save("theme", value);
+            localStorage.setItem("quill-theme", value);
             applyTheme(value);
             showSavedToast();
           }}

--- a/src/components/settings/LanguageSettings.tsx
+++ b/src/components/settings/LanguageSettings.tsx
@@ -33,6 +33,7 @@ export default function LanguageSettings({ settings, loading, save, showSavedToa
           onChange={(lang) => {
             setLanguage(lang);
             save("language", lang);
+            localStorage.setItem("quill-language", lang);
             i18n.changeLanguage(lang);
             showSavedToast();
           }}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -5,6 +5,7 @@ import en from "./en.json";
 import zh from "./zh.json";
 
 const SUPPORTED_LANGUAGES = ["en", "zh"];
+const CACHE_KEY = "quill-language";
 
 /**
  * Detect the system language from the browser locale.
@@ -21,31 +22,39 @@ function detectSystemLanguage(): string {
   return SUPPORTED_LANGUAGES.includes(primary) ? primary : "en";
 }
 
-/**
- * Read persisted language from the settings DB.
- * On first launch (no setting stored), detect from the OS and persist it
- * so the Rust backend (AI system prompts) can also read it.
- */
-async function getInitialLanguage(): Promise<string> {
-  try {
-    const stored = await invoke<string | null>("get_setting", { key: "language" });
-    if (stored && SUPPORTED_LANGUAGES.includes(stored)) return stored;
-
-    const detected = detectSystemLanguage();
-    await invoke("set_setting", { key: "language", value: detected }).catch(() => {});
-    return detected;
-  } catch {
-    return detectSystemLanguage();
-  }
+// Resolve initial language synchronously from localStorage cache (or OS), so
+// React can mount immediately without waiting on a Tauri IPC roundtrip.
+function initialLanguage(): string {
+  const cached = localStorage.getItem(CACHE_KEY);
+  if (cached && SUPPORTED_LANGUAGES.includes(cached)) return cached;
+  return detectSystemLanguage();
 }
 
-export const i18nReady = getInitialLanguage().then((lng) =>
-  i18n.use(initReactI18next).init({
-    resources: { en: { translation: en }, zh: { translation: zh } },
-    lng,
-    fallbackLng: "en",
-    interpolation: { escapeValue: false },
-  })
-);
+i18n.use(initReactI18next).init({
+  resources: { en: { translation: en }, zh: { translation: zh } },
+  lng: initialLanguage(),
+  fallbackLng: "en",
+  interpolation: { escapeValue: false },
+});
+
+// Reconcile with the persisted setting in the DB after mount. If the stored
+// value differs from the cache, swap languages and update the cache. On first
+// launch (no stored value), persist the detected language so the Rust backend
+// (AI system prompts) can read it too.
+export async function reconcileLanguage(): Promise<void> {
+  try {
+    const stored = await invoke<string | null>("get_setting", { key: "language" });
+    if (stored && SUPPORTED_LANGUAGES.includes(stored)) {
+      if (stored !== i18n.language) await i18n.changeLanguage(stored);
+      localStorage.setItem(CACHE_KEY, stored);
+      return;
+    }
+    const detected = detectSystemLanguage();
+    await invoke("set_setting", { key: "language", value: detected }).catch(() => {});
+    localStorage.setItem(CACHE_KEY, detected);
+  } catch {
+    // Best-effort — keep the synchronously-resolved language
+  }
+}
 
 export default i18n;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
-import { i18nReady } from "./i18n";
+import "./i18n";
 
 // Polyfill Map.getOrInsertComputed for PDF.js v5.5+ (Stage 3 proposal, not yet in WebKit)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -16,10 +16,17 @@ if (!(Map.prototype as any).getOrInsertComputed) {
   };
 }
 
-i18nReady.then(() => {
-  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  );
-});
+// Apply cached theme synchronously before React mounts so the window doesn't
+// flash light-mode on cold start. Reconciled with the DB in App.tsx.
+const cachedTheme = localStorage.getItem("quill-theme") ?? "system";
+const prefersDark =
+  cachedTheme === "dark" ||
+  (cachedTheme === "system" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches);
+if (prefersDark) document.documentElement.classList.add("dark");
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -668,6 +668,7 @@ export default function SettingsPage() {
               onChange={(lang) => {
                 setLanguage(lang);
                 save("language", lang);
+                localStorage.setItem("quill-language", lang);
                 i18n.changeLanguage(lang);
                 showSavedToast();
               }}


### PR DESCRIPTION
## Summary
Two unrelated quality-of-life fixes I bundled into one PR since they touch the same area (`lib.rs` + the app boot path).

### Faster cold start
The first launch was showing a beach ball over a blank webview for ~1-3 seconds (more if iCloud is enabled). Three fixes:

- **Hide the main window until React mounts.** `tauri.conf.json` now sets `visible: false` on the main window. New `app_ready` command shows the window from `useEffect` after React commits the DOM. The OS dock-bounces and the window appears already-rendered.
- **Cache theme + language in `localStorage`** and apply them synchronously in `main.tsx` / `i18n/index.ts` before React mounts. No more light-mode flash on cold start, and React no longer waits on a `get_setting("language")` IPC roundtrip before rendering.
- **Move `URLForUbiquityContainerIdentifier` off the main thread.** The iCloud Documents path is deterministic (`~/Library/Mobile Documents/iCloud~com~wycstudios~quill/Documents`), so we open the DB from a hardcoded fast path and let the iCloud daemon registration + evicted-file downloads run in a background `spawn_blocking` task. This was the single slowest call on cold start for iCloud users.

### Hide library on close (macOS)
Closing the library window via the red button used to quit the app. Now it hides the window — the standard Mac convention. Clicking the dock icon brings the library back, even when reader windows are open. cmd-Q still quits. Win/Linux behavior is unchanged.

## Test plan
- [ ] Cold launch: window appears already rendered, no beach ball, no light-mode flash
- [ ] Close library window via red button → app stays in dock, reader windows (if any) still work
- [ ] Click dock icon while library is hidden → library reappears
- [ ] cmd-Q → app actually quits
- [ ] Language and theme switching from settings still work and persist across launches
- [ ] iCloud users: DB opens, files sync as before (background task should establish daemon access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)