### PR TITLE
fix: hide collection scrollbar + use folder icon (#160)

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: ship
+description: Commit, create PR, wait for CI, and merge
+---
+
+# Ship
+
+Commit current changes, open a PR, wait for CI to pass, then squash-merge.
+
+## Steps
+
+1. Run `git status` and `git diff --stat` to see what's changed. Run `git log --oneline -5` for commit message style.
+
+2. Draft a concise commit message based on the changes. Stage relevant files (not `.env`, credentials, etc.) and commit.
+
+3. Create a feature branch if not already on one (use a descriptive name based on the changes). Push with `-u`.
+
+4. Create a PR with `gh pr create` — short title, summary bullets, test plan.
+
+5. Wait for CI: `gh pr checks <pr-number> --watch`
+
+6. Once CI passes, merge: `gh pr merge <pr-number> --squash --delete-branch`
+
+If any step fails, stop and report the error.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Library, BookOpen, CheckCircle2, Sparkles, BookA, Plus, MessageSquare, Globe, Pencil, Trash2, GripVertical } from "lucide-react";
+import { Library, BookOpen, CheckCircle2, FolderClosed, BookA, Plus, MessageSquare, Globe, Pencil, Trash2, GripVertical } from "lucide-react";
 import Button from "./ui/Button";
 import QuillLogo from "./QuillLogo";
 import type { Book } from "../hooks/useBooks";
@@ -265,7 +265,7 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
           </form>
         )}
 
-        <div ref={collectionListRef} className="flex flex-col gap-1 overflow-y-auto min-h-0">
+        <div ref={collectionListRef} className="flex flex-col gap-1 overflow-y-auto min-h-0 scrollbar-none">
           {displayCollections.map((collection) => {
             const isActive = activeFilter === `collection:${collection.id}`;
             if (renamingId === collection.id) {
@@ -305,7 +305,7 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
                   <div data-grip className="flex items-center justify-center w-5 h-9 cursor-grab touch-none">
                     <GripVertical size={12} className="text-text-muted/40" />
                   </div>
-                  <Sparkles
+                  <FolderClosed
                     size={16}
                     className={isActive ? "text-accent-text" : "text-text-muted"}
                   />

--- a/src/index.css
+++ b/src/index.css
@@ -122,6 +122,13 @@ body {
   background: transparent;
 }
 
+.scrollbar-none {
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
 [data-tauri-drag-region] {
   cursor: default;
 }


### PR DESCRIPTION
## Summary
- Hide explicit scrollbar in sidebar collection list via `scrollbar-none` CSS utility (`scrollbar-width: none` + `::-webkit-scrollbar { display: none }`)
- Swap collection icon from `Sparkles` to `FolderClosed` for clearer visual semantics

Closes #160

## Test plan
- [ ] Collection list scrolls via trackpad/wheel/keyboard — no visible scrollbar
- [ ] Collection items show folder icon instead of sparkles
- [ ] Active collection folder icon uses accent color

🤖 Generated with [Claude Code](https://claude.com/claude-code)