### PR TITLE
fix: PDF import fallback + diagnostic instrumentation

### DIFF
--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -53,7 +53,10 @@ async function pickFile(): Promise<string | null> {
   });
 }
 
-async function importFile(filePath: string): Promise<Book> {
+async function importFile(
+  filePath: string,
+  onMetadataWarning?: (warning: string) => void,
+): Promise<Book> {
   if (!filePath.toLowerCase().endsWith(".pdf")) {
     return invoke<Book>("import_book", { filePath });
   }
@@ -65,8 +68,26 @@ async function importFile(filePath: string): Promise<Book> {
     sourcePath: filePath,
   });
   try {
-    const { extractPdfMetadata } = await import("../utils/pdfMetadata");
-    const meta = await extractPdfMetadata(staged.abs_path);
+    const { extractPdfMetadata, filenameToTitle } = await import("../utils/pdfMetadata");
+    let meta;
+    try {
+      meta = await extractPdfMetadata(staged.abs_path);
+    } catch (err) {
+      // Metadata extraction failed (PDF.js error, missing CMaps, malformed
+      // PDF, etc.). Don't block the import — fall back to filename-based
+      // metadata so the user still gets their book. Surface the diagnostic
+      // via onMetadataWarning so we can debug what actually broke.
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("PDF metadata extraction failed, importing with filename only:", err);
+      onMetadataWarning?.(message);
+      meta = {
+        title: filenameToTitle(filePath),
+        author: null,
+        description: null,
+        pages: 0,
+        coverData: null as Uint8Array | null,
+      };
+    }
     return await invoke<Book>("commit_pdf_import", {
       bookId: staged.book_id,
       title: meta.title,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -29,6 +29,7 @@
   "home.dropFormats": "EPUB & PDF",
   "home.importing": "Importing book...",
   "home.importError": "Couldn't import book",
+  "home.importWarning": "Imported with limited metadata",
 
   "reader.pageOf": "Page {{current}} of {{total}}",
   "reader.chapterOf": "Chapter {{current}} of {{total}}",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -29,6 +29,7 @@
   "home.dropFormats": "EPUB & PDF",
   "home.importing": "正在导入书籍...",
   "home.importError": "无法导入书籍",
+  "home.importWarning": "已导入，但元数据不完整",
 
   "reader.pageOf": "第 {{current}} 页，共 {{total}} 页",
   "reader.chapterOf": "第 {{current}} 章，共 {{total}} 章",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Search, LayoutGrid, List, Plus, Upload, BookOpen, Loader, AlertCircle, X } from "lucide-react";
+import { Search, LayoutGrid, List, Plus, Upload, BookOpen, Loader, AlertCircle, AlertTriangle, X } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -34,6 +34,7 @@ export default function Home() {
   const [isDragging, setIsDragging] = useState(false);
   const [importing, setImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
+  const [importWarning, setImportWarning] = useState<string | null>(null);
   const [icloudSyncing, setIcloudSyncing] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<"general" | "reading" | "ai" | "lookup" | "icloud" | "about">("general");
@@ -151,7 +152,7 @@ export default function Home() {
           try {
             for (const filePath of books) {
               try {
-                await importBookDialog.importFile(filePath);
+                await importBookDialog.importFile(filePath, setImportWarning);
               } catch (err) {
                 console.error("Failed to import dropped book:", err);
                 setImportError(`${filePath.split("/").pop()}: ${formatError(err)}`);
@@ -208,7 +209,7 @@ export default function Home() {
       if (!selected) return;
       setImporting(true);
       try {
-        const book = await importBookDialog.importFile(selected);
+        const book = await importBookDialog.importFile(selected, setImportWarning);
         if (book) {
           refresh();
           allBooks.refresh();
@@ -365,6 +366,26 @@ export default function Home() {
           </div>
           <button
             onClick={() => setImportError(null)}
+            className="shrink-0 size-6 flex items-center justify-center rounded-lg hover:bg-bg-input cursor-pointer transition-colors"
+          >
+            <X size={14} className="text-text-muted" />
+          </button>
+        </div>
+      )}
+
+      {importWarning && (
+        <div className="fixed top-20 left-1/2 -translate-x-1/2 z-[60] max-w-[600px] bg-white dark:bg-bg-surface border border-border rounded-[14px] shadow-popover flex items-start gap-3 pl-4 pr-3 py-3">
+          <AlertTriangle size={16} className="shrink-0 mt-0.5 text-amber-500" />
+          <div className="flex-1 min-w-0">
+            <p className="text-[13px] font-medium text-text-primary tracking-[-0.08px]">
+              {t("home.importWarning")}
+            </p>
+            <p className="text-[12px] text-text-secondary mt-0.5 break-words">
+              {importWarning}
+            </p>
+          </div>
+          <button
+            onClick={() => setImportWarning(null)}
             className="shrink-0 size-6 flex items-center justify-center rounded-lg hover:bg-bg-input cursor-pointer transition-colors"
           >
             <X size={14} className="text-text-muted" />

--- a/src/utils/pdfMetadata.ts
+++ b/src/utils/pdfMetadata.ts
@@ -1,6 +1,6 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
 
-interface PdfMetadata {
+export interface PdfMetadata {
   title: string;
   author: string | null;
   description: string | null;
@@ -8,48 +8,84 @@ interface PdfMetadata {
   coverData: Uint8Array | null;
 }
 
-/** Extract metadata from a PDF file using foliate-js. */
+/**
+ * Extract metadata from a PDF file using foliate-js.
+ *
+ * Each step is labeled so a thrown error names the exact failing step —
+ * Safari/JavaScriptCore's "undefined is not a function (near '...}...')"
+ * is otherwise impossible to localize without a stack trace.
+ */
 export async function extractPdfMetadata(filePath: string): Promise<PdfMetadata> {
-  // Fetch the PDF file via Tauri's asset protocol
-  const url = convertFileSrc(filePath);
-  const response = await fetch(url);
-  const blob = new File([await response.blob()], "book.pdf");
-
-  // Use foliate-js makeBook to parse the PDF
-  // Dynamic import via URL to bypass Vite's static analysis of /public files
-  const viewModule = await import(/* @vite-ignore */ new URL("/foliate-js/view.js", window.location.origin).href)
-  const makeBook = viewModule.makeBook;
-  const book = await makeBook(blob);
-
-  // Extract metadata — PDF.js may return arrays for multi-valued fields
-  const meta = book.metadata || {};
-  const title = flatten(meta.title) || filenameToTitle(filePath);
-  const author = flatten(meta.author) || null;
-  const description = flatten(meta.description) || null;
-  const pages = book.sections?.length || 0;
-
-  // Extract cover (first page rendered as thumbnail)
-  let coverData: Uint8Array | null = null;
+  let step = "init";
   try {
-    if (book.getCover) {
-      const coverBlob: Blob = await book.getCover();
-      if (coverBlob) {
-        const buffer = await coverBlob.arrayBuffer();
-        coverData = new Uint8Array(buffer);
-      }
+    step = "convertFileSrc";
+    const url = convertFileSrc(filePath);
+
+    step = "fetch staged file";
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`fetch returned ${response.status} ${response.statusText}`);
     }
-  } catch {
-    // Cover extraction failed — not critical
-  }
 
-  // Clean up PDF.js resources
-  try {
-    book.destroy?.();
-  } catch {
-    // Ignore cleanup errors
-  }
+    step = "blob → File";
+    const blob = new File([await response.blob()], "book.pdf");
 
-  return { title, author, description, pages, coverData };
+    step = "dynamic import view.js";
+    const viewModule = await import(
+      /* @vite-ignore */ new URL("/foliate-js/view.js", window.location.origin).href
+    );
+
+    step = "viewModule.makeBook lookup";
+    if (typeof viewModule.makeBook !== "function") {
+      throw new Error(
+        `viewModule.makeBook is ${typeof viewModule.makeBook}; exports: [${Object.keys(viewModule).join(", ")}]`
+      );
+    }
+    const makeBook = viewModule.makeBook;
+
+    step = "makeBook(blob)";
+    const book = await makeBook(blob);
+    if (!book) {
+      throw new Error(`makeBook returned ${book}`);
+    }
+
+    step = "read metadata";
+    const meta = book.metadata || {};
+    const title = flatten(meta.title) || filenameToTitle(filePath);
+    const author = flatten(meta.author) || null;
+    const description = flatten(meta.description) || null;
+    const pages = book.sections?.length || 0;
+
+    step = "getCover";
+    let coverData: Uint8Array | null = null;
+    try {
+      if (typeof book.getCover === "function") {
+        const coverBlob: Blob = await book.getCover();
+        if (coverBlob) {
+          const buffer = await coverBlob.arrayBuffer();
+          coverData = new Uint8Array(buffer);
+        }
+      }
+    } catch {
+      // Cover extraction failed — not critical, continue without one
+    }
+
+    step = "destroy";
+    try {
+      book.destroy?.();
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    return { title, author, description, pages, coverData };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const wrapped = new Error(`PDF metadata failed at "${step}": ${message}`);
+    if (err instanceof Error && err.stack) {
+      wrapped.stack = err.stack;
+    }
+    throw wrapped;
+  }
 }
 
 /** Flatten a value that may be a string, array, or null into a single string. */
@@ -61,7 +97,7 @@ function flatten(value: unknown): string | null {
 }
 
 /** Derive a title from a filename: strip extension, replace separators, title-case. */
-function filenameToTitle(filePath: string): string {
+export function filenameToTitle(filePath: string): string {
   const name = filePath.split("/").pop()?.split("\\").pop() || "Untitled";
   return name
     .replace(/\.pdf$/i, "")


### PR DESCRIPTION
## Summary
- Diagnostic: instrument every step of \`extractPdfMetadata\` so a thrown error names the failing step (\`PDF metadata failed at \"makeBook(blob)\": ...\`). Safari/JavaScriptCore's \`undefined is not a function (near '...}...')\` was impossible to localize otherwise.
- Fallback: if metadata extraction throws, the import no longer fails — falls back to filename-as-title with \`pages: 0\` and no cover, then commits. The user gets their book.
- New amber warning toast (separate from the red error toast, no auto-dismiss) surfaces the diagnostic without blocking the import. Users can screenshot the exact failing step.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Manually import a working PDF — should succeed silently, no warning toast
- [ ] Manually import an EPUB — unchanged behavior
- [ ] Force a metadata failure (rename a non-PDF to .pdf) and verify the warning toast appears with a labeled step
- [ ] Verify warning toast doesn't auto-dismiss; X button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)