### PR TITLE
fix: stage PDF imports into appdata to avoid silent failures

### DIFF
--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -387,9 +387,44 @@ pub fn update_book_metadata(
     Ok(())
 }
 
+#[derive(Debug, Serialize)]
+pub struct StagedPdf {
+    pub book_id: String,
+    /// Absolute path to the staged file inside `$APPDATA/books/`,
+    /// safe for the frontend to fetch via the asset protocol.
+    pub abs_path: String,
+}
+
+/// Step 1 of PDF import: copy the user-selected file into `$APPDATA/books/`
+/// under a UUID filename. Returns an absolute path the frontend can read via
+/// the asset protocol (so PDF metadata extraction never has to fetch from
+/// arbitrary user paths, which is fragile across macOS/Tauri configurations).
 #[tauri::command]
-pub async fn import_pdf(
-    source_path: String,
+pub async fn stage_pdf_import(source_path: String, db: State<'_, Db>) -> AppResult<StagedPdf> {
+    let data_dir = db
+        .data_dir
+        .lock()
+        .map_err(|e| AppError::Other(e.to_string()))?
+        .clone();
+    let books_dir = data_dir.join("books");
+    fs::create_dir_all(&books_dir)?;
+
+    let book_id = uuid::Uuid::new_v4().to_string();
+    let staged = books_dir.join(format!("{}.pdf", book_id));
+    fs::copy(std::path::Path::new(&source_path), &staged)?;
+
+    Ok(StagedPdf {
+        book_id,
+        abs_path: staged.to_string_lossy().to_string(),
+    })
+}
+
+/// Step 2 of PDF import: rename the staged file to a slugged name, write the
+/// cover, and insert the DB row. Caller must have first called
+/// `stage_pdf_import` to obtain `book_id`.
+#[tauri::command]
+pub async fn commit_pdf_import(
+    book_id: String,
     title: String,
     author: Option<String>,
     description: Option<String>,
@@ -405,16 +440,24 @@ pub async fn import_pdf(
     let books_dir = data_dir.join("books");
     let covers_dir = data_dir.join("covers");
 
-    let book_id = uuid::Uuid::new_v4().to_string();
-    let src = std::path::Path::new(&source_path);
+    let staged = books_dir.join(format!("{}.pdf", book_id));
+    if !staged.exists() {
+        return Err(AppError::Other(format!(
+            "staged PDF not found for book_id {}",
+            book_id
+        )));
+    }
 
-    // Copy PDF to app data with readable filename
+    // Rename to a human-readable filename
     let filename = book_filename(&title, &book_id, "pdf");
     let dest = books_dir.join(&filename);
-    fs::copy(src, &dest)?;
+    if dest != staged {
+        fs::rename(&staged, &dest)?;
+    }
 
     // Save cover image if provided
     let cover_path = if let Some(ref data) = cover_data {
+        fs::create_dir_all(&covers_dir)?;
         let cover_file = covers_dir.join(format!("{}.png", book_id));
         fs::write(&cover_file, data)?;
         Some(format!("covers/{}.png", book_id))
@@ -468,6 +511,20 @@ pub async fn import_pdf(
     let mut result = book;
     resolve_book_paths(&mut result, &db);
     Ok(result)
+}
+
+/// Roll back a staged PDF import by deleting the staged file. Used by the
+/// frontend when metadata extraction or commit fails.
+#[tauri::command]
+pub async fn cancel_pdf_import(book_id: String, db: State<'_, Db>) -> AppResult<()> {
+    let data_dir = db
+        .data_dir
+        .lock()
+        .map_err(|e| AppError::Other(e.to_string()))?
+        .clone();
+    let staged = data_dir.join("books").join(format!("{}.pdf", book_id));
+    let _ = fs::remove_file(&staged);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,7 +97,9 @@ pub fn run() {
             commands::app::app_ready,
             // Books
             commands::books::import_book,
-            commands::books::import_pdf,
+            commands::books::stage_pdf_import,
+            commands::books::commit_pdf_import,
+            commands::books::cancel_pdf_import,
             commands::books::list_books,
             commands::books::get_book,
             commands::books::delete_book,

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -54,20 +54,35 @@ async function pickFile(): Promise<string | null> {
 }
 
 async function importFile(filePath: string): Promise<Book> {
-  if (filePath.toLowerCase().endsWith(".pdf")) {
+  if (!filePath.toLowerCase().endsWith(".pdf")) {
+    return invoke<Book>("import_book", { filePath });
+  }
+
+  // PDF: stage → extract metadata from the staged copy → commit.
+  // Staging into $APPDATA/books/ avoids fetching arbitrary user paths via
+  // the asset protocol, which can fail on some Macs (TCC, scope, encoding).
+  const staged = await invoke<{ book_id: string; abs_path: string }>("stage_pdf_import", {
+    sourcePath: filePath,
+  });
+  try {
     const { extractPdfMetadata } = await import("../utils/pdfMetadata");
-    const meta = await extractPdfMetadata(filePath);
-    return invoke<Book>("import_pdf", {
-      sourcePath: filePath,
+    const meta = await extractPdfMetadata(staged.abs_path);
+    return await invoke<Book>("commit_pdf_import", {
+      bookId: staged.book_id,
       title: meta.title,
       author: meta.author,
       description: meta.description,
       pages: meta.pages,
       coverData: meta.coverData ? Array.from(meta.coverData) : null,
     });
+  } catch (err) {
+    try {
+      await invoke("cancel_pdf_import", { bookId: staged.book_id });
+    } catch {
+      // Ignore rollback failure — original error is more useful
+    }
+    throw err;
   }
-
-  return invoke<Book>("import_book", { filePath });
 }
 
 export const importBookDialog = { pickFile, importFile };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -28,6 +28,7 @@
   "home.dropOverlay": "Drop to add to your library",
   "home.dropFormats": "EPUB & PDF",
   "home.importing": "Importing book...",
+  "home.importError": "Couldn't import book",
 
   "reader.pageOf": "Page {{current}} of {{total}}",
   "reader.chapterOf": "Chapter {{current}} of {{total}}",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -28,6 +28,7 @@
   "home.dropOverlay": "松开以添加到书库",
   "home.dropFormats": "EPUB & PDF",
   "home.importing": "正在导入书籍...",
+  "home.importError": "无法导入书籍",
 
   "reader.pageOf": "第 {{current}} 页，共 {{total}} 页",
   "reader.chapterOf": "第 {{current}} 章，共 {{total}} 章",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Search, LayoutGrid, List, Plus, Upload, BookOpen, Loader } from "lucide-react";
+import { Search, LayoutGrid, List, Plus, Upload, BookOpen, Loader, AlertCircle, X } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -13,8 +13,18 @@ import TranslationsContent from "../components/TranslationsContent";
 import SettingsModal from "../components/SettingsModal";
 import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
-import { useBooks, importBookDialog, type Book } from "../hooks/useBooks";
+import { useBooks, importBookDialog } from "../hooks/useBooks";
 import { useCollections } from "../hooks/useCollections";
+
+function formatError(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
 
 export default function Home() {
   const { t } = useTranslation();
@@ -23,6 +33,7 @@ export default function Home() {
   const [searchQuery, setSearchQuery] = useState("");
   const [isDragging, setIsDragging] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
   const [icloudSyncing, setIcloudSyncing] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<"general" | "reading" | "ai" | "lookup" | "icloud" | "about">("general");
@@ -102,6 +113,13 @@ export default function Home() {
   useEffect(() => { refreshRef.current = refresh; }, [refresh]);
   useEffect(() => { allBooksRefreshRef.current = allBooks.refresh; }, [allBooks.refresh]);
 
+  // Auto-dismiss import error after 10s
+  useEffect(() => {
+    if (!importError) return;
+    const timer = setTimeout(() => setImportError(null), 10000);
+    return () => clearTimeout(timer);
+  }, [importError]);
+
   // iCloud background sync indicator + refresh books when sync finishes
   useEffect(() => {
     const unlistenStart = listen("icloud-sync-start", () => setIcloudSyncing(true));
@@ -133,22 +151,10 @@ export default function Home() {
           try {
             for (const filePath of books) {
               try {
-                if (filePath.toLowerCase().endsWith(".pdf")) {
-                  const { extractPdfMetadata } = await import("../utils/pdfMetadata");
-                  const meta = await extractPdfMetadata(filePath);
-                  await invoke<Book>("import_pdf", {
-                    sourcePath: filePath,
-                    title: meta.title,
-                    author: meta.author,
-                    description: meta.description,
-                    pages: meta.pages,
-                    coverData: meta.coverData ? Array.from(meta.coverData) : null,
-                  });
-                } else {
-                  await invoke<Book>("import_book", { filePath });
-                }
+                await importBookDialog.importFile(filePath);
               } catch (err) {
                 console.error("Failed to import dropped book:", err);
+                setImportError(`${filePath.split("/").pop()}: ${formatError(err)}`);
               }
             }
             refreshRef.current();
@@ -176,22 +182,10 @@ export default function Home() {
       try {
         for (const filePath of paths) {
           try {
-            if (filePath.toLowerCase().endsWith(".pdf")) {
-              const { extractPdfMetadata } = await import("../utils/pdfMetadata");
-              const meta = await extractPdfMetadata(filePath);
-              await invoke<Book>("import_pdf", {
-                sourcePath: filePath,
-                title: meta.title,
-                author: meta.author,
-                description: meta.description,
-                pages: meta.pages,
-                coverData: meta.coverData ? Array.from(meta.coverData) : null,
-              });
-            } else {
-              await invoke<Book>("import_book", { filePath });
-            }
+            await importBookDialog.importFile(filePath);
           } catch (err) {
             console.error("Failed to import file-open book:", err);
+            setImportError(`${filePath.split("/").pop()}: ${formatError(err)}`);
           }
         }
         refreshRef.current();
@@ -208,8 +202,9 @@ export default function Home() {
     : books;
 
   const handleImport = async () => {
+    let selected: string | null = null;
     try {
-      const selected = await importBookDialog.pickFile();
+      selected = await importBookDialog.pickFile();
       if (!selected) return;
       setImporting(true);
       try {
@@ -223,6 +218,8 @@ export default function Home() {
       }
     } catch (err) {
       console.error("Failed to import book:", err);
+      const name = selected ? selected.split("/").pop() : null;
+      setImportError(name ? `${name}: ${formatError(err)}` : formatError(err));
     }
   };
 
@@ -352,6 +349,26 @@ export default function Home() {
               {t("home.importing")}
             </p>
           </div>
+        </div>
+      )}
+
+      {importError && (
+        <div className="fixed top-5 left-1/2 -translate-x-1/2 z-[60] max-w-[600px] bg-white dark:bg-bg-surface border border-border rounded-[14px] shadow-popover flex items-start gap-3 pl-4 pr-3 py-3">
+          <AlertCircle size={16} className="shrink-0 mt-0.5 text-red-500" />
+          <div className="flex-1 min-w-0">
+            <p className="text-[13px] font-medium text-text-primary tracking-[-0.08px]">
+              {t("home.importError")}
+            </p>
+            <p className="text-[12px] text-text-secondary mt-0.5 break-words">
+              {importError}
+            </p>
+          </div>
+          <button
+            onClick={() => setImportError(null)}
+            className="shrink-0 size-6 flex items-center justify-center rounded-lg hover:bg-bg-input cursor-pointer transition-colors"
+          >
+            <X size={14} className="text-text-muted" />
+          </button>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Split PDF import into `stage_pdf_import` → metadata extraction → `commit_pdf_import` (with `cancel_pdf_import` rollback). The frontend now reads PDFs via the asset protocol from `$APPDATA/books/<uuid>.pdf` instead of arbitrary user paths, avoiding TCC / scope / encoding / iCloud-placeholder failures observed on a friend's Mac.
- Surface import errors in the UI: a top-of-screen toast in `Home` shows the failing filename + error message instead of swallowing it to `console.error`.
- Refactor `Home.tsx` drag-drop and file-open handlers to share `importBookDialog.importFile` — single source of truth for all three import paths.

## Test plan
- [x] `cargo test` (62 passing)
- [x] `tsc --noEmit` clean
- [ ] Manually import an EPUB via picker, drag-drop, and "open with"
- [ ] Manually import a PDF via picker, drag-drop, and "open with"
- [ ] Verify error toast appears (e.g. import a corrupt or non-existent PDF)
- [ ] Verify staged file is cleaned up on metadata extraction failure (no orphan in `$APPDATA/books/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)