### PR TITLE
chore: bump version to v0.9.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quill",
   "private": true,
-  "version": "0.9.13",
+  "version": "0.9.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "0.9.13"
+version = "0.9.14"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quill",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "identifier": "com.wycstudios.quill",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bump version to v0.9.14 across package.json, tauri.conf.json, Cargo.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)