### PR TITLE
fix: require macOS 14.4+ for PDF import with clear error

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Grab the latest `.dmg` from the [Releases](https://github.com/yicheng47/quill/re
 
 Open the `.dmg` and drag **Quill.app** to your Applications folder.
 
+**Requirements:** macOS 14.4 (Sonoma) or later for PDF support. EPUB files work on earlier versions.
+
 ## AI Setup
 
 Quill supports multiple AI providers. Configure in Settings:

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -61,6 +61,16 @@ async function importFile(
     return invoke<Book>("import_book", { filePath });
   }
 
+  // PDF.js uses Promise.withResolvers() everywhere internally. That API
+  // shipped in Safari 17.4 / macOS Sonoma 14.4; older systems can't load
+  // PDF.js at all. Fail fast with a clear message instead of letting it
+  // explode deep inside pdf.mjs with "undefined is not a function".
+  if (typeof (Promise as unknown as { withResolvers?: unknown }).withResolvers !== "function") {
+    throw new Error(
+      "PDF support requires macOS 14.4 (Sonoma) or later. Please update macOS to import PDFs. EPUB files work on older systems.",
+    );
+  }
+
   // PDF: stage → extract metadata from the staged copy → commit.
   // Staging into $APPDATA/books/ avoids fetching arbitrary user paths via
   // the asset protocol, which can fail on some Macs (TCC, scope, encoding).


### PR DESCRIPTION
## Summary
Root cause confirmed: PDF.js v5 (bundled via foliate-js) uses \`Promise.withResolvers()\` — added in Safari 17.4 / macOS Sonoma 14.4. Her MacBook Air is on 14.2, so PDF.js's \`PDFDocumentLoadingTask\` constructor throws at its first class-field initializer. Same binary works on 14.4+.

Rather than patching vendored PDF.js with a polyfill (messy submodule change, 26 + 14 usages to maintain), feature-detect \`Promise.withResolvers\` upfront in \`importFile\` and throw a clear, actionable error. EPUB path unaffected — those still work on older systems.

## Changes
- \`useBooks.ts\`: feature-detect before any PDF staging; throw "PDF support requires macOS 14.4 (Sonoma) or later. EPUB files work on older systems." This hits the red error toast, avoids orphan staged files.
- \`README.md\`: add a **Requirements** line under Download.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] On 14.4+: PDFs import normally
- [ ] On < 14.4: PDF import shows clear error; EPUB import still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)