### PR TITLE
fix: PDF scroll mode reflows on side panel resize (#165)

### DIFF
--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -748,10 +748,8 @@ export default function Reader() {
   // When side panel toggles while zoomed, re-fit the renderer to the new container size
   useEffect(() => {
     if (book?.format !== "pdf" || zoomLevel === 100) return;
-    // Scroll mode reflows automatically as the container resizes (rows are
-    // sized in CSS pixels at the current zoom attribute, not via CSS
-    // transforms), so the lock-and-rescale dance below would actively break
-    // it. Skip.
+    // Scroll mode reflows via its own ResizeObserver in pdf-scroll.js,
+    // so the lock-and-rescale dance below is not needed. Skip.
     if (readerSettings.readingMode === "scrolling") return;
     const view = viewRef.current;
     const viewer = viewerRef.current;


### PR DESCRIPTION
## Summary
- Add debounced `ResizeObserver` to `pdf-scroll.js` so pages re-layout when the container resizes (side panel open/close/drag)
- Respects `resize-dragging` attribute to skip re-layout during active panel drag
- Matches the existing working pattern in `paginator.js`
- Updated comment in `Reader.tsx` to reflect the new behavior

Closes #165

## Test plan
- [ ] Open a PDF in scroll mode → open AI panel → pages reflow to fit narrower width
- [ ] Close the panel → pages expand back to full width
- [ ] Drag the panel resize handle → pages reflow after drag ends
- [ ] EPUB scroll mode still works correctly (no regression)
- [ ] PDF paginated mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)