### PR TITLE
feat: add iCloud sync indicator in sidebar

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,12 +1,20 @@
 use tauri::{AppHandle, Manager};
 
+#[cfg(target_os = "macos")]
+use tauri::Emitter;
+
 use crate::error::{AppError, AppResult};
+use crate::LocalDir;
 
 /// Called by the frontend after React has mounted and painted its first frame.
 /// Shows the main window — the window starts hidden so the user sees the dock
 /// bounce → fully-rendered window instead of a beach ball over a blank webview.
+///
+/// Also kicks off background iCloud daemon registration + evicted-file downloads.
+/// We do this here (not in setup) so the frontend event listeners are already
+/// registered and can show the sync indicator.
 #[tauri::command]
-pub fn app_ready(app: AppHandle) -> AppResult<()> {
+pub fn app_ready(app: AppHandle, _local_dir: tauri::State<'_, LocalDir>) -> AppResult<()> {
     let window = app
         .get_webview_window("main")
         .ok_or_else(|| AppError::Other("main window not found".into()))?;
@@ -16,5 +24,22 @@ pub fn app_ready(app: AppHandle) -> AppResult<()> {
     window
         .set_focus()
         .map_err(|e| AppError::Other(e.to_string()))?;
+
+    #[cfg(target_os = "macos")]
+    if crate::icloud::is_icloud_enabled(&_local_dir.0) {
+        let handle = app.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+            let _ = handle.emit("icloud-sync-start", ());
+            if let Some(icloud_dir) = crate::icloud::icloud_data_dir() {
+                let _ = crate::icloud::ensure_downloaded(&icloud_dir);
+            } else {
+                eprintln!(
+                    "iCloud: daemon unreachable; running against the cached path. Sync will resume on next launch."
+                );
+            }
+            let _ = handle.emit("icloud-sync-done", ());
+        });
+    }
+
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,21 +86,6 @@ pub fn run() {
                 .migrate_from_settings(&db)
                 .expect("failed to migrate secrets");
 
-            // Establish iCloud daemon access + trigger evicted-file downloads
-            // in the background, off the main thread.
-            #[cfg(target_os = "macos")]
-            if icloud::is_icloud_enabled(&local_dir) {
-                tauri::async_runtime::spawn_blocking(|| {
-                    if let Some(icloud_dir) = icloud::icloud_data_dir() {
-                        let _ = icloud::ensure_downloaded(&icloud_dir);
-                    } else {
-                        eprintln!(
-                            "iCloud: daemon unreachable; running against the cached path. Sync will resume on next launch."
-                        );
-                    }
-                });
-            }
-
             app.manage(LocalDir(local_dir));
             app.manage(db);
             app.manage(secrets);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Library, BookOpen, CheckCircle2, FolderClosed, BookA, Plus, MessageSquare, Globe, Pencil, Trash2, GripVertical } from "lucide-react";
+import { Library, BookOpen, CheckCircle2, FolderClosed, BookA, Plus, MessageSquare, Globe, Pencil, Trash2, GripVertical, Cloud } from "lucide-react";
 import Button from "./ui/Button";
 import QuillLogo from "./QuillLogo";
 import type { Book } from "../hooks/useBooks";
@@ -19,6 +19,7 @@ interface SidebarProps {
   };
   userName?: string;
   onOpenSettings?: () => void;
+  icloudSyncing?: boolean;
 }
 
 const SIDEBAR_MIN = 180;
@@ -35,7 +36,7 @@ function getStoredWidth(): number {
   return SIDEBAR_DEFAULT;
 }
 
-export default function Sidebar({ activeFilter, onFilterChange, books, collections: collectionsHook, userName, onOpenSettings }: SidebarProps) {
+export default function Sidebar({ activeFilter, onFilterChange, books, collections: collectionsHook, userName, onOpenSettings, icloudSyncing }: SidebarProps) {
   const { t } = useTranslation();
   const [sidebarWidth, setSidebarWidth] = useState(getStoredWidth);
   const resizingRef = useRef(false);
@@ -178,6 +179,11 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
         <span className="text-[18px] font-semibold tracking-[0.5px] text-text-primary" style={{ fontFamily: "Georgia, 'Times New Roman', serif" }}>
           Quill
         </span>
+        {icloudSyncing && (
+          <span title={t("sidebar.icloudSyncing")} className="ml-auto shrink-0">
+            <Cloud size={14} className="text-text-muted animate-pulse" />
+          </span>
+        )}
       </div>
 
       <div className="flex flex-col gap-3">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -11,6 +11,7 @@
   "sidebar.collectionPlaceholder": "Collection name...",
   "sidebar.renameCollection": "Rename",
   "sidebar.deleteCollection": "Delete",
+  "sidebar.icloudSyncing": "Syncing with iCloud…",
 
   "home.title.all": "All Books",
   "home.title.reading": "Currently Reading",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -11,6 +11,7 @@
   "sidebar.collectionPlaceholder": "书单名称...",
   "sidebar.renameCollection": "重命名",
   "sidebar.deleteCollection": "删除",
+  "sidebar.icloudSyncing": "正在与 iCloud 同步…",
 
   "home.title.all": "全部书籍",
   "home.title.reading": "正在阅读",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,6 +23,7 @@ export default function Home() {
   const [searchQuery, setSearchQuery] = useState("");
   const [isDragging, setIsDragging] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [icloudSyncing, setIcloudSyncing] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<"general" | "reading" | "ai" | "lookup" | "icloud" | "about">("general");
   const [userName, setUserName] = useState("");
@@ -100,6 +101,20 @@ export default function Home() {
   const allBooksRefreshRef = useRef(allBooks.refresh);
   useEffect(() => { refreshRef.current = refresh; }, [refresh]);
   useEffect(() => { allBooksRefreshRef.current = allBooks.refresh; }, [allBooks.refresh]);
+
+  // iCloud background sync indicator + refresh books when sync finishes
+  useEffect(() => {
+    const unlistenStart = listen("icloud-sync-start", () => setIcloudSyncing(true));
+    const unlistenDone = listen("icloud-sync-done", () => {
+      setIcloudSyncing(false);
+      refreshRef.current();
+      allBooksRefreshRef.current();
+    });
+    return () => {
+      unlistenStart.then((fn) => fn());
+      unlistenDone.then((fn) => fn());
+    };
+  }, []);
 
   // Listen for Tauri file drag-and-drop events
   useEffect(() => {
@@ -231,6 +246,7 @@ export default function Home() {
         collections={collections}
         userName={userName}
         onOpenSettings={() => setSettingsOpen(true)}
+        icloudSyncing={icloudSyncing}
       />
 
       {activeFilter === "vocab" ? (


### PR DESCRIPTION
## Summary
- Move background iCloud daemon registration from `setup()` to `app_ready()` so frontend event listeners are active when sync events fire
- Emit `icloud-sync-start` / `icloud-sync-done` events from the background sync thread
- Show a pulsing cloud icon in the sidebar header while iCloud sync is in progress
- Auto-refresh book list when sync completes

## Test plan
- [x] Rust compiles clean, all 62 tests pass
- [x] TypeScript compiles clean
- [x] Verified indicator visually with a debug mock (5s delay) — icon pulses and disappears on completion
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)