### PR TITLE
chore: release v0.9.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quill",
   "private": true,
-  "version": "0.9.14",
+  "version": "0.9.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "0.9.14"
+version = "0.9.15"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quill",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "identifier": "com.wycstudios.quill",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Version bump to v0.9.15.

Changes since v0.9.14:
- **refactor: normalize DB timestamps to int64 unix millis (#186)** — foundational schema work for the per-device event log sync (Chunk 1 of #185). Converts every synced table's timestamp from TEXT RFC-3339 to INTEGER unix millis via SQLite table-rebuild migration. No user-facing behavior change.

## Test plan
- [x] `cargo test --lib` green
- [x] `cargo check` / `cargo clippy` / `tsc --noEmit` clean
- [x] Real dev DB migrated cleanly to schema v9 with zero data loss