### PR TITLE
refactor: normalize DB timestamps to int64 unix millis

### DIFF
--- a/docs/impls/31-sync.md
+++ b/docs/impls/31-sync.md
@@ -6,11 +6,14 @@
 
 ## Context
 
-Replace today's "SQLite file in iCloud ubiquity container" sync with a per-device append-only event log stored in a user-chosen shared folder. Local `quill.db` becomes a materialized view, rebuildable from merged peer logs. No backend, no CloudKit, no file-level conflicts.
+Replace today's "SQLite file in iCloud ubiquity container" sync with a per-device append-only event log stored in the same iCloud ubiquity container (BYOC deferred to a later release — see v1 scope below). Local `quill.db` becomes a materialized view, rebuildable from merged peer logs. No backend, no CloudKit, no file-level conflicts.
 
 This rewrites the write path. Every mutation becomes `SQL write + event append` in one transaction. Reads are unchanged — still pure SQLite.
 
-**First shipping version:** migrate iCloud-on users directly (no dual-write phase — pre-1.0). iCloud-off users are unaffected until they enable sync. BYOC (custom folder) is a later phase.
+**First shipping version (v1):**
+- **iCloud-only.** The `<shared-folder>` is always the existing iCloud ubiquity container (`iCloud~com~wycstudios~quill/Documents`). No folder picker, no backend enum. BYOC (custom folder) is a later release, landing alongside the next cloud provider.
+- **Same UX as today.** Settings shows a single "Sync with iCloud" Toggle — identical surface to the current `ICloudSettings.tsx`. Users shouldn't notice a UI-level change; the engine underneath is what's new.
+- **No dual-write phase** — pre-1.0, so we migrate iCloud-on users directly on first launch. iCloud-off users are unaffected until they enable sync.
 
 ---
 
@@ -19,7 +22,7 @@ This rewrites the write path. Every mutation becomes `SQL write + event append` 
 ### File layout
 
 ```
-<shared-folder>/                       # iCloud Documents, or user-chosen dir
+<shared-folder>/                       # iCloud Documents container (v1); any user-chosen dir in a future release
   logs/
     <device-uuid>.jsonl                # append-only; this device writes only here
     <device-uuid>.snapshot.json        # latest compaction/migration snapshot
@@ -37,13 +40,13 @@ This rewrites the write path. Every mutation becomes `SQL write + event append` 
 ### Event format
 
 ```jsonc
-{"id":"01HV2X9KQRPTZC8F9EKH2MBAAT","ts":"2026-04-14T12:34:56.789Z","device":"7b6f...","v":1,"type":"highlight.add","payload":{"id":"h1","book":"b1","cfi":"...","color":"yellow"}}
+{"id":"01HV2X9KQRPTZC8F9EKH2MBAAT","ts":1776429296789,"device":"7b6f...","v":1,"type":"highlight.add","payload":{"id":"h1","book":"b1","cfi":"...","color":"yellow"}}
 ```
 
 | Field | Type | Details |
 |---|---|---|
 | `id` | string, 26 chars | ULID — see below |
-| `ts` | string | ISO-8601 UTC with millisecond precision and trailing `Z`, e.g. `2026-04-14T12:34:56.789Z`. Produced by `chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)`. |
+| `ts` | i64 (JSON number) | Unix time in **milliseconds** since epoch, UTC. Produced by `chrono::Utc::now().timestamp_millis()`. Fits comfortably in JS `number` — `Date.now()` returns exactly this shape; the JS safe-integer limit (2⁵³) holds another ~285,000 years of headroom over current unix millis (~1.78 × 10¹²). Aligns with the 48-bit millis embedded in the ULID. |
 | `device` | string | UUIDv4 of the originating device, as 36-char hyphenated form (e.g. `7b6f4c3a-1e2d-4f5b-8a9c-0d1e2f3a4b5c`) |
 | `v` | u32 | Event schema version. Starts at `1`. Bumped on any breaking payload change. |
 | `type` | string | Dotted event type from the catalog — see spec §Event catalog & merge rules |
@@ -51,7 +54,7 @@ This rewrites the write path. Every mutation becomes `SQL write + event append` 
 
 Wire encoding: one event per line, UTF-8, no BOM, trailing `\n` after every line including the last. Pretty-printing is forbidden — each event must be exactly one line. Unknown fields on read are preserved via `#[serde(flatten)]` on an `extra: serde_json::Map<String, Value>` field, so a newer peer's additions survive a round trip through an older reader.
 
-Total order across peers: sort ascending by the pair `(ts, device)`, where `device` is the UUID string (arbitrary but deterministic tiebreak). The `id` is NOT used for cross-device ordering — only for per-device watermarks.
+Total order across peers: sort ascending by the pair `(ts, device)`, where `device` is the UUID string (arbitrary but deterministic tiebreak). The `id` is NOT used for cross-device ordering — only for per-device watermarks. Because `ts` is an integer, the merge engine's LWW comparisons are native integer compares — no string-lex format traps.
 
 ### ULID format
 
@@ -90,20 +93,41 @@ let id = generator.generate()?;    // use MonotonicGenerator owned by EventLog
 ```sql
 CREATE TABLE _replay_state (
   peer_device        TEXT PRIMARY KEY,
-  last_event_id      TEXT,              -- resume point in peer's tail
-  last_snapshot_id   TEXT,              -- latest applied snapshot from peer
-  updated_at         TEXT NOT NULL
+  last_event_id      TEXT,              -- resume point in peer's tail (ULID string)
+  last_snapshot_id   TEXT,              -- latest applied snapshot from peer (ULID string)
+  updated_at         INTEGER NOT NULL   -- unix millis
 );
 
 CREATE TABLE _tombstones (
   entity TEXT NOT NULL,
   id     TEXT NOT NULL,
-  ts     TEXT NOT NULL,
+  ts     INTEGER NOT NULL,              -- unix millis
   PRIMARY KEY (entity, id)
 );
 ```
 
 Never appear in any event; never synced.
+
+### Schema normalization — every synced table gets `created_at` + `updated_at` as `INTEGER` unix millis
+
+Before sync code lands, normalize every synced table to carry both `created_at` and `updated_at` as `INTEGER NOT NULL` storing unix time in **milliseconds**. Two changes in one migration:
+
+1. **Shape uniformity.** Every synced table carries both columns. Append-only tables get `updated_at` too — it just equals `created_at` and never changes — so the merge engine can LWW-compare against a single column name on every table, no per-table special cases.
+2. **Type change: TEXT → INTEGER millis.** LWW compares timestamps natively via integer order instead of string-lex order (which is brittle across RFC-3339 format variants — `to_rfc3339()` emits variable sub-second precision and `+00:00`, which string-compares incorrectly against `...Z` millis format). Int64 also aligns with the 48-bit millis embedded in every ULID, so the sync engine uses one time representation end-to-end.
+
+| Table | Today | After migration 009 |
+|---|---|---|
+| `books`, `vocab_words`, `chats` | `created_at TEXT`, `updated_at TEXT` | `created_at INTEGER`, `updated_at INTEGER` (unix millis) |
+| `bookmarks`, `highlights`, `collections`, `chat_messages`, `translations` | `created_at TEXT` only | both columns as `INTEGER` |
+| `vocab_words.next_review_at` | `TEXT` | `INTEGER` (nullable — represents a scheduled future instant) |
+| `collection_books` | no timestamps | both columns as `INTEGER`, backfilled with migration time |
+| `settings`, `book_settings`, `schema_version`, `secrets` | local-only | skip — never synced |
+
+**Migration mechanics.** SQLite can't retype a column in place, so the migration is Rust-driven (not a pure `.sql` file) and runs inside a single transaction: `ALTER TABLE ... ADD COLUMN <col>_ms INTEGER` on every affected column → iterate existing rows, parse the old TEXT via `chrono::DateTime::parse_from_rfc3339`, write `timestamp_millis()` into the new column → `DROP COLUMN` the old TEXT → `RENAME COLUMN <col>_ms TO <col>`. Any parse or SQL failure rolls the entire transaction back, so the DB is either fully migrated or identical to pre-migration. `schema_version` only advances on successful commit, so a crash mid-flight re-runs cleanly on next launch.
+
+**Frontend contract change.** Every Tauri command that returned a timestamp as `string` now returns `number`. TypeScript types switch `created_at: string` → `created_at: number`. Components rendering timestamps use `new Date(millis)` / `toLocaleString()` (or a shared formatter util) in place of ISO string display. This is the only outward-visible change; the UI behavior is unchanged.
+
+This lands as a single normalization commit (Chunk 1 below). It's a breaking internal change, not a feature — it's the moment before sync solidifies the format to fix the choice once.
 
 ---
 
@@ -120,13 +144,14 @@ Never appear in any event; never synced.
 - `src-tauri/src/sync/migration.rs` — one-shot migration from legacy file-sync
 - `src-tauri/src/sync/watcher.rs` — fs-notify wrapper (macOS FSEvents, Linux inotify)
 - `src-tauri/src/commands/sync.rs` — Tauri commands for settings UI
-- `src-tauri/migrations/010_replay_state.sql`
+- `src-tauri/src/migrations_009.rs` — Rust-driven migration 009 (schema normalization + TEXT→INTEGER millis conversion; see "Schema normalization" above)
+- `src-tauri/migrations/010_replay_state.sql` — creates `_replay_state` and `_tombstones`
 - `src/components/settings/LibrarySyncSettings.tsx`
 
 **Modified:**
 - `src-tauri/src/lib.rs` — wire sync module, register commands, spawn watcher task
-- `src-tauri/src/db.rs` — add migration 010; helpers to write local-only rows
-- `src-tauri/src/commands/{bookmarks,books,collections,vocab,chats,translations,settings}.rs` — route every mutation through `SyncWriter`
+- `src-tauri/src/db.rs` — register migrations 009 and 010; helpers to write local-only rows
+- `src-tauri/src/commands/{bookmarks,books,collections,vocab,chats,translation,settings}.rs` — route every mutation through `SyncWriter`; in Chunk 1, additionally start writing `updated_at` on every INSERT/UPDATE to newly-normalized tables
 - `src-tauri/src/icloud.rs` — deprecated; keep only the legacy migration entry point used by the one-shot migration routine
 - `src/components/settings/ICloudSettings.tsx` → replaced by `LibrarySyncSettings.tsx`
 - `src/i18n/en.json`, `src/i18n/zh.json` — new keys under `settings.librarySync`
@@ -145,7 +170,7 @@ Never appear in any event; never synced.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Event {
     pub id: String,          // ULID
-    pub ts: String,          // RFC-3339
+    pub ts: i64,             // unix millis
     pub device: String,      // UUID
     pub v: u32,              // schema version
     #[serde(flatten)]
@@ -310,10 +335,10 @@ pub fn apply_event(tx: &Transaction, event: &Event) -> AppResult<()> {
             tx.execute("INSERT OR IGNORE INTO _tombstones (entity, id, ts) VALUES ('book', ?1, ?2)", params![id, event.ts])?;
         }
         EventBody::BookProgressSet { book, progress, cfi } => {
-            let existing_ts: Option<String> = tx.query_row(
+            let existing_ts: Option<i64> = tx.query_row(
                 "SELECT updated_at FROM books WHERE id = ?1", params![book], |r| r.get(0),
             ).optional()?;
-            if existing_ts.as_deref().map_or(true, |t| t < event.ts.as_str()) {
+            if existing_ts.map_or(true, |t| t < event.ts) {
                 tx.execute(
                     "UPDATE books SET progress = ?1, current_cfi = ?2, updated_at = ?3 WHERE id = ?4",
                     params![progress, cfi, event.ts, book],
@@ -548,34 +573,26 @@ Lifetime: spawned from `lib.rs::setup` if sync is enabled; cancelled on disable.
 **Component:** `src/components/settings/LibrarySyncSettings.tsx` (replaces `ICloudSettings.tsx`).
 
 **Tauri commands** (`src-tauri/src/commands/sync.rs`):
-- `sync_status() -> SyncStatus { backend, shared_dir, device_uuid, peers: Vec<Peer>, last_replay_at, pending_events, last_error }`
-- `sync_enable(backend: "icloud" | "custom", path: Option<String>) -> AppResult<()>`
-- `sync_disable() -> AppResult<()>`  (local-only fallback; keeps logs, stops writing new ones)
+- `sync_status() -> SyncStatus { enabled, shared_dir, device_uuid, peers: Vec<Peer>, last_replay_at, pending_events, last_error }`
+- `sync_enable() -> AppResult<()>` — no args; always iCloud in v1. Same semantics as today's `icloud_enable`.
+- `sync_disable() -> AppResult<()>` — keeps logs on disk, stops appending. Same semantics as today's `icloud_disable`.
 - `sync_now() -> AppResult<ReplayReport>`
-- `sync_revert_to_legacy() -> AppResult<()>` (grace-period rollback)
+- `sync_revert_to_legacy() -> AppResult<()>` — grace-period rollback (30 days).
+
+Keep `icloud_status`/`icloud_enable`/`icloud_disable` aliased to these during the transition so in-flight builds don't break; remove in cleanup.
 
 **Sections:**
-1. **Storage backend** — segmented control: Local / iCloud Drive / Custom folder. Path display. Folder picker for Custom.
-2. **Migration status** — banner if `migration.complete == false` with a "Migrate now" button; hidden once complete.
-3. **Peers** — list of other devices writing to the shared folder. Each row: device name (editable), last seen, events in tail, snapshot age.
-4. **Actions** — "Sync now", "Compact own log", "Export local backup", "Revert to legacy sync" (only visible within 30 days of migration).
-5. **Notes** — "Secrets are never synced." / "Avoid editing simultaneously on multiple devices."
+1. **Sync toggle** — a single 73px row with a Toggle labelled "Sync with iCloud" / subtitle "Store your library in iCloud Drive". Identical copy and layout to today's `ICloudSettings.tsx`. Loading/error/confirmation states mirror the existing component exactly — users shouldn't notice a UI change at this level.
+2. **Migration banner** — conditional amber card when `migration.complete == false`, with title "Migration pending", body "Your library is still using the legacy iCloud file sync. Migrate now for record-level sync across devices.", and a "Migrate now" button. Hidden once complete; never appears on fresh installs.
+3. **Peers** — expandable "Other devices" row. Each peer row: device icon, device name, last-seen timestamp (relative, e.g. "2 min ago"), pending-events count as a subtle pill. Read-only in v1.
+4. **Actions** — compact cluster of secondary buttons: "Sync now" (icon + label) and "Compact log" (icon + label). Right-aligned destructive-style link "Revert to legacy sync" visible only during the 30-day grace window. Export backup deferred.
+5. **Notes** — "API keys and tokens are stored locally and never synced." / "Avoid editing on multiple devices simultaneously for best results."
 
-### Figma prompt
-
-> Design a settings section titled "Library & Sync". Layout: 73px-tall rows, `flex justify-between`, 1px `black/10` dividers — matches `GeneralSettings.tsx`.
->
-> Section 1: **Storage backend** — single row. Left: label "Library storage" + small-caps helper "Where your books and reading data live". Right: a segmented control with three options: "This device", "iCloud Drive", "Custom folder". Below (when Custom is selected): a second row with a path display (monospace, truncated left) and a "Choose folder…" button.
->
-> Section 2: **Migration banner** (conditional) — full-width amber card above the rows: title "Migration pending", body "Your library is still using the legacy iCloud file sync. Migrate now for record-level sync across devices.", right-aligned primary button "Migrate now".
->
-> Section 3: **Peers** — expandable list under a row titled "Other devices". Each peer row: device icon, editable device name, last-seen timestamp (relative, e.g. "2 min ago"), pending-events count as a subtle pill.
->
-> Section 4: **Actions** — a compact cluster of secondary buttons: "Sync now" (icon + label), "Compact log" (icon + label), "Export local backup" (icon + label). Right-aligned destructive-style link "Revert to legacy sync" (visible only during the 30-day grace window).
->
-> Section 5: **Notes** — small-text section at the bottom: "API keys and tokens are stored locally and never synced." and "Avoid editing on multiple devices simultaneously for best results."
->
-> Palette: keep the existing Quill Settings palette (`quillSurface`, `quillBorder`, `quillText`, `quillTextTertiary`, `quillAccent`, `quillElevated`). Loading/error states match existing `ICloudSettings.tsx` conventions.
+**Deferred to a future release** (alongside the next cloud provider):
+- Segmented control (This device / iCloud Drive / Custom folder).
+- Folder picker via `@tauri-apps/plugin-dialog`'s `open({ directory: true })`.
+- `sync_enable(backend, path)` signature with a `backend` argument.
+- "Export local backup" action.
 
 ---
 
@@ -589,6 +606,121 @@ Because we're shipping end-to-end in v1 (no dual-write):
 4. Ship. Release notes call out migration: "Quill now uses a per-device event log to sync your library. On first launch we'll migrate your existing iCloud data."
 
 Cross-device testing against iOS is blocked until quill-ios ships its mirror — can be done in parallel or staged later.
+
+---
+
+## Shipping chunks
+
+Cross-cutting work — land as a sequence of narrow PRs, each independently reviewable and leaving the app in a working state. The user-facing switch doesn't flip until Chunk 7.
+
+### Chunk 1 — Schema normalization (standalone refactor, no sync code)
+
+Shape + type normalization as a single commit. Lands separately from the sync work so the sync PR doesn't mix two concerns. Internally breaking (all Tauri commands that returned timestamps now return numbers) but no end-user behavior change.
+
+**Backend:**
+- `src-tauri/src/migrations_009.rs` — new module. Single `fn migrate(conn: &Connection) -> AppResult<()>` driven from `db.rs::run_migrations`. One transaction: ADD new `*_ms INTEGER` columns → backfill from existing TEXT via `chrono::DateTime::parse_from_rfc3339` → DROP old TEXT columns → RENAME `*_ms` to final names. Tables touched: `books`, `bookmarks`, `highlights`, `collections`, `collection_books` (adds both cols), `vocab_words` (incl. `next_review_at`), `chats`, `chat_messages`, `translations`.
+- `src-tauri/src/db.rs` — register migration 9 (call `migrations_009::migrate`); bump the two `assert_eq!(version, 8)` tests to 9.
+- `src-tauri/src/commands/{books,bookmarks,collections,vocab,chats,translation}.rs` — every `created_at: String` / `updated_at: String` / `next_review_at: Option<String>` struct field becomes `i64` / `Option<i64>`. Every `chrono::Utc::now().to_rfc3339()` becomes `chrono::Utc::now().timestamp_millis()`. Every row mapper reads `INTEGER` instead of `TEXT`. Commands on tables that previously lacked `updated_at` (bookmarks add, highlights add/color/note, collections rename/reorder, collection_books add, chat_messages add, translations add) now set it.
+- **Migration tests** (in `migrations_009.rs`): seed a fresh DB at schema v8 with realistic old-format TEXT timestamps across every affected table → run `migrate()` → assert (a) each new INTEGER equals `DateTime::parse_from_rfc3339(original).timestamp_millis()`; (b) row counts unchanged; (c) no NULL in any NOT NULL timestamp column; (d) rollback on injected parse failure leaves DB identical to v8 state.
+
+**Frontend:**
+- TypeScript types: every timestamp field becomes `number` (likely in `src/types/` or inline interfaces — grep to find them all).
+- Display sites: every place that rendered the ISO string now formats via `new Date(millis).toLocaleString()` or a shared formatter. Affected components at minimum: book cards, chat list, vocab panel, translations panel, bookmarks list, highlights list. Find via grep on `created_at` / `updated_at` usage.
+
+**Verification:**
+- `cargo check` + `cargo test` pass; migration tests specifically green.
+- Manual: copy a real v0.9.14 `quill.db` to a scratch dir, point a dev build at it, confirm the app opens and shows existing books/highlights/chats correctly with their real historical timestamps (rendered from the migrated INTEGER values).
+- Verify timestamps render identically pre- and post-migration in the UI.
+
+### Chunk 2 — Crates + sync module skeleton + `_replay_state`
+
+- `src-tauri/Cargo.toml` — add `ulid = "1"` (feature `serde`), `notify = "6"`. `cargo check` to sync `Cargo.lock`.
+- `src-tauri/migrations/010_replay_state.sql` — `_replay_state` and `_tombstones` tables.
+- `src-tauri/src/db.rs` — register migration 10.
+- `src-tauri/src/sync/mod.rs` — declare submodules as empty stubs so `cargo check` compiles.
+- `src-tauri/src/lib.rs` — `mod sync;`.
+
+**Verification:** `cargo check` passes. DB advances 9→10; `_replay_state` and `_tombstones` exist.
+
+### Chunk 3 — Event schema + EventLog (pure code, no wiring)
+
+- `src-tauri/src/sync/events.rs` — `Event` struct + `EventBody` enum per Step 1. `#[serde(flatten)] extra` for forward-compat.
+- `src-tauri/src/sync/log.rs` — `EventLog::{open, append, append_batch, read_all, read_after}` per Step 2. Owns a monotonic `ulid::Generator` + `BufWriter<File>` behind one `Mutex`. macOS: `NSFileCoordinator` wrapper via `objc2` in a `#[cfg(target_os = "macos")]` block — net-new helper (current `icloud.rs` doesn't use it).
+- `src-tauri/src/sync/device.rs` — `DeviceIdentity::load_or_create(&local_dir)` reads/writes `device.json` with `{ device_uuid, created_at }`. UUIDv4 via the existing `uuid` crate.
+
+**Tests** (colocated `#[cfg(test)] mod tests`): round-trip every `EventBody` variant; append-then-read ordering; torn-write recovery (truncate last byte); unknown-field preservation.
+
+**Verification:** `cargo test --lib sync::` green. Not wired to the rest of the app yet.
+
+### Chunk 4 — Merge + replay + snapshot (pure)
+
+- `src-tauri/src/sync/merge.rs` — `apply_event` match per `EventBody` variant (Step 4). Helpers: `lww_update_if_newer`, `is_tombstoned`, `insert_tombstone`. Every INSERT uses `OR IGNORE`; every LWW update compares `existing.updated_at < event.ts`; tombstone check precedes every add.
+- `src-tauri/src/sync/replay.rs` — `ReplayEngine::tick()` per Step 5. Lists peer logs + snapshots, skips own files, merges events sorted by `(ts, device)`, applies in one SQL tx. Process-wide `Mutex` serializes concurrent ticks.
+- `src-tauri/src/sync/snapshot.rs` — `Snapshot::{from_log, write_atomic, apply_peer}` per Step 6. Apply follows the 6-step procedure exactly (stat → header parse → watermark compare → full parse → apply under tombstone guard → monotonic watermark update).
+
+**Tests:** merge determinism property test (shuffled apply → byte-identical `SELECT *`); tombstone wins; LWW correctness; snapshot equivalence (events vs snapshot+tail yield identical state).
+
+**Verification:** `cargo test` green. Still not wired to any command.
+
+### Chunk 5 — SyncWriter + command instrumentation
+
+- `src-tauri/src/sync/writer.rs` — `SyncWriter::with_tx<F>(f: F)` per Step 3. Opens SQL tx, passes `(tx, events: &mut Vec<EventBody>)` to closure, on success appends events to log (single fsync) and commits the tx. Disabled case: events vec dropped, tx commits normally. Progress-event debounce ring: per-book trailing 2-second window via `HashMap<book_id, Instant>`.
+- `src-tauri/src/commands/books.rs` — route `import_book`, `commit_pdf_import`, `delete_book`, `update_reading_progress`, `update_book_status`, `mark_finished`, `update_book_metadata` through `SyncWriter`.
+- `src-tauri/src/commands/bookmarks.rs` — all 6 commands; highlight writes also set `updated_at`.
+- `src-tauri/src/commands/collections.rs` — all 6 commands; `rename_collection` and `reorder_collections` also set `updated_at`.
+- `src-tauri/src/commands/vocab.rs`, `chats.rs`, `translation.rs` — remaining events per the Step 3 table.
+- `src-tauri/src/commands/settings.rs` + `book_settings` path — explicitly no-op (local-only).
+- `src-tauri/src/lib.rs` — construct `SyncWriter::new(db, Option<Arc<EventLog>>)` once in `setup`, store in Tauri state. Commands now take `State<SyncWriter>` instead of `State<Db>`.
+
+**Tests:** for each command — sync off → no events; sync on → event content matches SQL write. Progress debounce: 10 rapid calls within 2s → exactly 1 event appended.
+
+**Verification:** existing frontend works unchanged with sync off. `cargo test` green. Manual: import a book with sync off, confirm no log file.
+
+### Chunk 6 — Migration routine + replay wiring on launch
+
+- `src-tauri/src/sync/migration.rs` — `run_migration(...)` per Step 7. Reuses `icloud::ensure_downloaded` and `icloud::icloud_data_dir_fast`. Writes `Snapshot::from_legacy_db(&old_db, device_id)` + empty log, copies ubiquity `quill.db` → local bit-exact, retires ubiquity DB via rename to `quill.db.migrated-<iso-ts>`. Conflict-copy merge for `quill (1).db`, `quill (2).db`.
+- `src-tauri/src/sync/watcher.rs` — `notify` wrapper on `<shared>/logs/`. Debounce 250ms, call `replay_engine.tick()` on tokio task. Skip while a reader session is active (shared `AtomicBool` flag set from reader commands).
+- `src-tauri/src/lib.rs` launch flow per Step 7:
+  ```
+  read migration.complete from local settings
+  if icloud_was_enabled && !migration.complete:
+      run_migration(...)
+  else if migration.complete:
+      retire_ubiquity_db(...)   # self-healing
+  open <local>/quill.db          # always local post-migration
+  replay_engine.tick()           # catch up from peer logs
+  spawn watcher if sync enabled
+  ```
+- `src-tauri/src/commands/sync.rs` — `sync_now` command (manual tick).
+
+**Tests:** migration idempotency; conflict-copy merge; fresh-install replay from existing peer log; no-op tick.
+
+**Verification:** manual E2E on a dev iCloud account — copy a v0.9.x DB to ubiquity, launch v1 build, confirm migration completes, retired file appears, local DB row counts match source.
+
+### Chunk 7 — Settings UI (swap `ICloudSettings` → `LibrarySyncSettings`)
+
+- `src/components/settings/LibrarySyncSettings.tsx` — new, single Toggle + migration banner + peers + actions (see §Step 9 above).
+- `src/components/SettingsModal.tsx` — swap import and section id (`icloud` → `librarySync`).
+- `src/i18n/{en,zh}.json` — add `settings.librarySync.*` namespace mirroring existing `settings.icloud.*` copy. Keep old keys during the transition.
+- `src-tauri/src/commands/sync.rs` — `sync_status`, `sync_enable`, `sync_disable`, `sync_revert_to_legacy`. Register in `generate_handler!`.
+
+**Verification:** Tauri dev server, open Settings → Library & Sync, toggle iCloud off → on → verify `<icloud-container>/logs/<device-uuid>.jsonl` appears and grows with usage.
+
+### Chunk 8 — Compaction
+
+- Wire triggers in `snapshot.rs` per Step 6: own log > 2 MB **OR** > 5000 events **OR** monthly. Invoked at end of migration, from "Compact log" button, and after each launch's `replay_engine.tick()`.
+
+**Verification:** compact round-trip on real usage data produces a snapshot + truncated log that replays to the same state.
+
+### Chunk 9 — Cleanup (Phase D, post-ship, separate follow-up issue)
+
+After v1 ships and stabilizes over 2 releases:
+- Delete `src-tauri/src/icloud.rs` legacy paths.
+- Delete `src-tauri/src/commands/icloud.rs`.
+- Delete old `settings.icloud.*` i18n keys.
+- Delete `src/components/settings/ICloudSettings.tsx` (unreferenced after Chunk 7).
+
+Tracked separately; not part of #185.
 
 ---
 
@@ -616,5 +748,4 @@ Manual / E2E:
 - [ ] Read past existing progress on A while B is open on older position; verify A doesn't clobber B's newer writes.
 - [ ] Delete book on A, verify it disappears on B.
 - [ ] Settings "Revert to legacy sync" restores old DB and sync path; re-migration runs cleanly.
-- [ ] Switch shared folder from iCloud Drive to Dropbox; library follows.
 - [ ] Secrets never appear in shared folder.

--- a/src-tauri/migrations/009_normalize_timestamps.sql
+++ b/src-tauri/migrations/009_normalize_timestamps.sql
@@ -1,0 +1,268 @@
+-- Migration 009 — normalize timestamps across every synced table.
+--
+-- Converts every TEXT RFC-3339 timestamp to INTEGER unix milliseconds and
+-- adds `updated_at` to tables that lacked it. After this migration every
+-- synced table has: `created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL`.
+--
+-- Mechanics: SQLite's 12-step table-rebuild pattern. CREATE TABLE <x>_new with
+-- the final schema, INSERT INTO <x>_new SELECT ... FROM <x> converting
+-- timestamps to unix millis in SQL, DROP <x>, RENAME <x>_new → <x>. One
+-- transaction; any failure rolls back the whole thing leaving the DB
+-- byte-identical to pre-migration.
+--
+-- Foreign keys are toggled OFF around the rebuild because rebuilding a parent
+-- table (books, collections) would otherwise cascade-delete child rows via
+-- ON DELETE CASCADE. PRAGMA foreign_keys can only change outside a
+-- transaction, hence the OFF → BEGIN → … → COMMIT → ON sequence. Child tables
+-- are rebuilt after their parents so their FK declarations resolve.
+--
+-- Timestamp conversion formula:
+--   CAST(strftime('%s', ts) AS INTEGER) * 1000
+--     + CAST(substr(strftime('%f', ts), -3) AS INTEGER)
+-- = integer unix seconds × 1000 + the 3-digit millisecond tail from the
+-- SS.SSS fractional-seconds output. This is exact at millisecond precision
+-- for every format chrono's `to_rfc3339()` emits (bare / .SSS / nanoseconds
+-- / Z suffix / +HH:MM suffix). Nanosecond digits beyond millisecond are
+-- silently truncated, which matches the target precision. Using julianday()
+-- would lose ±1ms to double-precision float rounding at this magnitude.
+--
+-- On malformed input, strftime() returns NULL → CAST(NULL AS INTEGER) = NULL
+-- → INSERT into the NOT NULL column fails → transaction rolls back. Safe by
+-- construction; the user's DB is never left in an intermediate state.
+--
+-- See `docs/impls/31-sync.md` §"Schema normalization" for the design rationale.
+
+PRAGMA foreign_keys = OFF;
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- books (parent — rebuild before any table that references it)
+-- ---------------------------------------------------------------------------
+CREATE TABLE books_new (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  author TEXT NOT NULL,
+  description TEXT,
+  cover_path TEXT,
+  file_path TEXT NOT NULL,
+  genre TEXT,
+  pages INTEGER,
+  format TEXT NOT NULL DEFAULT 'epub',
+  status TEXT NOT NULL DEFAULT 'unread',
+  progress INTEGER NOT NULL DEFAULT 0,
+  current_cfi TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO books_new (id, title, author, description, cover_path, file_path,
+                      genre, pages, format, status, progress, current_cfi,
+                      created_at, updated_at)
+SELECT id, title, author, description, cover_path, file_path,
+       genre, pages, format, status, progress, current_cfi,
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER),
+       CAST(strftime('%s', updated_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', updated_at), -3) AS INTEGER)
+FROM books;
+DROP TABLE books;
+ALTER TABLE books_new RENAME TO books;
+
+-- ---------------------------------------------------------------------------
+-- collections (parent of collection_books — rebuild before it)
+-- ---------------------------------------------------------------------------
+CREATE TABLE collections_new (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO collections_new (id, name, sort_order, created_at, updated_at)
+SELECT id, name, sort_order,
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER),
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER)
+FROM collections;
+DROP TABLE collections;
+ALTER TABLE collections_new RENAME TO collections;
+
+-- ---------------------------------------------------------------------------
+-- bookmarks (child of books)
+-- ---------------------------------------------------------------------------
+CREATE TABLE bookmarks_new (
+  id TEXT PRIMARY KEY,
+  book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  cfi TEXT NOT NULL,
+  label TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO bookmarks_new (id, book_id, cfi, label, created_at, updated_at)
+SELECT id, book_id, cfi, label,
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER),
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER)
+FROM bookmarks;
+DROP TABLE bookmarks;
+ALTER TABLE bookmarks_new RENAME TO bookmarks;
+
+-- ---------------------------------------------------------------------------
+-- highlights (child of books)
+-- ---------------------------------------------------------------------------
+CREATE TABLE highlights_new (
+  id TEXT PRIMARY KEY,
+  book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  cfi_range TEXT NOT NULL,
+  color TEXT NOT NULL DEFAULT 'yellow',
+  note TEXT,
+  text_content TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO highlights_new (id, book_id, cfi_range, color, note, text_content,
+                            created_at, updated_at)
+SELECT id, book_id, cfi_range, color, note, text_content,
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER),
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER)
+FROM highlights;
+DROP TABLE highlights;
+ALTER TABLE highlights_new RENAME TO highlights;
+
+-- ---------------------------------------------------------------------------
+-- vocab_words (child of books; next_review_at stays nullable)
+-- ---------------------------------------------------------------------------
+CREATE TABLE vocab_words_new (
+  id TEXT PRIMARY KEY,
+  book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  word TEXT NOT NULL,
+  definition TEXT NOT NULL,
+  context_sentence TEXT,
+  cfi TEXT,
+  mastery TEXT NOT NULL DEFAULT 'new',
+  review_count INTEGER NOT NULL DEFAULT 0,
+  next_review_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO vocab_words_new (id, book_id, word, definition, context_sentence, cfi,
+                             mastery, review_count, next_review_at,
+                             created_at, updated_at)
+SELECT id, book_id, word, definition, context_sentence, cfi,
+       mastery, review_count,
+       CASE WHEN next_review_at IS NULL THEN NULL
+            ELSE CAST(strftime('%s', next_review_at) AS INTEGER) * 1000
+                   + CAST(substr(strftime('%f', next_review_at), -3) AS INTEGER)
+       END,
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER),
+       CAST(strftime('%s', updated_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', updated_at), -3) AS INTEGER)
+FROM vocab_words;
+DROP TABLE vocab_words;
+ALTER TABLE vocab_words_new RENAME TO vocab_words;
+CREATE INDEX IF NOT EXISTS idx_vocab_book_id ON vocab_words(book_id);
+CREATE INDEX IF NOT EXISTS idx_vocab_mastery ON vocab_words(mastery);
+
+-- ---------------------------------------------------------------------------
+-- collection_books (junction; no timestamps today — backfill with migration time)
+-- ---------------------------------------------------------------------------
+CREATE TABLE collection_books_new (
+  collection_id TEXT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+  book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (collection_id, book_id)
+);
+INSERT INTO collection_books_new (collection_id, book_id, created_at, updated_at)
+SELECT collection_id, book_id,
+       CAST(strftime('%s', 'now') AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', 'now'), -3) AS INTEGER),
+       CAST(strftime('%s', 'now') AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', 'now'), -3) AS INTEGER)
+FROM collection_books;
+DROP TABLE collection_books;
+ALTER TABLE collection_books_new RENAME TO collection_books;
+
+-- ---------------------------------------------------------------------------
+-- chats (soft-reference to books — no FK declared, but rebuild anyway)
+-- ---------------------------------------------------------------------------
+CREATE TABLE chats_new (
+  id TEXT PRIMARY KEY,
+  book_id TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT 'New chat',
+  model TEXT,
+  pinned INTEGER NOT NULL DEFAULT 0,
+  metadata TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO chats_new (id, book_id, title, model, pinned, metadata,
+                       created_at, updated_at)
+SELECT id, book_id, title, model, pinned, metadata,
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER),
+       CAST(strftime('%s', updated_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', updated_at), -3) AS INTEGER)
+FROM chats;
+DROP TABLE chats;
+ALTER TABLE chats_new RENAME TO chats;
+CREATE INDEX IF NOT EXISTS idx_chat_book_id ON chats(book_id);
+
+-- ---------------------------------------------------------------------------
+-- chat_messages (soft-reference to chats)
+-- ---------------------------------------------------------------------------
+CREATE TABLE chat_messages_new (
+  id TEXT PRIMARY KEY,
+  chat_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  context TEXT,
+  metadata TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO chat_messages_new (id, chat_id, role, content, context, metadata,
+                               created_at, updated_at)
+SELECT id, chat_id, role, content, context, metadata,
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER),
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER)
+FROM chat_messages;
+DROP TABLE chat_messages;
+ALTER TABLE chat_messages_new RENAME TO chat_messages;
+CREATE INDEX IF NOT EXISTS idx_chat_msg_chat_id ON chat_messages(chat_id);
+
+-- ---------------------------------------------------------------------------
+-- translations (soft-reference to books)
+-- ---------------------------------------------------------------------------
+CREATE TABLE translations_new (
+  id TEXT PRIMARY KEY,
+  book_id TEXT NOT NULL,
+  source_text TEXT NOT NULL,
+  translated_text TEXT NOT NULL,
+  target_language TEXT NOT NULL,
+  cfi TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO translations_new (id, book_id, source_text, translated_text,
+                              target_language, cfi, created_at, updated_at)
+SELECT id, book_id, source_text, translated_text, target_language, cfi,
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER),
+       CAST(strftime('%s', created_at) AS INTEGER) * 1000
+         + CAST(substr(strftime('%f', created_at), -3) AS INTEGER)
+FROM translations;
+DROP TABLE translations;
+ALTER TABLE translations_new RENAME TO translations;
+CREATE INDEX IF NOT EXISTS idx_translations_book ON translations(book_id);
+
+COMMIT;
+
+PRAGMA foreign_keys = ON;

--- a/src-tauri/src/commands/bookmarks.rs
+++ b/src-tauri/src/commands/bookmarks.rs
@@ -11,7 +11,8 @@ pub struct Bookmark {
     pub book_id: String,
     pub cfi: String,
     pub label: Option<String>,
-    pub created_at: String,
+    pub created_at: i64,
+    pub updated_at: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -22,7 +23,8 @@ pub struct Highlight {
     pub color: String,
     pub note: Option<String>,
     pub text_content: Option<String>,
-    pub created_at: String,
+    pub created_at: i64,
+    pub updated_at: i64,
 }
 
 #[tauri::command]
@@ -34,10 +36,10 @@ pub fn add_bookmark(
 ) -> AppResult<Bookmark> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let id = uuid::Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
 
     conn.execute(
-        "INSERT INTO bookmarks (id, book_id, cfi, label, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+        "INSERT INTO bookmarks (id, book_id, cfi, label, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
         params![id, book_id, cfi, label, now],
     )?;
 
@@ -47,6 +49,7 @@ pub fn add_bookmark(
         cfi,
         label,
         created_at: now,
+        updated_at: now,
     })
 }
 
@@ -61,7 +64,7 @@ pub fn remove_bookmark(id: String, db: State<'_, Db>) -> AppResult<()> {
 pub fn list_bookmarks(book_id: String, db: State<'_, Db>) -> AppResult<Vec<Bookmark>> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let mut stmt = conn.prepare(
-        "SELECT id, book_id, cfi, label, created_at FROM bookmarks WHERE book_id = ?1 ORDER BY created_at DESC",
+        "SELECT id, book_id, cfi, label, created_at, updated_at FROM bookmarks WHERE book_id = ?1 ORDER BY created_at DESC",
     )?;
     let bookmarks = stmt
         .query_map(params![book_id], |row| {
@@ -71,6 +74,7 @@ pub fn list_bookmarks(book_id: String, db: State<'_, Db>) -> AppResult<Vec<Bookm
                 cfi: row.get(2)?,
                 label: row.get(3)?,
                 created_at: row.get(4)?,
+                updated_at: row.get(5)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -88,11 +92,11 @@ pub fn add_highlight(
 ) -> AppResult<Highlight> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let id = uuid::Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
     let color = color.unwrap_or_else(|| "yellow".to_string());
 
     conn.execute(
-        "INSERT INTO highlights (id, book_id, cfi_range, color, note, text_content, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        "INSERT INTO highlights (id, book_id, cfi_range, color, note, text_content, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
         params![id, book_id, cfi_range, color, note, text_content, now],
     )?;
 
@@ -104,6 +108,7 @@ pub fn add_highlight(
         note,
         text_content,
         created_at: now,
+        updated_at: now,
     })
 }
 
@@ -118,7 +123,7 @@ pub fn remove_highlight(id: String, db: State<'_, Db>) -> AppResult<()> {
 pub fn list_highlights(book_id: String, db: State<'_, Db>) -> AppResult<Vec<Highlight>> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let mut stmt = conn.prepare(
-        "SELECT id, book_id, cfi_range, color, note, text_content, created_at FROM highlights WHERE book_id = ?1 ORDER BY created_at DESC",
+        "SELECT id, book_id, cfi_range, color, note, text_content, created_at, updated_at FROM highlights WHERE book_id = ?1 ORDER BY created_at DESC",
     )?;
     let highlights = stmt
         .query_map(params![book_id], |row| {
@@ -130,6 +135,7 @@ pub fn list_highlights(book_id: String, db: State<'_, Db>) -> AppResult<Vec<High
                 note: row.get(4)?,
                 text_content: row.get(5)?,
                 created_at: row.get(6)?,
+                updated_at: row.get(7)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -139,9 +145,10 @@ pub fn list_highlights(book_id: String, db: State<'_, Db>) -> AppResult<Vec<High
 #[tauri::command]
 pub fn update_highlight_note(id: String, note: String, db: State<'_, Db>) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let now = chrono::Utc::now().timestamp_millis();
     conn.execute(
-        "UPDATE highlights SET note = ?1 WHERE id = ?2",
-        params![note, id],
+        "UPDATE highlights SET note = ?1, updated_at = ?2 WHERE id = ?3",
+        params![note, now, id],
     )?;
     Ok(())
 }
@@ -149,9 +156,10 @@ pub fn update_highlight_note(id: String, note: String, db: State<'_, Db>) -> App
 #[tauri::command]
 pub fn update_highlight_color(id: String, color: String, db: State<'_, Db>) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let now = chrono::Utc::now().timestamp_millis();
     conn.execute(
-        "UPDATE highlights SET color = ?1 WHERE id = ?2",
-        params![color, id],
+        "UPDATE highlights SET color = ?1, updated_at = ?2 WHERE id = ?3",
+        params![color, now, id],
     )?;
     Ok(())
 }

--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -52,8 +52,8 @@ pub struct Book {
     pub status: String,
     pub progress: i32,
     pub current_cfi: Option<String>,
-    pub created_at: String,
-    pub updated_at: String,
+    pub created_at: i64,
+    pub updated_at: i64,
     /// Whether the book file is locally available (not an iCloud placeholder).
     #[serde(default = "default_true")]
     pub available: bool,
@@ -106,7 +106,7 @@ pub async fn import_book(file_path: String, db: State<'_, Db>) -> AppResult<Book
     let dest = books_dir.join(&filename);
     fs::copy(src, &dest)?;
 
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
 
     // Store relative path in DB
     let rel_file_path = format!("books/{}", filename);
@@ -124,7 +124,7 @@ pub async fn import_book(file_path: String, db: State<'_, Db>) -> AppResult<Book
         status: "unread".to_string(),
         progress: 0,
         current_cfi: None,
-        created_at: now.clone(),
+        created_at: now,
         updated_at: now,
         available: true,
     };
@@ -323,7 +323,7 @@ pub fn update_reading_progress(
     db: State<'_, Db>,
 ) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
 
     conn.execute(
         "UPDATE books SET progress = ?1, current_cfi = ?2, updated_at = ?3 WHERE id = ?4",
@@ -346,7 +346,7 @@ pub fn update_book_pages(id: String, pages: i32, db: State<'_, Db>) -> AppResult
 #[tauri::command]
 pub fn mark_finished(id: String, db: State<'_, Db>) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
 
     conn.execute(
         "UPDATE books SET status = 'finished', progress = 100, updated_at = ?1 WHERE id = ?2",
@@ -359,7 +359,7 @@ pub fn mark_finished(id: String, db: State<'_, Db>) -> AppResult<()> {
 #[tauri::command]
 pub fn update_book_status(id: String, status: String, db: State<'_, Db>) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
 
     conn.execute(
         "UPDATE books SET status = ?1, updated_at = ?2 WHERE id = ?3",
@@ -377,7 +377,7 @@ pub fn update_book_metadata(
     db: State<'_, Db>,
 ) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
 
     conn.execute(
         "UPDATE books SET title = ?1, author = ?2, updated_at = ?3 WHERE id = ?4",
@@ -465,7 +465,7 @@ pub async fn commit_pdf_import(
         None
     };
 
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
     let rel_file_path = format!("books/{}", filename);
 
     let book = Book {
@@ -481,7 +481,7 @@ pub async fn commit_pdf_import(
         status: "unread".to_string(),
         progress: 0,
         current_cfi: None,
-        created_at: now.clone(),
+        created_at: now,
         updated_at: now,
         available: true,
     };
@@ -542,7 +542,7 @@ mod tests {
 
     fn insert_book(db: &Db, id: &str, format: &str) {
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
             "INSERT INTO books (id, title, author, file_path, format, status, progress, created_at, updated_at)
              VALUES (?1, 'Test', 'Author', 'books/test.epub', ?2, 'reading', 0, ?3, ?3)",
@@ -554,7 +554,7 @@ mod tests {
     fn test_format_defaults_to_epub() {
         let (_dir, db) = setup();
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
             "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
              VALUES ('b1', 'Test', 'Author', 'books/test.epub', 'reading', 0, ?1, ?1)",
@@ -588,7 +588,7 @@ mod tests {
 
         let conn = db.conn.lock().unwrap();
         let book_id = uuid::Uuid::new_v4().to_string();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         let rel_file_path = format!("books/{}.pdf", book_id);
 
         let dest = dir.path().join("books").join(format!("{}.pdf", book_id));
@@ -622,7 +622,7 @@ mod tests {
         fs::write(&cover_file, cover_data).unwrap();
 
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         let cover_path = format!("covers/{}.png", book_id);
 
         conn.execute(
@@ -680,7 +680,7 @@ mod tests {
     fn test_import_pdf_none_author_defaults() {
         let (_dir, db) = setup();
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
 
         // Simulate import_pdf with author = None
         let author: Option<String> = None;
@@ -707,7 +707,7 @@ mod tests {
         fs::write(&src, b"%PDF-1.7 fake").unwrap();
 
         let book_id = uuid::Uuid::new_v4().to_string();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         let rel_path = format!("books/{}.pdf", book_id);
         let cover_rel = format!("covers/{}.png", book_id);
 
@@ -754,7 +754,7 @@ mod tests {
         insert_book(&db, "b1", "epub");
 
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
             "UPDATE books SET title = ?1, author = ?2, updated_at = ?3 WHERE id = ?4",
             params!["New Title", "New Author", now, "b1"],
@@ -773,7 +773,7 @@ mod tests {
         insert_book(&db, "b1", "epub");
 
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
             "UPDATE books SET title = ?1, author = ?2, updated_at = ?3 WHERE id = ?4",
             params!["Changed Title", "Author", now, "b1"],
@@ -792,18 +792,18 @@ mod tests {
         insert_book(&db, "b1", "epub");
 
         let conn = db.conn.lock().unwrap();
-        let before: String = conn.query_row(
+        let before: i64 = conn.query_row(
             "SELECT updated_at FROM books WHERE id = 'b1'", [], |r| r.get(0),
         ).unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(10));
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
             "UPDATE books SET title = ?1, author = ?2, updated_at = ?3 WHERE id = ?4",
             params!["New", "New", now, "b1"],
         ).unwrap();
 
-        let after: String = conn.query_row(
+        let after: i64 = conn.query_row(
             "SELECT updated_at FROM books WHERE id = 'b1'", [], |r| r.get(0),
         ).unwrap();
         assert_ne!(before, after);
@@ -814,7 +814,7 @@ mod tests {
         let (_dir, db) = setup();
 
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         let rows = conn.execute(
             "UPDATE books SET title = ?1, author = ?2, updated_at = ?3 WHERE id = ?4",
             params!["Title", "Author", now, "nonexistent"],

--- a/src-tauri/src/commands/chats.rs
+++ b/src-tauri/src/commands/chats.rs
@@ -14,8 +14,8 @@ pub struct Chat {
     pub model: Option<String>,
     pub pinned: bool,
     pub metadata: Option<String>,
-    pub created_at: String,
-    pub updated_at: String,
+    pub created_at: i64,
+    pub updated_at: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub book_title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -32,7 +32,8 @@ pub struct ChatMsg {
     pub content: String,
     pub context: Option<String>,
     pub metadata: Option<String>,
-    pub created_at: String,
+    pub created_at: i64,
+    pub updated_at: i64,
 }
 
 fn row_to_chat(row: &rusqlite::Row) -> rusqlite::Result<Chat> {
@@ -76,6 +77,7 @@ fn row_to_msg(row: &rusqlite::Row) -> rusqlite::Result<ChatMsg> {
         context: row.get(4)?,
         metadata: row.get(5)?,
         created_at: row.get(6)?,
+        updated_at: row.get(7)?,
     })
 }
 
@@ -88,7 +90,7 @@ pub fn create_chat(
 ) -> AppResult<Chat> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let id = Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
     let title = title.unwrap_or_else(|| "New chat".to_string());
 
     conn.execute(
@@ -104,7 +106,7 @@ pub fn create_chat(
         model,
         pinned: false,
         metadata: None,
-        created_at: now.clone(),
+        created_at: now,
         updated_at: now,
         book_title: None,
         message_count: None,
@@ -171,7 +173,7 @@ pub fn delete_chat(chat_id: String, db: State<'_, Db>) -> AppResult<()> {
 #[tauri::command]
 pub fn rename_chat(chat_id: String, title: String, db: State<'_, Db>) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
     conn.execute(
         "UPDATE chats SET title = ?1, updated_at = ?2 WHERE id = ?3",
         params![title, now, chat_id],
@@ -183,7 +185,7 @@ pub fn rename_chat(chat_id: String, title: String, db: State<'_, Db>) -> AppResu
 pub fn list_chat_messages(chat_id: String, db: State<'_, Db>) -> AppResult<Vec<ChatMsg>> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let mut stmt = conn.prepare(
-        "SELECT id, chat_id, role, content, context, metadata, created_at
+        "SELECT id, chat_id, role, content, context, metadata, created_at, updated_at
          FROM chat_messages WHERE chat_id = ?1
          ORDER BY created_at ASC",
     )?;
@@ -204,12 +206,12 @@ pub fn save_chat_message(
 ) -> AppResult<ChatMsg> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let id = Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
 
     let tx = conn.unchecked_transaction()?;
     tx.execute(
-        "INSERT INTO chat_messages (id, chat_id, role, content, context, metadata, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        "INSERT INTO chat_messages (id, chat_id, role, content, context, metadata, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
         params![id, chat_id, role, content, context, metadata, now],
     )?;
     tx.execute(
@@ -226,6 +228,7 @@ pub fn save_chat_message(
         context,
         metadata,
         created_at: now,
+        updated_at: now,
     })
 }
 
@@ -240,15 +243,16 @@ mod tests {
         let db = Db::init(&dir.path().to_path_buf()).unwrap();
         // Insert a test book for foreign key references
         let conn = db.conn.lock().unwrap();
+        let t0: i64 = 1704067200000; // 2024-01-01T00:00:00Z
         conn.execute(
             "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
-             VALUES ('book1', 'Test Book', 'Author', 'books/test.epub', 'reading', 0, '2024-01-01', '2024-01-01')",
-            [],
+             VALUES ('book1', 'Test Book', 'Author', 'books/test.epub', 'reading', 0, ?1, ?1)",
+            params![t0],
         ).unwrap();
         conn.execute(
             "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
-             VALUES ('book2', 'Second Book', 'Author 2', 'books/test2.epub', 'reading', 0, '2024-01-01', '2024-01-01')",
-            [],
+             VALUES ('book2', 'Second Book', 'Author 2', 'books/test2.epub', 'reading', 0, ?1, ?1)",
+            params![t0],
         ).unwrap();
         drop(conn);
         (dir, db)
@@ -256,7 +260,7 @@ mod tests {
 
     fn insert_chat(db: &Db, id: &str, book_id: &str, title: &str) {
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
             "INSERT INTO chats (id, book_id, title, pinned, created_at, updated_at)
              VALUES (?1, ?2, ?3, 0, ?4, ?4)",
@@ -267,10 +271,10 @@ mod tests {
     fn insert_msg(db: &Db, chat_id: &str, role: &str, content: &str) {
         let conn = db.conn.lock().unwrap();
         let id = Uuid::new_v4().to_string();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
-            "INSERT INTO chat_messages (id, chat_id, role, content, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO chat_messages (id, chat_id, role, content, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
             params![id, chat_id, role, content, now],
         ).unwrap();
     }
@@ -292,7 +296,7 @@ mod tests {
         let (_dir, db) = setup();
         let conn = db.conn.lock().unwrap();
         let id = Uuid::new_v4().to_string();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
             "INSERT INTO chats (id, book_id, title, pinned, created_at, updated_at)
              VALUES (?1, 'book1', 'New chat', 0, ?2, ?2)",
@@ -316,7 +320,7 @@ mod tests {
         let (_dir, db) = setup();
         let conn = db.conn.lock().unwrap();
         let id = Uuid::new_v4().to_string();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
             "INSERT INTO chats (id, book_id, title, model, pinned, created_at, updated_at)
              VALUES (?1, 'book1', 'My Discussion', 'gpt-4o', 0, ?2, ?2)",
@@ -482,7 +486,7 @@ mod tests {
         insert_chat(&db, "c1", "book1", "New chat");
 
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         conn.execute(
             "UPDATE chats SET title = ?1, updated_at = ?2 WHERE id = ?3",
             params!["Renamed", now, "c1"],
@@ -504,7 +508,7 @@ mod tests {
         let (_dir, db) = setup();
         insert_chat(&db, "c1", "book1", "Chat A");
 
-        let original_updated: String = {
+        let original_updated: i64 = {
             let conn = db.conn.lock().unwrap();
             conn.query_row("SELECT updated_at FROM chats WHERE id = 'c1'", [], |r| r.get(0)).unwrap()
         };
@@ -514,10 +518,10 @@ mod tests {
         // Insert message and update chat's updated_at
         {
             let conn = db.conn.lock().unwrap();
-            let now = chrono::Utc::now().to_rfc3339();
+            let now = chrono::Utc::now().timestamp_millis();
             conn.execute(
-                "INSERT INTO chat_messages (id, chat_id, role, content, created_at)
-                 VALUES ('m1', 'c1', 'user', 'Hello', ?1)",
+                "INSERT INTO chat_messages (id, chat_id, role, content, created_at, updated_at)
+                 VALUES ('m1', 'c1', 'user', 'Hello', ?1, ?1)",
                 params![now],
             ).unwrap();
             conn.execute(
@@ -526,7 +530,7 @@ mod tests {
             ).unwrap();
         }
 
-        let new_updated: String = {
+        let new_updated: i64 = {
             let conn = db.conn.lock().unwrap();
             conn.query_row("SELECT updated_at FROM chats WHERE id = 'c1'", [], |r| r.get(0)).unwrap()
         };
@@ -543,26 +547,29 @@ mod tests {
 
         {
             let conn = db.conn.lock().unwrap();
+            let t1: i64 = 1704067200000; // 2024-01-01T00:00:00Z
+            let t2: i64 = 1704067201000; // 2024-01-01T00:00:01Z
+            let t3: i64 = 1704067202000; // 2024-01-01T00:00:02Z
             conn.execute(
-                "INSERT INTO chat_messages (id, chat_id, role, content, created_at)
-                 VALUES ('m1', 'c1', 'user', 'First', '2024-01-01T00:00:00Z')",
-                [],
+                "INSERT INTO chat_messages (id, chat_id, role, content, created_at, updated_at)
+                 VALUES ('m1', 'c1', 'user', 'First', ?1, ?1)",
+                params![t1],
             ).unwrap();
             conn.execute(
-                "INSERT INTO chat_messages (id, chat_id, role, content, context, created_at)
-                 VALUES ('m2', 'c1', 'assistant', 'Second', NULL, '2024-01-01T00:00:01Z')",
-                [],
+                "INSERT INTO chat_messages (id, chat_id, role, content, context, created_at, updated_at)
+                 VALUES ('m2', 'c1', 'assistant', 'Second', NULL, ?1, ?1)",
+                params![t2],
             ).unwrap();
             conn.execute(
-                "INSERT INTO chat_messages (id, chat_id, role, content, context, created_at)
-                 VALUES ('m3', 'c1', 'user', 'Third', 'some highlighted text', '2024-01-01T00:00:02Z')",
-                [],
+                "INSERT INTO chat_messages (id, chat_id, role, content, context, created_at, updated_at)
+                 VALUES ('m3', 'c1', 'user', 'Third', 'some highlighted text', ?1, ?1)",
+                params![t3],
             ).unwrap();
         }
 
         let conn = db.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, chat_id, role, content, context, metadata, created_at
+            "SELECT id, chat_id, role, content, context, metadata, created_at, updated_at
              FROM chat_messages WHERE chat_id = ?1 ORDER BY created_at ASC",
         ).unwrap();
         let msgs: Vec<ChatMsg> = stmt
@@ -582,7 +589,7 @@ mod tests {
     fn test_metadata_json_roundtrip() {
         let (_dir, db) = setup();
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
         let meta = r#"{"temperature":0.7,"tokens":150}"#;
 
         conn.execute(

--- a/src-tauri/src/commands/collections.rs
+++ b/src-tauri/src/commands/collections.rs
@@ -11,14 +11,15 @@ pub struct Collection {
     pub name: String,
     pub book_count: i32,
     pub sort_order: i32,
-    pub created_at: String,
+    pub created_at: i64,
+    pub updated_at: i64,
 }
 
 #[tauri::command]
 pub fn list_collections(db: State<'_, Db>) -> AppResult<Vec<Collection>> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let mut stmt = conn.prepare(
-        "SELECT c.id, c.name, c.created_at, c.sort_order, COUNT(cb.book_id) as book_count
+        "SELECT c.id, c.name, c.created_at, c.updated_at, c.sort_order, COUNT(cb.book_id) as book_count
          FROM collections c
          LEFT JOIN collection_books cb ON c.id = cb.collection_id
          GROUP BY c.id
@@ -30,8 +31,9 @@ pub fn list_collections(db: State<'_, Db>) -> AppResult<Vec<Collection>> {
                 id: row.get(0)?,
                 name: row.get(1)?,
                 created_at: row.get(2)?,
-                sort_order: row.get(3)?,
-                book_count: row.get(4)?,
+                updated_at: row.get(3)?,
+                sort_order: row.get(4)?,
+                book_count: row.get(5)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -42,7 +44,7 @@ pub fn list_collections(db: State<'_, Db>) -> AppResult<Vec<Collection>> {
 pub fn create_collection(name: String, db: State<'_, Db>) -> AppResult<Collection> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let id = uuid::Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
 
     let max_order: i32 = conn
         .query_row("SELECT COALESCE(MAX(sort_order), -1) FROM collections", [], |r| r.get(0))
@@ -51,7 +53,7 @@ pub fn create_collection(name: String, db: State<'_, Db>) -> AppResult<Collectio
     let sort_order = max_order + 1;
 
     conn.execute(
-        "INSERT INTO collections (id, name, sort_order, created_at) VALUES (?1, ?2, ?3, ?4)",
+        "INSERT INTO collections (id, name, sort_order, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?4)",
         params![id, name, sort_order, now],
     )?;
 
@@ -61,15 +63,17 @@ pub fn create_collection(name: String, db: State<'_, Db>) -> AppResult<Collectio
         book_count: 0,
         sort_order,
         created_at: now,
+        updated_at: now,
     })
 }
 
 #[tauri::command]
 pub fn rename_collection(id: String, name: String, db: State<'_, Db>) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let now = chrono::Utc::now().timestamp_millis();
     conn.execute(
-        "UPDATE collections SET name = ?1 WHERE id = ?2",
-        params![name, id],
+        "UPDATE collections SET name = ?1, updated_at = ?2 WHERE id = ?3",
+        params![name, now, id],
     )?;
     Ok(())
 }
@@ -84,10 +88,11 @@ pub fn delete_collection(id: String, db: State<'_, Db>) -> AppResult<()> {
 #[tauri::command]
 pub fn reorder_collections(ids: Vec<String>, db: State<'_, Db>) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let now = chrono::Utc::now().timestamp_millis();
     for (i, id) in ids.iter().enumerate() {
         conn.execute(
-            "UPDATE collections SET sort_order = ?1 WHERE id = ?2",
-            params![i as i32, id],
+            "UPDATE collections SET sort_order = ?1, updated_at = ?2 WHERE id = ?3",
+            params![i as i32, now, id],
         )?;
     }
     Ok(())
@@ -100,9 +105,10 @@ pub fn add_book_to_collection(
     db: State<'_, Db>,
 ) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let now = chrono::Utc::now().timestamp_millis();
     conn.execute(
-        "INSERT OR IGNORE INTO collection_books (collection_id, book_id) VALUES (?1, ?2)",
-        params![collection_id, book_id],
+        "INSERT OR IGNORE INTO collection_books (collection_id, book_id, created_at, updated_at) VALUES (?1, ?2, ?3, ?3)",
+        params![collection_id, book_id, now],
     )?;
     Ok(())
 }

--- a/src-tauri/src/commands/translation.rs
+++ b/src-tauri/src/commands/translation.rs
@@ -14,7 +14,8 @@ pub struct Translation {
     pub translated_text: String,
     pub target_language: String,
     pub cfi: Option<String>,
-    pub created_at: String,
+    pub created_at: i64,
+    pub updated_at: i64,
     pub book_title: Option<String>,
 }
 
@@ -166,9 +167,9 @@ pub fn save_translation(
 ) -> AppResult<String> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let id = uuid::Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
     conn.execute(
-        "INSERT INTO translations (id, book_id, source_text, translated_text, target_language, cfi, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        "INSERT INTO translations (id, book_id, source_text, translated_text, target_language, cfi, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
         rusqlite::params![id, book_id, source_text, translated_text, target_language, cfi, now],
     )?;
     Ok(id)
@@ -191,7 +192,7 @@ pub fn list_translations(
 ) -> AppResult<Vec<Translation>> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
 
-    let mut sql = "SELECT t.id, t.book_id, t.source_text, t.translated_text, t.target_language, t.cfi, t.created_at, b.title FROM translations t LEFT JOIN books b ON t.book_id = b.id".to_string();
+    let mut sql = "SELECT t.id, t.book_id, t.source_text, t.translated_text, t.target_language, t.cfi, t.created_at, t.updated_at, b.title FROM translations t LEFT JOIN books b ON t.book_id = b.id".to_string();
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
 
     if let Some(ref bid) = book_id {
@@ -212,7 +213,8 @@ pub fn list_translations(
             target_language: row.get(4)?,
             cfi: row.get(5)?,
             created_at: row.get(6)?,
-            book_title: row.get(7)?,
+            updated_at: row.get(7)?,
+            book_title: row.get(8)?,
         })
     })?;
 

--- a/src-tauri/src/commands/vocab.rs
+++ b/src-tauri/src/commands/vocab.rs
@@ -15,9 +15,9 @@ pub struct VocabWord {
     pub cfi: Option<String>,
     pub mastery: String,
     pub review_count: i64,
-    pub next_review_at: Option<String>,
-    pub created_at: String,
-    pub updated_at: String,
+    pub next_review_at: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub book_title: Option<String>,
 }
@@ -95,7 +95,7 @@ pub fn add_vocab_word(
     }
 
     let id = uuid::Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
 
     conn.execute(
         "INSERT INTO vocab_words (id, book_id, word, definition, context_sentence, cfi, mastery, review_count, next_review_at, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'new', 0, NULL, ?7, ?7)",
@@ -112,7 +112,7 @@ pub fn add_vocab_word(
         mastery: "new".to_string(),
         review_count: 0,
         next_review_at: None,
-        created_at: now.clone(),
+        created_at: now,
         updated_at: now,
         book_title: None,
     })
@@ -171,11 +171,11 @@ pub fn list_all_vocab_words(db: State<'_, Db>) -> AppResult<Vec<VocabWord>> {
 pub fn update_vocab_mastery(
     id: String,
     mastery: String,
-    next_review_at: Option<String>,
+    next_review_at: Option<i64>,
     db: State<'_, Db>,
 ) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now().timestamp_millis();
     conn.execute(
         "UPDATE vocab_words SET mastery = ?1, next_review_at = ?2, review_count = review_count + 1, updated_at = ?3 WHERE id = ?4",
         params![mastery, next_review_at, now, id],
@@ -186,12 +186,13 @@ pub fn update_vocab_mastery(
 #[tauri::command]
 pub fn list_vocab_due_for_review(db: State<'_, Db>) -> AppResult<Vec<VocabWord>> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let now_ms = chrono::Utc::now().timestamp_millis();
     let mut stmt = conn.prepare(&format!(
-        "SELECT {} FROM vocab_words WHERE next_review_at IS NOT NULL AND next_review_at <= datetime('now') ORDER BY next_review_at ASC",
+        "SELECT {} FROM vocab_words WHERE next_review_at IS NOT NULL AND next_review_at <= ?1 ORDER BY next_review_at ASC",
         SELECT_COLS
     ))?;
     let words = stmt
-        .query_map([], row_to_vocab)?
+        .query_map(params![now_ms], row_to_vocab)?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(words)
 }
@@ -199,6 +200,7 @@ pub fn list_vocab_due_for_review(db: State<'_, Db>) -> AppResult<Vec<VocabWord>>
 #[tauri::command]
 pub fn get_vocab_stats(db: State<'_, Db>) -> AppResult<VocabStats> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let now_ms = chrono::Utc::now().timestamp_millis();
     let total: i64 = conn.query_row("SELECT COUNT(*) FROM vocab_words", [], |r| r.get(0))?;
     let new_count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM vocab_words WHERE mastery = 'new'",
@@ -216,8 +218,8 @@ pub fn get_vocab_stats(db: State<'_, Db>) -> AppResult<VocabStats> {
         |r| r.get(0),
     )?;
     let due_for_review: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM vocab_words WHERE next_review_at IS NOT NULL AND next_review_at <= datetime('now')",
-        [],
+        "SELECT COUNT(*) FROM vocab_words WHERE next_review_at IS NOT NULL AND next_review_at <= ?1",
+        params![now_ms],
         |r| r.get(0),
     )?;
     Ok(VocabStats {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -14,6 +14,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (6, include_str!("../migrations/006_translations.sql")),
     (7, include_str!("../migrations/007_book_settings.sql")),
     (8, include_str!("../migrations/008_drop_book_settings.sql")),
+    (9, include_str!("../migrations/009_normalize_timestamps.sql")),
 ];
 
 pub struct Db {
@@ -48,7 +49,7 @@ impl Db {
             "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);",
         )?;
 
-        let current: i64 = conn
+        let mut current: i64 = conn
             .query_row("SELECT COALESCE(MAX(version), 0) FROM schema_version", [], |r| {
                 r.get(0)
             })
@@ -62,17 +63,15 @@ impl Db {
                 } else {
                     conn.execute_batch(sql)?;
                 }
+                // Advance schema_version per migration, so a failure in a later
+                // migration doesn't force successful earlier ones to re-run.
+                conn.execute("DELETE FROM schema_version", [])?;
+                conn.execute(
+                    "INSERT INTO schema_version (version) VALUES (?1)",
+                    params![version],
+                )?;
+                current = version;
             }
-        }
-
-        // Set version to the latest migration
-        let latest = MIGRATIONS.last().map(|(v, _)| *v).unwrap_or(0);
-        if latest > current {
-            conn.execute("DELETE FROM schema_version", [])?;
-            conn.execute(
-                "INSERT INTO schema_version (version) VALUES (?1)",
-                params![latest],
-            )?;
         }
 
         Ok(())
@@ -93,6 +92,42 @@ impl Db {
     #[cfg(test)]
     pub fn run_migrations_on(conn: &Connection) -> AppResult<()> {
         Self::run_migrations(conn)
+    }
+
+    /// Run migrations up to (and including) `max_version`. For tests that need
+    /// to seed data at a specific schema version before applying a later migration.
+    #[cfg(test)]
+    pub fn run_migrations_up_to(conn: &Connection, max_version: i64) -> AppResult<()> {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);",
+        )?;
+
+        let mut current: i64 = conn
+            .query_row("SELECT COALESCE(MAX(version), 0) FROM schema_version", [], |r| {
+                r.get(0)
+            })
+            .unwrap_or(0);
+
+        for &(version, sql) in MIGRATIONS {
+            if version > max_version {
+                break;
+            }
+            if version > current {
+                if version == 4 || version == 5 {
+                    let _ = conn.execute_batch(sql);
+                } else {
+                    conn.execute_batch(sql)?;
+                }
+                conn.execute("DELETE FROM schema_version", [])?;
+                conn.execute(
+                    "INSERT INTO schema_version (version) VALUES (?1)",
+                    params![version],
+                )?;
+                current = version;
+            }
+        }
+
+        Ok(())
     }
 
     /// Migrate existing absolute paths in the books table to relative paths.
@@ -146,7 +181,7 @@ mod tests {
         let conn = db.conn.lock().unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 8);
+        assert_eq!(version, 9);
     }
 
     #[test]
@@ -179,19 +214,19 @@ mod tests {
         Db::run_migrations_on(&conn).unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 8);
+        assert_eq!(version, 9);
     }
 
     #[test]
     fn test_books_has_format_column() {
         let (_dir, db) = setup();
         let conn = db.conn.lock().unwrap();
-        let now = chrono::Utc::now().to_rfc3339();
+        let now_ms = chrono::Utc::now().timestamp_millis();
         // Insert without format — should default to 'epub'
         conn.execute(
             "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
              VALUES ('b1', 'Test', 'Author', 'books/test.epub', 'reading', 0, ?1, ?1)",
-            params![now],
+            params![now_ms],
         )
         .unwrap();
         let format: String =
@@ -207,5 +242,324 @@ mod tests {
         let count: i64 =
             conn.query_row("SELECT COUNT(*) FROM schema_version", [], |r| r.get(0)).unwrap();
         assert_eq!(count, 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Migration 009 integrity — TEXT → INTEGER millis conversion.
+    //
+    // These tests seed a v8 DB with realistic RFC-3339 strings matching every
+    // precision chrono's to_rfc3339() emits (bare, .SSS, nanosecond, `Z` vs
+    // `+00:00` suffix), run migration 9 via the framework, and verify each
+    // row's INTEGER value equals `DateTime::parse_from_rfc3339(orig).timestamp_millis()`.
+    // -----------------------------------------------------------------------
+
+    fn rfc3339_to_millis(s: &str) -> i64 {
+        chrono::DateTime::parse_from_rfc3339(s)
+            .unwrap_or_else(|_| panic!("test bug: malformed RFC-3339: {s}"))
+            .timestamp_millis()
+    }
+
+    fn seed_v8(dir: &TempDir) -> Connection {
+        let conn = Connection::open(dir.path().join("quill.db")).unwrap();
+        conn.execute_batch("PRAGMA journal_mode=DELETE; PRAGMA foreign_keys=ON;").unwrap();
+        Db::run_migrations_up_to(&conn, 8).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_migration_009_converts_book_timestamps() {
+        let dir = TempDir::new().unwrap();
+        let conn = seed_v8(&dir);
+
+        // Cover every format chrono to_rfc3339() can emit.
+        let ts_bare      = "2024-01-15T12:34:56+00:00";           // no sub-second
+        let ts_millis    = "2024-06-15T12:34:56.789+00:00";       // 3 digits
+        let ts_nanos     = "2026-03-10T08:15:30.123456789+00:00"; // 9 digits
+        let ts_z         = "2025-12-25T00:00:00Z";                // Z suffix, no frac
+        let ts_z_millis  = "2025-12-25T00:00:00.500Z";            // Z suffix with millis
+
+        for (id, c, u) in [
+            ("b1", ts_bare, ts_millis),
+            ("b2", ts_nanos, ts_z),
+            ("b3", ts_z_millis, ts_bare),
+        ] {
+            conn.execute(
+                "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+                 VALUES (?1, 'T', 'A', 'books/x.epub', 'reading', 0, ?2, ?3)",
+                params![id, c, u],
+            ).unwrap();
+        }
+
+        Db::run_migrations_up_to(&conn, 9).unwrap();
+
+        // Verify column types are INTEGER.
+        let (ty_c, ty_u): (String, String) = {
+            let mut types = std::collections::HashMap::new();
+            let mut stmt = conn.prepare("PRAGMA table_info(books)").unwrap();
+            let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(1)?, r.get::<_, String>(2)?))).unwrap();
+            for row in rows {
+                let (n, t) = row.unwrap();
+                types.insert(n, t);
+            }
+            (types.remove("created_at").unwrap(), types.remove("updated_at").unwrap())
+        };
+        assert_eq!(ty_c, "INTEGER");
+        assert_eq!(ty_u, "INTEGER");
+
+        // Verify values.
+        for (id, expected_c, expected_u) in [
+            ("b1", rfc3339_to_millis(ts_bare), rfc3339_to_millis(ts_millis)),
+            ("b2", rfc3339_to_millis(ts_nanos), rfc3339_to_millis(ts_z)),
+            ("b3", rfc3339_to_millis(ts_z_millis), rfc3339_to_millis(ts_bare)),
+        ] {
+            let (c, u): (i64, i64) = conn.query_row(
+                "SELECT created_at, updated_at FROM books WHERE id = ?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            ).unwrap();
+            assert_eq!(c, expected_c, "book {id} created_at mismatch");
+            assert_eq!(u, expected_u, "book {id} updated_at mismatch");
+        }
+    }
+
+    #[test]
+    fn test_migration_009_adds_updated_at_to_append_only_tables() {
+        let dir = TempDir::new().unwrap();
+        let conn = seed_v8(&dir);
+
+        // Parent book.
+        let book_ts = "2024-01-15T12:34:56+00:00";
+        conn.execute(
+            "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+             VALUES ('b1', 'T', 'A', 'books/x.epub', 'reading', 0, ?1, ?1)",
+            params![book_ts],
+        ).unwrap();
+
+        // Bookmark, highlight (both had only created_at pre-migration).
+        let bm_ts = "2024-02-20T08:00:00+00:00";
+        conn.execute(
+            "INSERT INTO bookmarks (id, book_id, cfi, created_at)
+             VALUES ('bm1', 'b1', 'epubcfi(/6/4!)', ?1)",
+            params![bm_ts],
+        ).unwrap();
+        let hl_ts = "2024-03-01T10:30:45.500+00:00";
+        conn.execute(
+            "INSERT INTO highlights (id, book_id, cfi_range, color, created_at)
+             VALUES ('hl1', 'b1', 'epubcfi(/6/4!/2)', 'yellow', ?1)",
+            params![hl_ts],
+        ).unwrap();
+
+        // Translation + chat_message (also created_at-only).
+        let tr_ts = "2024-04-10T14:15:00+00:00";
+        conn.execute(
+            "INSERT INTO translations (id, book_id, source_text, translated_text, target_language, created_at)
+             VALUES ('tr1', 'b1', 'hello', '你好', 'zh', ?1)",
+            params![tr_ts],
+        ).unwrap();
+
+        let chat_ts = "2024-05-15T09:00:00+00:00";
+        conn.execute(
+            "INSERT INTO chats (id, book_id, title, pinned, created_at, updated_at)
+             VALUES ('c1', 'b1', 'Chat', 0, ?1, ?1)",
+            params![chat_ts],
+        ).unwrap();
+        let msg_ts = "2024-05-15T09:00:05+00:00";
+        conn.execute(
+            "INSERT INTO chat_messages (id, chat_id, role, content, created_at)
+             VALUES ('m1', 'c1', 'user', 'hi', ?1)",
+            params![msg_ts],
+        ).unwrap();
+
+        Db::run_migrations_up_to(&conn, 9).unwrap();
+
+        // For append-only tables, updated_at should equal created_at.
+        for (sql, expected) in [
+            ("SELECT created_at, updated_at FROM bookmarks WHERE id = 'bm1'", rfc3339_to_millis(bm_ts)),
+            ("SELECT created_at, updated_at FROM highlights WHERE id = 'hl1'", rfc3339_to_millis(hl_ts)),
+            ("SELECT created_at, updated_at FROM translations WHERE id = 'tr1'", rfc3339_to_millis(tr_ts)),
+            ("SELECT created_at, updated_at FROM chat_messages WHERE id = 'm1'", rfc3339_to_millis(msg_ts)),
+        ] {
+            let (c, u): (i64, i64) = conn.query_row(sql, [], |r| Ok((r.get(0)?, r.get(1)?))).unwrap();
+            assert_eq!(c, expected, "{sql}: created_at mismatch");
+            assert_eq!(u, expected, "{sql}: updated_at should equal created_at for append-only tables");
+        }
+    }
+
+    #[test]
+    fn test_migration_009_collection_books_backfilled_with_migration_time() {
+        let dir = TempDir::new().unwrap();
+        let conn = seed_v8(&dir);
+
+        let book_ts = "2024-01-15T12:34:56+00:00";
+        conn.execute(
+            "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+             VALUES ('b1', 'T', 'A', 'books/x.epub', 'reading', 0, ?1, ?1)",
+            params![book_ts],
+        ).unwrap();
+        let coll_ts = "2024-02-01T00:00:00+00:00";
+        conn.execute(
+            "INSERT INTO collections (id, name, sort_order, created_at) VALUES ('c1', 'Favorites', 0, ?1)",
+            params![coll_ts],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO collection_books (collection_id, book_id) VALUES ('c1', 'b1')",
+            [],
+        ).unwrap();
+
+        let before_migrate_ms = chrono::Utc::now().timestamp_millis();
+        Db::run_migrations_up_to(&conn, 9).unwrap();
+        let after_migrate_ms = chrono::Utc::now().timestamp_millis();
+
+        let (c, u): (i64, i64) = conn.query_row(
+            "SELECT created_at, updated_at FROM collection_books WHERE collection_id = 'c1' AND book_id = 'b1'",
+            [], |r| Ok((r.get(0)?, r.get(1)?)),
+        ).unwrap();
+        // Backfilled with migration time — within the bracket [before, after].
+        assert!(c >= before_migrate_ms - 1000 && c <= after_migrate_ms + 1000, "created_at {c} not in bracket");
+        assert!(u >= before_migrate_ms - 1000 && u <= after_migrate_ms + 1000, "updated_at {u} not in bracket");
+    }
+
+    #[test]
+    fn test_migration_009_vocab_next_review_nullable_preserved() {
+        let dir = TempDir::new().unwrap();
+        let conn = seed_v8(&dir);
+
+        let book_ts = "2024-01-15T12:34:56+00:00";
+        conn.execute(
+            "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+             VALUES ('b1', 'T', 'A', 'books/x.epub', 'reading', 0, ?1, ?1)",
+            params![book_ts],
+        ).unwrap();
+
+        // One vocab with next_review_at set, one without.
+        let nr_ts = "2024-07-01T00:00:00+00:00";
+        conn.execute(
+            "INSERT INTO vocab_words (id, book_id, word, definition, mastery, review_count, next_review_at, created_at, updated_at)
+             VALUES ('v1', 'b1', 'hello', 'greeting', 'new', 0, ?1, ?2, ?2)",
+            params![nr_ts, book_ts],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO vocab_words (id, book_id, word, definition, mastery, review_count, next_review_at, created_at, updated_at)
+             VALUES ('v2', 'b1', 'world', 'planet', 'new', 0, NULL, ?1, ?1)",
+            params![book_ts],
+        ).unwrap();
+
+        Db::run_migrations_up_to(&conn, 9).unwrap();
+
+        let nr1: Option<i64> = conn.query_row(
+            "SELECT next_review_at FROM vocab_words WHERE id = 'v1'", [], |r| r.get(0),
+        ).unwrap();
+        let nr2: Option<i64> = conn.query_row(
+            "SELECT next_review_at FROM vocab_words WHERE id = 'v2'", [], |r| r.get(0),
+        ).unwrap();
+        assert_eq!(nr1, Some(rfc3339_to_millis(nr_ts)));
+        assert_eq!(nr2, None);
+    }
+
+    #[test]
+    fn test_migration_009_preserves_row_counts_and_fk_integrity() {
+        let dir = TempDir::new().unwrap();
+        let conn = seed_v8(&dir);
+
+        // Seed every table with some rows.
+        let ts = "2024-06-15T12:00:00+00:00";
+        for i in 0..5 {
+            conn.execute(
+                "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+                 VALUES (?1, 'T', 'A', 'books/x.epub', 'reading', 0, ?2, ?2)",
+                params![format!("b{i}"), ts],
+            ).unwrap();
+        }
+        for i in 0..3 {
+            conn.execute(
+                "INSERT INTO bookmarks (id, book_id, cfi, created_at) VALUES (?1, 'b0', 'cfi', ?2)",
+                params![format!("bm{i}"), ts],
+            ).unwrap();
+        }
+        for i in 0..4 {
+            conn.execute(
+                "INSERT INTO highlights (id, book_id, cfi_range, color, created_at) VALUES (?1, 'b1', 'cfi', 'yellow', ?2)",
+                params![format!("hl{i}"), ts],
+            ).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO collections (id, name, sort_order, created_at) VALUES ('c1', 'Top', 0, ?1)",
+            params![ts],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO collection_books (collection_id, book_id) VALUES ('c1', 'b0'), ('c1', 'b1')",
+            [],
+        ).unwrap();
+
+        let counts_before: Vec<(String, i64)> = [
+            "books", "bookmarks", "highlights", "collections", "collection_books",
+            "vocab_words", "chats", "chat_messages", "translations",
+        ]
+        .iter()
+        .map(|t| {
+            let n: i64 = conn
+                .query_row(&format!("SELECT COUNT(*) FROM {t}"), [], |r| r.get(0))
+                .unwrap();
+            (t.to_string(), n)
+        })
+        .collect();
+
+        Db::run_migrations_up_to(&conn, 9).unwrap();
+
+        // Row counts unchanged.
+        for (t, expected) in counts_before {
+            let n: i64 = conn
+                .query_row(&format!("SELECT COUNT(*) FROM {t}"), [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(n, expected, "{t} row count changed");
+        }
+
+        // FK integrity post-migration.
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        let violations: i64 = conn
+            .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(violations, 0, "foreign key violations after migration");
+    }
+
+    #[test]
+    fn test_migration_009_malformed_timestamp_rolls_back() {
+        let dir = TempDir::new().unwrap();
+        let conn = seed_v8(&dir);
+
+        let ts = "2024-06-15T12:00:00+00:00";
+        conn.execute(
+            "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+             VALUES ('b1', 'T', 'A', 'books/x.epub', 'reading', 0, ?1, ?1)",
+            params![ts],
+        ).unwrap();
+        // Inject a malformed timestamp — julianday returns NULL, the NOT NULL
+        // INSERT fails, the whole migration rolls back.
+        conn.execute(
+            "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+             VALUES ('b2', 'Bad', 'A', 'books/y.epub', 'reading', 0, 'not a date', ?1)",
+            params![ts],
+        ).unwrap();
+
+        let result = Db::run_migrations_up_to(&conn, 9);
+        assert!(result.is_err(), "migration should fail on malformed timestamp");
+
+        // Schema is unchanged: created_at is still TEXT, both rows still present.
+        let ty: String = conn.query_row(
+            "SELECT type FROM pragma_table_info('books') WHERE name = 'created_at'",
+            [], |r| r.get(0),
+        ).unwrap();
+        assert_eq!(ty, "TEXT", "books.created_at should still be TEXT after rollback");
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "rows should still be present after rollback");
+
+        // schema_version should still be 8.
+        let v: i64 = conn
+            .query_row("SELECT version FROM schema_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, 8, "schema_version should not advance on failed migration");
     }
 }

--- a/src/components/ChatsContent.tsx
+++ b/src/components/ChatsContent.tsx
@@ -37,7 +37,7 @@ export default function ChatsContent() {
   const sorted = useMemo(() => {
     const copy = [...filtered];
     if (sort === "oldest") {
-      copy.sort((a, b) => a.updated_at.localeCompare(b.updated_at));
+      copy.sort((a, b) => a.updated_at - b.updated_at);
     }
     return copy;
   }, [filtered, sort]);

--- a/src/components/DictionaryContent.tsx
+++ b/src/components/DictionaryContent.tsx
@@ -45,7 +45,7 @@ export default function DictionaryContent() {
   const sorted = useMemo(() => {
     const copy = [...filtered];
     if (sort === "oldest") {
-      copy.sort((a, b) => a.created_at.localeCompare(b.created_at));
+      copy.sort((a, b) => a.created_at - b.created_at);
     } else if (sort === "az") {
       copy.sort((a, b) => a.word.localeCompare(b.word, undefined, { sensitivity: "base" }));
     }

--- a/src/components/TranslationsContent.tsx
+++ b/src/components/TranslationsContent.tsx
@@ -42,7 +42,7 @@ export default function TranslationsContent() {
   const sorted = useMemo(() => {
     const copy = [...filtered];
     if (sort === "oldest") {
-      copy.sort((a, b) => a.created_at.localeCompare(b.created_at));
+      copy.sort((a, b) => a.created_at - b.created_at);
     }
     return copy;
   }, [filtered, sort]);

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -18,8 +18,8 @@ interface ChatRecord {
   model: string | null;
   pinned: boolean;
   metadata: string | null;
-  created_at: string;
-  updated_at: string;
+  created_at: number;
+  updated_at: number;
 }
 
 interface ChatMsgRecord {
@@ -29,7 +29,8 @@ interface ChatMsgRecord {
   content: string;
   context: string | null;
   metadata: string | null;
-  created_at: string;
+  created_at: number;
+  updated_at: number;
 }
 
 /** Derive a short title from the user's first message (truncated at word boundary). */

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -6,7 +6,8 @@ export interface Bookmark {
   book_id: string;
   cfi: string;
   label: string | null;
-  created_at: string;
+  created_at: number;
+  updated_at: number;
 }
 
 export interface Highlight {
@@ -16,7 +17,8 @@ export interface Highlight {
   color: string;
   note: string | null;
   text_content: string | null;
-  created_at: string;
+  created_at: number;
+  updated_at: number;
 }
 
 export function useBookmarks(bookId: string) {

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -15,8 +15,8 @@ export interface Book {
   status: "reading" | "finished" | "unread";
   progress: number;
   current_cfi: string | null;
-  created_at: string;
-  updated_at: string;
+  created_at: number;
+  updated_at: number;
   available: boolean;
 }
 

--- a/src/hooks/useChats.ts
+++ b/src/hooks/useChats.ts
@@ -8,8 +8,8 @@ export interface ChatSummary {
   model: string | null;
   pinned: boolean;
   metadata: string | null;
-  created_at: string;
-  updated_at: string;
+  created_at: number;
+  updated_at: number;
   book_title: string | null;
   message_count: number | null;
   last_message: string | null;

--- a/src/hooks/useCollections.ts
+++ b/src/hooks/useCollections.ts
@@ -6,7 +6,8 @@ export interface Collection {
   name: string;
   book_count: number;
   sort_order: number;
-  created_at: string;
+  created_at: number;
+  updated_at: number;
 }
 
 export function useCollections() {

--- a/src/hooks/useDictionary.ts
+++ b/src/hooks/useDictionary.ts
@@ -10,9 +10,9 @@ export interface DictionaryWord {
   cfi: string | null;
   mastery: string;
   review_count: number;
-  next_review_at: string | null;
-  created_at: string;
-  updated_at: string;
+  next_review_at: number | null;
+  created_at: number;
+  updated_at: number;
   book_title: string | null;
 }
 

--- a/src/hooks/useTranslations.ts
+++ b/src/hooks/useTranslations.ts
@@ -8,7 +8,8 @@ export interface SavedTranslation {
   translated_text: string;
   target_language: string;
   cfi: string | null;
-  created_at: string;
+  created_at: number;
+  updated_at: number;
   book_title?: string | null;
 }
 

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -49,7 +49,7 @@ export default function DictionaryPage() {
   const sorted = useMemo(() => {
     const copy = [...filtered];
     if (sort === "oldest") {
-      copy.sort((a, b) => a.created_at.localeCompare(b.created_at));
+      copy.sort((a, b) => a.created_at - b.created_at);
     } else if (sort === "az") {
       copy.sort((a, b) => a.word.localeCompare(b.word, undefined, { sensitivity: "base" }));
     }

--- a/src/utils/timeAgo.ts
+++ b/src/utils/timeAgo.ts
@@ -1,10 +1,10 @@
 import i18n from "../i18n";
 
-export function timeAgo(dateStr: string): string {
+/** Relative-time formatter. Input is a unix timestamp in **milliseconds** — the
+ *  shape returned by all Tauri commands since migration 009. */
+export function timeAgo(millis: number): string {
   const t = i18n.t.bind(i18n);
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diff = now - then;
+  const diff = Date.now() - millis;
   if (diff < 60000) return t("time.justNow");
   const minutes = Math.floor(diff / 60000);
   if (minutes < 60) return t("time.minutesAgo", { count: minutes });


### PR DESCRIPTION
## Summary

Chunk 1 of 9 in the per-device event log sync plan (#185). **Does not close #185** — this is foundational schema work; the sync engine itself comes in later chunks.

Purely a schema + type refactor with no user-facing behavior change. Gives every synced table a uniform shape and an integer time representation so the upcoming sync merge engine can use native LWW comparisons instead of brittle string-lex order on RFC-3339 strings.

- Migration 009 rebuilds every synced table via SQLite's 12-step pattern (CREATE `_new`, INSERT SELECT with TEXT→INTEGER conversion, DROP, RENAME). Single transaction with FK off around it — any failure rolls the whole DB back byte-identical.
- Conversion formula: `strftime('%s') * 1000 + substr(strftime('%f'), -3)`. Exact at millisecond precision for every RFC-3339 variant chrono emits (bare / `.SSS` / nanoseconds / `Z` / `+HH:MM`). julianday was avoided because its double arithmetic loses ±1ms at today's millis magnitudes.
- Every synced table ends at `created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL`. `collection_books` gains both (backfilled with migration time). bookmarks / highlights / collections / chat_messages / translations gain `updated_at` (backfilled from `created_at`).
- Rust structs: every timestamp `String` → `i64` (`Option<String>` → `Option<i64>`). All `to_rfc3339()` → `timestamp_millis()`. Row mappers updated. Write sites for newly-normalized tables now set `updated_at`.
- Frontend: TS interfaces timestamp fields `string` → `number`. `timeAgo` signature updated. `localeCompare` on timestamps → numeric subtraction.
- Bonus framework fix: `schema_version` now advances per-migration instead of only at the end of the loop, so a future migration's failure can't force successful earlier migrations to re-run.

## Why int64 millis (vs. just normalizing TEXT format)

- Native integer comparison for LWW in the upcoming merge engine — no string-lex format traps.
- Aligns with the 48-bit millis embedded in every ULID the sync events will use.
- JS `number` holds unix millis trivially (`Date.now()` returns exactly this shape; safe-int range gives ~285k years of headroom).

Docs: `docs/impls/31-sync.md` updated — event format (`ts: i64` JSON number), Schema normalization section with the TEXT→INTEGER mechanics, Chunk 1 description reflects the type change.

## Test plan

- [x] `cargo test --lib` — 68 passed, 0 failed (including 6 new migration 009 integrity tests)
- [x] `cargo check` — clean
- [x] `cargo clippy --lib` — no warnings
- [x] `tsc --noEmit` — clean
- [x] New integrity tests cover: format round-trip (bare / `.SSS` / nanos / `Z` / `+HH:MM`), append-only tables `updated_at = created_at`, `collection_books` migration-time backfill, nullable `next_review_at` preserved, row counts + FK integrity unchanged, malformed-input rollback leaves schema_version at 8
- [x] Verified on a real dev DB: schema advanced to v9, every table `INTEGER NOT NULL`, all rows decode to correct historical timestamps, 0 FK violations, 0 NULL timestamps
- [ ] CI green

Part of #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)