### PR TITLE
feat(sync): Chunk 3 — event schema, device identity, per-device log (#185)

### DIFF
--- a/docs/impls/README.md
+++ b/docs/impls/README.md
@@ -5,6 +5,8 @@ Detailed implementation plans for features and bug fixes. Numbers match the corr
 ## Plans
 
 - [15 — AI Translation](15-ai-translation.md)
-- [31 — Sync (per-device event log)](31-sync.md)
+- Sync
+- [31 — Sync (per-device event log)](sync/31-sync.md)
+- [31 — Sync Known Problems](sync/31-sync-known-problems.md)
 - [140 — Vocab Detail View](140-vocab-detail.md)
 - [146 — PDF Continuous Scroll Mode](146-pdf-scroll-mode.md)

--- a/docs/impls/sync/31-sync-known-problems.md
+++ b/docs/impls/sync/31-sync-known-problems.md
@@ -1,0 +1,116 @@
+# 31 — Sync Known Problems
+
+Companion notes for [31 — Sync (per-device event log)](31-sync.md).
+
+These are design gaps identified during plan review. Each now carries a
+resolution decision.
+
+## 1. SyncWriter failure asymmetry needs a repair path
+
+`SyncWriter::with_tx` currently assumes a rare partial failure is acceptable:
+append succeeds, commit fails, or vice versa. That is not a consensus problem,
+but it is still a correctness problem because `ReplayEngine::tick()` skips this
+device's own log. If an event is durable in the shared log but absent from the
+origin device's SQLite commit, peers can ingest it while the origin device has
+no built-in way to converge later.
+
+Required plan change:
+- replay self logs as a local crash-recovery path, or
+- persist locally-pending events and only publish/advance once both the event
+  append and SQL commit have completed.
+
+Preferred choice: a local outbox plus publish retry.
+
+### Resolution (accepted, folded into 31-sync.md)
+
+Adopted a two-part fix:
+
+1. **Use a local outbox (`_pending_publish`) plus commit-then-append**
+   (Step 3 / Chunk 5). `SyncWriter::with_tx` writes SQL changes and
+   serialized `EventBody` rows into `_pending_publish` inside the same SQL
+   transaction, commits, then flushes the outbox to the device log. That
+   bounds partial-failure outcomes so peers can only lag the origin, never
+   run ahead of it — the opposite order would produce an event visible to
+   peers with no corresponding local row, which is unrecoverable.
+2. **Have `ReplayEngine::tick()` drain `_pending_publish` before replay**
+   (Step 5 / Chunk 4), and still include the local device as a peer for
+   migration snapshot apply-back and idempotent own-log replay. Unpublished
+   events now live in the outbox, not in the log, so replay is no longer
+   responsible for discovering them.
+
+The pure self-log-replay alternative was rejected because it cannot recover
+the `commit succeeded, append never happened` case unless some separate
+local durable marker already exists.
+
+## 2. LWW rows need a stored tiebreak, not just `updated_at`
+
+The original plan sorted events globally by `(ts, device)` but only compared
+`existing.updated_at < event.ts` in most merge examples. That lost determinism
+when two devices wrote the same field in the same millisecond: the later event
+in `(ts, device)` order would be ignored because `updated_at == event.ts`.
+
+Required plan change:
+- for every LWW register, persist both the winning timestamp and the winning
+  device UUID (or an equivalent tiebreak field),
+- compare `(event.ts, event.device)` against `(stored_updated_at, stored_device)`
+  in merge helpers,
+- keep plain `updated_at` as the user-facing timestamp, but do not rely on it
+  alone for replay correctness.
+
+### Resolution (accepted, folded into 31-sync.md)
+
+Fix now by adding `updated_by_device TEXT NOT NULL` to every LWW-backed row:
+
+- `books`
+- `highlights`
+- `collections`
+- `collection_books`
+- `vocab_words`
+- `chats`
+
+Merge helpers compare `(event.ts, event.device)` against
+`(stored.updated_at, stored.updated_by_device)`, and local writes update both
+columns together. Migration 009 backfills legacy rows with a deterministic
+sentinel such as `'migration'`.
+
+This removes the same-millisecond determinism hole without changing the
+high-level model. The extra plumbing is acceptable for a core sync feature,
+and much cheaper than carrying a known split-brain caveat in the merge
+contract indefinitely.
+
+## 3. Conflict-copy migration must update the migrating device's local view
+
+The migration flow says conflict copies such as `quill (1).db` can be merged
+into one synthesized snapshot, but the plan also copies one source DB
+bit-exact into local `quill.db` and skips own snapshot/log replay afterward.
+That means peers may see the merged superset while the migrating device still
+boots from only the copied primary DB.
+
+Required plan change:
+- after synthesizing the merged migration snapshot, rebuild local `quill.db`
+  from that merged state instead of copying a single source DB verbatim, or
+- allow the migrating device to apply its own migration snapshot/log once so
+  local state matches what peers will later replay.
+
+Without this, conflicted-copy migration is not self-consistent on the device
+that performs it.
+
+### Resolution (accepted, folded into 31-sync.md)
+
+Falls out of Problem 1's fix: the launch-time `replay_engine.tick()` (Step
+5 / Chunk 6) now treats the local device as a peer, so the migration
+snapshot written under `logs/<self>.snapshot.json` is applied back to the
+migrating device's `quill.db` on the very next tick. `Snapshot::apply_peer`
+uses `INSERT OR IGNORE` + LWW, so rows present in the primary source DB
+(copied bit-exact at step 3 of `run_migration`) stay put, and extra rows
+from `quill (1).db`, `quill (2).db` merged into the snapshot land on local
+DB the same way they land on peers.
+
+The primary-DB bit-exact copy in `run_migration` step 3 is kept — it's a
+cheap starting point that preserves any row that might exist in the legacy
+DB but not in the event schema (future-proofing against columns the sync
+layer doesn't model). The self-replay then fills in the conflict-copy
+delta.
+
+No standalone plan change required beyond Problem 1's fix; 31-sync.md
+Step 7 now explicitly calls out the self-replay step.

--- a/docs/impls/sync/31-sync.md
+++ b/docs/impls/sync/31-sync.md
@@ -2,6 +2,7 @@
 
 **Issue:** [#185](https://github.com/yicheng47/quill/issues/185)
 **Spec:** [31 — Sync](../features/31-sync.md)
+**Known Problems:** [31 — Sync Known Problems](31-sync-known-problems.md)
 **Scope:** desktop only. iOS mirrors the same design and ships from `yicheng47/quill-ios` with its own impls doc once this one is proven. Event schema and merge rules below are the cross-platform contract.
 
 ## Context

--- a/docs/impls/sync/31-sync.md
+++ b/docs/impls/sync/31-sync.md
@@ -1,7 +1,7 @@
 # Sync — Per-Device Event Log (Desktop)
 
 **Issue:** [#185](https://github.com/yicheng47/quill/issues/185)
-**Spec:** [31 — Sync](../features/31-sync.md)
+**Spec:** [31 — Sync](../../features/31-sync.md)
 **Known Problems:** [31 — Sync Known Problems](31-sync-known-problems.md)
 **Scope:** desktop only. iOS mirrors the same design and ships from `yicheng47/quill-ios` with its own impls doc once this one is proven. Event schema and merge rules below are the cross-platform contract.
 
@@ -105,30 +105,53 @@ CREATE TABLE _tombstones (
   ts     INTEGER NOT NULL,              -- unix millis
   PRIMARY KEY (entity, id)
 );
+
+CREATE TABLE _pending_publish (
+  id         TEXT PRIMARY KEY,          -- local outbox row id (UUID)
+  ts         INTEGER NOT NULL,          -- event timestamp to publish
+  body_json  TEXT NOT NULL,             -- serialized EventBody JSON
+  created_at INTEGER NOT NULL           -- unix millis
+);
 ```
+
+`_replay_state` and `_tombstones` ship in migration 010 (Chunk 2, already on the umbrella branch). `_pending_publish` ships in migration 011 alongside Chunk 4, bundled with the `updated_by_device` column addition — see "Schema normalization" above for the why-bundled rationale. Chunk 4 is where the outbox first gets consumed (`ReplayEngine::tick()` drains it); Chunk 5's `SyncWriter::with_tx` is where rows first get inserted into it.
 
 Never appear in any event; never synced.
 
 ### Schema normalization — every synced table gets `created_at` + `updated_at` as `INTEGER` unix millis
 
+LWW-backed tables also get `updated_by_device TEXT NOT NULL` so equal-millisecond
+writes resolve deterministically by the tuple `(updated_at, updated_by_device)`.
+This applies to:
+- `books`
+- `highlights`
+- `collections`
+- `collection_books`
+- `vocab_words`
+- `chats`
+
 Before sync code lands, normalize every synced table to carry both `created_at` and `updated_at` as `INTEGER NOT NULL` storing unix time in **milliseconds**. Two changes in one migration:
 
 1. **Shape uniformity.** Every synced table carries both columns. Append-only tables get `updated_at` too — it just equals `created_at` and never changes — so the merge engine can LWW-compare against a single column name on every table, no per-table special cases.
 2. **Type change: TEXT → INTEGER millis.** LWW compares timestamps natively via integer order instead of string-lex order (which is brittle across RFC-3339 format variants — `to_rfc3339()` emits variable sub-second precision and `+00:00`, which string-compares incorrectly against `...Z` millis format). Int64 also aligns with the 48-bit millis embedded in every ULID, so the sync engine uses one time representation end-to-end.
+3. **Deterministic same-ms tiebreak.** Every LWW-backed row stores the device UUID that last won the register, so merge helpers can compare `(event.ts, event.device)` against `(stored.updated_at, stored.updated_by_device)` rather than dropping equal-ms writes nondeterministically.
 
-| Table | Today | After migration 009 |
-|---|---|---|
-| `books`, `vocab_words`, `chats` | `created_at TEXT`, `updated_at TEXT` | `created_at INTEGER`, `updated_at INTEGER` (unix millis) |
-| `bookmarks`, `highlights`, `collections`, `chat_messages`, `translations` | `created_at TEXT` only | both columns as `INTEGER` |
-| `vocab_words.next_review_at` | `TEXT` | `INTEGER` (nullable — represents a scheduled future instant) |
-| `collection_books` | no timestamps | both columns as `INTEGER`, backfilled with migration time |
-| `settings`, `book_settings`, `schema_version`, `secrets` | local-only | skip — never synced |
+| Table | Today | After migration 009 | After migration 011 (LWW tiebreak) |
+|---|---|---|---|
+| `books`, `vocab_words`, `chats` | `created_at TEXT`, `updated_at TEXT` | `created_at INTEGER`, `updated_at INTEGER` | + `updated_by_device TEXT NOT NULL DEFAULT 'migration'` |
+| `highlights`, `collections` | `created_at TEXT` only | `created_at INTEGER`, `updated_at INTEGER` | + `updated_by_device TEXT NOT NULL DEFAULT 'migration'` |
+| `collection_books` | no timestamps | `created_at INTEGER`, `updated_at INTEGER` | + `updated_by_device TEXT NOT NULL DEFAULT 'migration'` |
+| `bookmarks`, `chat_messages`, `translations` | `created_at TEXT` only | both columns as `INTEGER` | unchanged (append-only, not LWW-targeted) |
+| `vocab_words.next_review_at` | `TEXT` | `INTEGER` (nullable — scheduled future instant) | unchanged |
+| `settings`, `book_settings`, `schema_version`, `secrets` | local-only | skip — never synced | skip |
 
-**Migration mechanics.** SQLite can't retype a column in place, so the migration is Rust-driven (not a pure `.sql` file) and runs inside a single transaction: `ALTER TABLE ... ADD COLUMN <col>_ms INTEGER` on every affected column → iterate existing rows, parse the old TEXT via `chrono::DateTime::parse_from_rfc3339`, write `timestamp_millis()` into the new column → `DROP COLUMN` the old TEXT → `RENAME COLUMN <col>_ms TO <col>`. Any parse or SQL failure rolls the entire transaction back, so the DB is either fully migrated or identical to pre-migration. `schema_version` only advances on successful commit, so a crash mid-flight re-runs cleanly on next launch.
+**Migration 009 mechanics (shipped).** SQLite can't retype a column in place, so 009 rebuilds each affected table inside a single transaction: `CREATE TABLE <x>_new` with the final schema → `INSERT ... SELECT` converting timestamps in SQL via `CAST(strftime('%s', ts) AS INTEGER) * 1000 + CAST(substr(strftime('%f', ts), -3) AS INTEGER)` → `DROP` old table → `RENAME` new table. Any failure rolls the entire transaction back, so the DB is either fully migrated or identical to pre-migration. `schema_version` advances only on successful commit, so a crash mid-flight re-runs cleanly on next launch. Pure SQL (`src-tauri/migrations/009_normalize_timestamps.sql`), not Rust-driven.
+
+**Migration 011 — `updated_by_device` + `_pending_publish` (bundled).** Migration 009 shipped before Problem 2's resolution was adopted (see `31-sync-known-problems.md` §2), so it does not add `updated_by_device`. A follow-up migration 011 — landing alongside Chunk 4 — adds the column to the six LWW-backed tables via `ALTER TABLE ... ADD COLUMN updated_by_device TEXT NOT NULL DEFAULT 'migration'` and simultaneously creates the `_pending_publish` outbox (Problem 1's durable queue, originally slated for migration 010 before that migration shipped on the umbrella branch). Both changes are sync-infrastructure additions that the merge engine (Chunk 4) and `SyncWriter` (Chunk 5) depend on, so bundling them in one migration keeps the sync series coherent.
 
 **Frontend contract change.** Every Tauri command that returned a timestamp as `string` now returns `number`. TypeScript types switch `created_at: string` → `created_at: number`. Components rendering timestamps use `new Date(millis)` / `toLocaleString()` (or a shared formatter util) in place of ISO string display. This is the only outward-visible change; the UI behavior is unchanged.
 
-This lands as a single normalization commit (Chunk 1 below). It's a breaking internal change, not a feature — it's the moment before sync solidifies the format to fix the choice once.
+Chunk 1 below handles the 009 portion (already shipped via PR #186); 011 is scoped to Chunk 4.
 
 ---
 
@@ -145,13 +168,14 @@ This lands as a single normalization commit (Chunk 1 below). It's a breaking int
 - `src-tauri/src/sync/migration.rs` — one-shot migration from legacy file-sync
 - `src-tauri/src/sync/watcher.rs` — fs-notify wrapper (macOS FSEvents, Linux inotify)
 - `src-tauri/src/commands/sync.rs` — Tauri commands for settings UI
-- `src-tauri/src/migrations_009.rs` — Rust-driven migration 009 (schema normalization + TEXT→INTEGER millis conversion; see "Schema normalization" above)
-- `src-tauri/migrations/010_replay_state.sql` — creates `_replay_state` and `_tombstones`
+- `src-tauri/migrations/009_normalize_timestamps.sql` — pure-SQL migration 009 (schema normalization + TEXT→INTEGER millis conversion; see "Schema normalization" above). Shipped via PR #186.
+- `src-tauri/migrations/010_replay_state.sql` — creates `_replay_state` and `_tombstones`. On the umbrella branch via Chunk 2.
+- `src-tauri/migrations/011_lww_tiebreak_and_outbox.sql` — adds `updated_by_device` to the six LWW-backed tables and creates `_pending_publish`. Lands with Chunk 4.
 - `src/components/settings/LibrarySyncSettings.tsx`
 
 **Modified:**
 - `src-tauri/src/lib.rs` — wire sync module, register commands, spawn watcher task
-- `src-tauri/src/db.rs` — register migrations 009 and 010; helpers to write local-only rows
+- `src-tauri/src/db.rs` — register migrations 009, 010, and 011; helpers to write local-only rows
 - `src-tauri/src/commands/{bookmarks,books,collections,vocab,chats,translation,settings}.rs` — route every mutation through `SyncWriter`; in Chunk 1, additionally start writing `updated_at` on every INSERT/UPDATE to newly-normalized tables
 - `src-tauri/src/icloud.rs` — deprecated; keep only the legacy migration entry point used by the one-shot migration routine
 - `src/components/settings/ICloudSettings.tsx` → replaced by `LibrarySyncSettings.tsx`
@@ -274,7 +298,12 @@ sync_writer.with_tx(|tx, events| {
 })?;
 ```
 
-`SyncWriter::with_tx` opens the SQL transaction, runs the closure to collect events, appends them to the log, and commits the transaction together with the log fsync. Partial failure (log fsync fails after SQL commit, or vice versa): log at error and surface; the state machine is resilient because re-applying the same event on the next launch is a no-op (INSERT OR IGNORE + LWW guards).
+`SyncWriter::with_tx` opens a SQL transaction, runs the closure to collect events, writes those events into the local `_pending_publish` outbox inside the same transaction, **commits the transaction, then flushes `_pending_publish` into the device log** (single fsync). Order is deliberate: commit-then-append. The asymmetric failure modes:
+
+- SQL commit fails → nothing in log, nothing for peers to ingest. Self-consistent; user sees the error and retries.
+- SQL commit succeeds, log append fails → local row and `_pending_publish` rows are durable but no event published yet. This is recovered by retrying the outbox flush on the next launch/focus/manual sync tick. The inverted order ("append then commit") would produce the dual failure — event visible to peers without a local row — which is catastrophic because the origin device would have no principled way to reconstruct the missing SQL state.
+
+If the process crashes after appending to the log but before deleting the `_pending_publish` rows, the next outbox flush may publish the same logical event twice with a fresh ULID. This is acceptable because the merge rules are idempotent: add/delete events key on stable entity ids, and LWW events carry the same `(ts, payload)` and therefore converge to the same state. Partial failures are rare; the design guarantees that when they happen we fail toward "peers lag the origin" rather than "origin lags peers."
 
 **If sync is disabled** (user hasn't enabled it): the writer's `EventSink` is a no-op that discards events. Zero disk cost, uniform command signatures whether or not sync is on.
 
@@ -336,13 +365,17 @@ pub fn apply_event(tx: &Transaction, event: &Event) -> AppResult<()> {
             tx.execute("INSERT OR IGNORE INTO _tombstones (entity, id, ts) VALUES ('book', ?1, ?2)", params![id, event.ts])?;
         }
         EventBody::BookProgressSet { book, progress, cfi } => {
-            let existing_ts: Option<i64> = tx.query_row(
-                "SELECT updated_at FROM books WHERE id = ?1", params![book], |r| r.get(0),
+            let existing: Option<(i64, String)> = tx.query_row(
+                "SELECT updated_at, updated_by_device FROM books WHERE id = ?1",
+                params![book],
+                |r| Ok((r.get(0)?, r.get(1)?)),
             ).optional()?;
-            if existing_ts.map_or(true, |t| t < event.ts) {
+            if existing.map_or(true, |(ts, dev)| (ts, dev) < (event.ts, event.device.clone())) {
                 tx.execute(
-                    "UPDATE books SET progress = ?1, current_cfi = ?2, updated_at = ?3 WHERE id = ?4",
-                    params![progress, cfi, event.ts, book],
+                    "UPDATE books
+                     SET progress = ?1, current_cfi = ?2, updated_at = ?3, updated_by_device = ?4
+                     WHERE id = ?5",
+                    params![progress, cfi, event.ts, event.device, book],
                 )?;
             }
         }
@@ -369,7 +402,7 @@ pub fn apply_event(tx: &Transaction, event: &Event) -> AppResult<()> {
 
 Applying the same events in any order must produce the same SQLite state. Enforced by:
 1. Sorting by `(ts, device)` before apply.
-2. `INSERT OR IGNORE` for add-events; `WHERE updated_at < event_ts` for LWW-events.
+2. `INSERT OR IGNORE` for add-events; `WHERE (updated_at, updated_by_device) < (event_ts, event_device)` for LWW-events.
 3. Tombstone check **before** every add.
 
 Property test: shuffle N events, apply, assert `SELECT * FROM <every table> ORDER BY id` is byte-identical across runs.
@@ -391,15 +424,16 @@ impl<'a> ReplayEngine<'a> {
 ```
 
 `tick()`:
-1. List `<shared>/logs/*.jsonl` and `*.snapshot.json`. Skip own files.
-2. For each peer:
+0. Drain local `_pending_publish`: append any unpublished outbox rows to the device log, then delete them on success. This is the publish-retry path for Step 3's `commit succeeds, append fails` case.
+1. List `<shared>/logs/*.jsonl` and `*.snapshot.json`. **Include own files** — the local device is treated as a peer keyed by `self_device` in `_replay_state`. This is primarily for migration snapshot apply-back (Step 7) and for idempotent replay of already-published own-log events.
+2. For each peer (including self):
    a. If `snapshot_id > last_snapshot_id` in `_replay_state`: apply peer snapshot (step 6).
    b. Iterate log events with `id > last_event_id`. Collect.
 3. Merge all collected events across peers, sort by `(ts, device)`.
 4. Open a single SQL transaction, call `merge::apply_event` for each, update `_replay_state` per peer.
 5. Commit.
 
-**Invariant:** `tick()` is always safe to call. Concurrent calls are serialized by a process-wide mutex.
+**Invariant:** `tick()` is always safe to call. Concurrent calls are serialized by a process-wide mutex. Own events that were already applied to local SQL (the common case) cost one `SELECT updated_at` each and then skip.
 
 **Triggers:**
 - On app launch (before UI).
@@ -513,17 +547,17 @@ pub fn run_migration(
     shared_dir: &Path,                     // = ubiquity_dir in the iCloud case
     device_id: &str,
 ) -> AppResult<()> {
-    // 1. Build snapshot from old_db
+    // 1. Build snapshot from old_db (merged with any conflict copies — see below)
     let snap = Snapshot::from_legacy_db(&old_db, device_id)?;
 
     // 2. Write snapshot + empty log
     snap.write_atomic(shared_dir.join("logs").join(format!("{device_id}.snapshot.json")))?;
     EventLog::create_empty(shared_dir.join("logs").join(format!("{device_id}.jsonl")))?;
 
-    // 3. Copy ubiquity quill.db -> local quill.db (bit-exact)
+    // 3. Copy ubiquity quill.db -> local quill.db (bit-exact starting point)
     fs::copy(ubiquity_dir.join("quill.db"), local_dir.join("quill.db"))?;
 
-    // 4. Verify row counts
+    // 4. Verify row counts match the primary source DB
     verify_counts(&old_db, &Connection::open(local_dir.join("quill.db"))?, &snap)?;
 
     // 5. Flip the flag (durable)
@@ -535,6 +569,8 @@ pub fn run_migration(
     Ok(())
 }
 ```
+
+The caller in `lib.rs` always runs `replay_engine.tick()` after `run_migration` returns. Because Step 5's `tick()` now treats the local device as a peer, the snapshot written in step 2 is immediately applied back to local `quill.db`. This is how conflict-copy rows that don't exist in the primary source DB reach the migrating device — `Snapshot::apply_peer` uses `INSERT OR IGNORE` + LWW, so primary-copy rows stay put and extra rows from `quill (1).db`, `quill (2).db` are merged in. Without this step the migrating device would only see the primary DB's rows while peers see the full union. (See `31-sync-known-problems.md` §3.)
 
 `Snapshot::from_legacy_db` reads every synced table, packs into snapshot format. Timestamps:
 - Use the row's `updated_at` if present, else `created_at`, else `MIGRATION_TS` (`2000-01-01T00:00:00Z`).
@@ -614,15 +650,15 @@ Cross-device testing against iOS is blocked until quill-ios ships its mirror —
 
 Cross-cutting work — land as a sequence of narrow PRs, each independently reviewable and leaving the app in a working state. The user-facing switch doesn't flip until Chunk 7.
 
-### Chunk 1 — Schema normalization (standalone refactor, no sync code)
+### Chunk 1 — Schema normalization (standalone refactor, no sync code) — SHIPPED (PR #186)
 
-Shape + type normalization as a single commit. Lands separately from the sync work so the sync PR doesn't mix two concerns. Internally breaking (all Tauri commands that returned timestamps now return numbers) but no end-user behavior change.
+Shape + type normalization as a single commit. Landed separately from the sync work so the sync PR doesn't mix two concerns. Internally breaking (all Tauri commands that returned timestamps now return numbers) but no end-user behavior change.
 
 **Backend:**
-- `src-tauri/src/migrations_009.rs` — new module. Single `fn migrate(conn: &Connection) -> AppResult<()>` driven from `db.rs::run_migrations`. One transaction: ADD new `*_ms INTEGER` columns → backfill from existing TEXT via `chrono::DateTime::parse_from_rfc3339` → DROP old TEXT columns → RENAME `*_ms` to final names. Tables touched: `books`, `bookmarks`, `highlights`, `collections`, `collection_books` (adds both cols), `vocab_words` (incl. `next_review_at`), `chats`, `chat_messages`, `translations`.
-- `src-tauri/src/db.rs` — register migration 9 (call `migrations_009::migrate`); bump the two `assert_eq!(version, 8)` tests to 9.
-- `src-tauri/src/commands/{books,bookmarks,collections,vocab,chats,translation}.rs` — every `created_at: String` / `updated_at: String` / `next_review_at: Option<String>` struct field becomes `i64` / `Option<i64>`. Every `chrono::Utc::now().to_rfc3339()` becomes `chrono::Utc::now().timestamp_millis()`. Every row mapper reads `INTEGER` instead of `TEXT`. Commands on tables that previously lacked `updated_at` (bookmarks add, highlights add/color/note, collections rename/reorder, collection_books add, chat_messages add, translations add) now set it.
-- **Migration tests** (in `migrations_009.rs`): seed a fresh DB at schema v8 with realistic old-format TEXT timestamps across every affected table → run `migrate()` → assert (a) each new INTEGER equals `DateTime::parse_from_rfc3339(original).timestamp_millis()`; (b) row counts unchanged; (c) no NULL in any NOT NULL timestamp column; (d) rollback on injected parse failure leaves DB identical to v8 state.
+- `src-tauri/migrations/009_normalize_timestamps.sql` — pure SQL migration. Per-table rebuild inside one transaction: `CREATE TABLE <x>_new` with final INTEGER-timestamp schema → `INSERT ... SELECT` converting each TEXT timestamp via `CAST(strftime('%s', ts) AS INTEGER) * 1000 + CAST(substr(strftime('%f', ts), -3) AS INTEGER)` → `DROP` old → `RENAME`. Tables touched: `books`, `bookmarks`, `highlights`, `collections`, `collection_books` (adds both `created_at` and `updated_at`), `vocab_words` (incl. `next_review_at`), `chats`, `chat_messages`, `translations`. **Did not add `updated_by_device`** — deferred to migration 011 (Chunk 4).
+- `src-tauri/src/db.rs` — registered migration 9 via `include_str!`; per-migration `schema_version` bump so a later failure doesn't force 9 to re-run; bumped the `assert_eq!(version, 8)` tests to 9.
+- `src-tauri/src/commands/{books,bookmarks,collections,vocab,chats,translation}.rs` — every `created_at: String` / `updated_at: String` / `next_review_at: Option<String>` struct field became `i64` / `Option<i64>`. Every `chrono::Utc::now().to_rfc3339()` became `chrono::Utc::now().timestamp_millis()`. Every row mapper reads `INTEGER` instead of `TEXT`. Commands on tables that previously lacked `updated_at` (bookmarks add, highlights add/color/note, collections rename/reorder, collection_books add, chat_messages add, translations add) now set it. Writing `updated_by_device` is deferred to Chunk 4/5 when migration 011 adds the column.
+- **Migration tests** (in `db.rs::tests`): seed a v8 DB with realistic RFC-3339 TEXT timestamps across every affected table → run migration → assert (a) each INTEGER equals `DateTime::parse_from_rfc3339(original).timestamp_millis()`; (b) `collection_books` backfilled with migration time; (c) row counts unchanged; (d) malformed-timestamp injection rolls back the whole transaction leaving the DB at v8.
 
 **Frontend:**
 - TypeScript types: every timestamp field becomes `number` (likely in `src/types/` or inline interfaces — grep to find them all).
@@ -636,7 +672,7 @@ Shape + type normalization as a single commit. Lands separately from the sync wo
 ### Chunk 2 — Crates + sync module skeleton + `_replay_state`
 
 - `src-tauri/Cargo.toml` — add `ulid = "1"` (feature `serde`), `notify = "6"`. `cargo check` to sync `Cargo.lock`.
-- `src-tauri/migrations/010_replay_state.sql` — `_replay_state` and `_tombstones` tables.
+- `src-tauri/migrations/010_replay_state.sql` — `_replay_state` and `_tombstones` tables. `_pending_publish` lands in migration 011 with Chunk 4.
 - `src-tauri/src/db.rs` — register migration 10.
 - `src-tauri/src/sync/mod.rs` — declare submodules as empty stubs so `cargo check` compiles.
 - `src-tauri/src/lib.rs` — `mod sync;`.
@@ -653,27 +689,29 @@ Shape + type normalization as a single commit. Lands separately from the sync wo
 
 **Verification:** `cargo test --lib sync::` green. Not wired to the rest of the app yet.
 
-### Chunk 4 — Merge + replay + snapshot (pure)
+### Chunk 4 — Merge + replay + snapshot (pure) + migration 011
 
-- `src-tauri/src/sync/merge.rs` — `apply_event` match per `EventBody` variant (Step 4). Helpers: `lww_update_if_newer`, `is_tombstoned`, `insert_tombstone`. Every INSERT uses `OR IGNORE`; every LWW update compares `existing.updated_at < event.ts`; tombstone check precedes every add.
-- `src-tauri/src/sync/replay.rs` — `ReplayEngine::tick()` per Step 5. Lists peer logs + snapshots, skips own files, merges events sorted by `(ts, device)`, applies in one SQL tx. Process-wide `Mutex` serializes concurrent ticks.
+- `src-tauri/migrations/011_lww_tiebreak_and_outbox.sql` — `ALTER TABLE ... ADD COLUMN updated_by_device TEXT NOT NULL DEFAULT 'migration'` on `books`, `highlights`, `collections`, `collection_books`, `vocab_words`, `chats`. Plus `CREATE TABLE _pending_publish (...)`. Bundled because both additions are prerequisites for the merge engine (`updated_by_device` for LWW tiebreak) and `SyncWriter` (`_pending_publish` for the outbox); landing them together avoids a no-op migration number between them.
+- `src-tauri/src/db.rs` — register migration 11; bump test asserts from 10 to 11.
+- `src-tauri/src/sync/merge.rs` — `apply_event` match per `EventBody` variant (Step 4). Helpers: `lww_update_if_newer`, `is_tombstoned`, `insert_tombstone`. Every INSERT uses `OR IGNORE`; every LWW update compares `(existing.updated_at, existing.updated_by_device) < (event.ts, event.device)` in Rust (tuple compare); tombstone check precedes every add.
+- `src-tauri/src/sync/replay.rs` — `ReplayEngine::tick()` per Step 5. Drains `_pending_publish`, then lists peer logs + snapshots **including own** (local device treated as a peer for migration apply-back and idempotent own-log replay), merges events sorted by `(ts, device)`, applies in one SQL tx. Process-wide `Mutex` serializes concurrent ticks.
 - `src-tauri/src/sync/snapshot.rs` — `Snapshot::{from_log, write_atomic, apply_peer}` per Step 6. Apply follows the 6-step procedure exactly (stat → header parse → watermark compare → full parse → apply under tombstone guard → monotonic watermark update).
 
-**Tests:** merge determinism property test (shuffled apply → byte-identical `SELECT *`); tombstone wins; LWW correctness; snapshot equivalence (events vs snapshot+tail yield identical state).
+**Tests:** migration 011 seeds a v10 DB with LWW rows → applies migration → asserts `updated_by_device = 'migration'` on every row, `_pending_publish` exists and is empty; merge determinism property test (shuffled apply → byte-identical `SELECT *`); same-ms cross-device LWW tie resolves deterministically by device UUID; tombstone wins; LWW correctness; snapshot equivalence (events vs snapshot+tail yield identical state).
 
 **Verification:** `cargo test` green. Still not wired to any command.
 
 ### Chunk 5 — SyncWriter + command instrumentation
 
-- `src-tauri/src/sync/writer.rs` — `SyncWriter::with_tx<F>(f: F)` per Step 3. Opens SQL tx, passes `(tx, events: &mut Vec<EventBody>)` to closure, on success appends events to log (single fsync) and commits the tx. Disabled case: events vec dropped, tx commits normally. Progress-event debounce ring: per-book trailing 2-second window via `HashMap<book_id, Instant>`.
-- `src-tauri/src/commands/books.rs` — route `import_book`, `commit_pdf_import`, `delete_book`, `update_reading_progress`, `update_book_status`, `mark_finished`, `update_book_metadata` through `SyncWriter`.
-- `src-tauri/src/commands/bookmarks.rs` — all 6 commands; highlight writes also set `updated_at`.
-- `src-tauri/src/commands/collections.rs` — all 6 commands; `rename_collection` and `reorder_collections` also set `updated_at`.
-- `src-tauri/src/commands/vocab.rs`, `chats.rs`, `translation.rs` — remaining events per the Step 3 table.
+- `src-tauri/src/sync/writer.rs` — `SyncWriter::with_tx<F>(f: F)` per Step 3. Opens SQL tx, passes `(tx, events: &mut Vec<EventBody>)` to closure, writes the events into `_pending_publish`, commits the tx, then flushes `_pending_publish` into the log (single fsync). Order is deliberate — see Step 3 for the failure-mode rationale. Disabled case: events vec dropped, tx commits normally. Progress-event debounce ring: per-book trailing 2-second window via `HashMap<book_id, Instant>`.
+- `src-tauri/src/commands/books.rs` — route `import_book`, `commit_pdf_import`, `delete_book`, `update_reading_progress`, `update_book_status`, `mark_finished`, `update_book_metadata` through `SyncWriter`. Every LWW-table INSERT/UPDATE now also writes `updated_by_device = self_device_uuid` (migration 011 added the column; SyncWriter exposes the local device UUID to the closure).
+- `src-tauri/src/commands/bookmarks.rs` — all 6 commands; highlight writes also set `updated_at` and `updated_by_device` (highlights is LWW-backed).
+- `src-tauri/src/commands/collections.rs` — all 6 commands; `rename_collection`, `reorder_collections`, and `add_book_to_collection` write `updated_at` and `updated_by_device`.
+- `src-tauri/src/commands/vocab.rs`, `chats.rs`, `translation.rs` — remaining events per the Step 3 table. vocab_words and chats are LWW-backed → set `updated_by_device`; chat_messages and translations are append-only → no tiebreak column.
 - `src-tauri/src/commands/settings.rs` + `book_settings` path — explicitly no-op (local-only).
 - `src-tauri/src/lib.rs` — construct `SyncWriter::new(db, Option<Arc<EventLog>>)` once in `setup`, store in Tauri state. Commands now take `State<SyncWriter>` instead of `State<Db>`.
 
-**Tests:** for each command — sync off → no events; sync on → event content matches SQL write. Progress debounce: 10 rapid calls within 2s → exactly 1 event appended.
+**Tests:** for each command — sync off → no events; sync on → event content matches SQL write. Outbox retry: simulate `commit ok, append fails` and verify `_pending_publish` drains on the next flush. Progress debounce: 10 rapid calls within 2s → exactly 1 event appended.
 
 **Verification:** existing frontend works unchanged with sync off. `cargo test` green. Manual: import a book with sync off, confirm no log file.
 
@@ -689,7 +727,12 @@ Shape + type normalization as a single commit. Lands separately from the sync wo
   else if migration.complete:
       retire_ubiquity_db(...)   # self-healing
   open <local>/quill.db          # always local post-migration
-  replay_engine.tick()           # catch up from peer logs
+  replay_engine.tick()           # first drains _pending_publish, then
+                                 # catches up from peer logs AND own log
+                                 # (self-replay handles:
+                                 #   (a) conflict-copy snapshot → local DB
+                                 #   (b) idempotent apply of already-published
+                                 #       own-log events)
   spawn watcher if sync enabled
   ```
 - `src-tauri/src/commands/sync.rs` — `sync_now` command (manual tick).

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3022,6 +3022,7 @@ name = "quill"
 version = "0.9.15"
 dependencies = [
  "base64 0.22.1",
+ "block2",
  "chrono",
  "epub",
  "futures",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,7 +42,8 @@ notify = "6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSFileManager", "NSString", "NSURL", "NSError"] }
+objc2-foundation = { version = "0.3", features = ["NSFileManager", "NSFileCoordinator", "NSString", "NSURL", "NSError", "block2"] }
+block2 = "0.6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/sync/device.rs
+++ b/src-tauri/src/sync/device.rs
@@ -1,2 +1,99 @@
-//! Device identity — UUID + created_at persisted to `device.json` in the
-//! local app data dir. Populated in Chunk 3.
+//! Stable device identifier — persisted once per install in the local app
+//! data dir. The UUID is the per-device log filename (`logs/<uuid>.jsonl`)
+//! and the `device` field on every emitted event.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+
+const DEVICE_FILE: &str = "device.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceIdentity {
+    pub device_uuid: String,
+    /// Unix millis when this identity was first created on this install.
+    pub created_at: i64,
+}
+
+impl DeviceIdentity {
+    /// Read `device.json` if it exists; otherwise mint a fresh identity and
+    /// persist it atomically. Always returns the same identity for the life
+    /// of an install — only deleting the file regenerates it (which effectively
+    /// makes the machine a new peer as far as sync is concerned).
+    pub fn load_or_create(local_dir: &Path) -> AppResult<Self> {
+        let path = local_dir.join(DEVICE_FILE);
+        if path.exists() {
+            let bytes = fs::read(&path)?;
+            let id: DeviceIdentity = serde_json::from_slice(&bytes)
+                .map_err(|e| AppError::Other(format!("device.json parse: {e}")))?;
+            return Ok(id);
+        }
+
+        let id = DeviceIdentity {
+            device_uuid: Uuid::new_v4().to_string(),
+            created_at: Utc::now().timestamp_millis(),
+        };
+        write_atomic(&path, &id)?;
+        Ok(id)
+    }
+
+    pub fn path(local_dir: &Path) -> PathBuf {
+        local_dir.join(DEVICE_FILE)
+    }
+}
+
+fn write_atomic(path: &Path, id: &DeviceIdentity) -> AppResult<()> {
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_vec_pretty(id)
+        .map_err(|e| AppError::Other(format!("device.json encode: {e}")))?;
+    fs::write(&tmp, &json)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn mints_on_first_call() {
+        let dir = TempDir::new().unwrap();
+        let id = DeviceIdentity::load_or_create(dir.path()).unwrap();
+        assert_eq!(id.device_uuid.len(), 36, "UUIDv4 has 36 chars");
+        assert!(id.created_at > 0);
+        assert!(DeviceIdentity::path(dir.path()).exists());
+    }
+
+    #[test]
+    fn stable_across_calls() {
+        let dir = TempDir::new().unwrap();
+        let a = DeviceIdentity::load_or_create(dir.path()).unwrap();
+        let b = DeviceIdentity::load_or_create(dir.path()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn survives_raw_file_read() {
+        // What's on disk must parse back identically.
+        let dir = TempDir::new().unwrap();
+        let a = DeviceIdentity::load_or_create(dir.path()).unwrap();
+        let raw = std::fs::read(DeviceIdentity::path(dir.path())).unwrap();
+        let parsed: DeviceIdentity = serde_json::from_slice(&raw).unwrap();
+        assert_eq!(a, parsed);
+    }
+
+    #[test]
+    fn regenerates_if_file_deleted() {
+        let dir = TempDir::new().unwrap();
+        let a = DeviceIdentity::load_or_create(dir.path()).unwrap();
+        std::fs::remove_file(DeviceIdentity::path(dir.path())).unwrap();
+        let b = DeviceIdentity::load_or_create(dir.path()).unwrap();
+        assert_ne!(a.device_uuid, b.device_uuid);
+    }
+}

--- a/src-tauri/src/sync/events.rs
+++ b/src-tauri/src/sync/events.rs
@@ -82,6 +82,11 @@ pub enum EventBody {
         id: String,
         mastery: String,
         next_review_at: Option<i64>,
+        /// Absolute review count after the writer's increment. Carrying it
+        /// as an absolute value (not a delta) keeps replay idempotent — a
+        /// snapshot rebuild that re-applies the same event lands on the
+        /// same number instead of double-counting.
+        review_count: i64,
     },
     #[serde(rename = "vocab.delete")]
     VocabDelete { id: String },
@@ -288,6 +293,7 @@ mod tests {
             id: "v1".into(),
             mastery: "learning".into(),
             next_review_at: Some(1_714_942_800_000),
+            review_count: 3,
         }));
         roundtrip(&mk(EventBody::VocabDelete { id: "v1".into() }));
     }

--- a/src-tauri/src/sync/events.rs
+++ b/src-tauri/src/sync/events.rs
@@ -1,2 +1,404 @@
-//! Event schema — `Event` + `EventBody` enum written by every mutating
-//! command and consumed by `merge::apply_event`. Populated in Chunk 3.
+//! Event schema — the wire format every mutating command writes into the
+//! per-device log and every replay tick consumes.
+//!
+//! An `Event` is one line of JSON in `<device>.jsonl`. It has a fixed
+//! envelope (`id`, `ts`, `device`, `v`) plus a tagged body discriminated by
+//! the `type` field. Unknown top-level fields are captured in `extra` so a
+//! future schema version can add metadata without breaking old readers that
+//! re-serialize the event back into a snapshot.
+//!
+//! Timestamps are `i64` unix milliseconds, matching the DB after migration
+//! 009. The `id` is a ULID string — its leading 48 bits encode the same
+//! millisecond, so sorting by `id` is equivalent to sorting by `(ts, tiebreak)`
+//! within a single device.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Schema version carried on every event. Bump when adding new fields that
+/// old clients cannot safely ignore.
+pub const EVENT_SCHEMA_VERSION: u32 = 1;
+
+/// One log line. Fields after `v` come from the tagged body and any unknown
+/// future fields land in `extra`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Event {
+    pub id: String,
+    pub ts: i64,
+    pub device: String,
+    pub v: u32,
+    #[serde(flatten)]
+    pub body: EventBody,
+    #[serde(flatten, default, skip_serializing_if = "Map::is_empty")]
+    pub extra: Map<String, Value>,
+}
+
+/// One variant per mutating command. The tag name on the wire is the
+/// dotted string in `#[serde(rename = "...")]` — it must match the names
+/// iOS and future clients will write, so don't change them casually.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
+pub enum EventBody {
+    #[serde(rename = "book.import")]
+    BookImport(BookImportPayload),
+    #[serde(rename = "book.delete")]
+    BookDelete { id: String },
+    #[serde(rename = "book.progress.set")]
+    BookProgressSet {
+        book: String,
+        progress: i32,
+        cfi: Option<String>,
+    },
+    #[serde(rename = "book.status.set")]
+    BookStatusSet { book: String, status: String },
+    #[serde(rename = "book.metadata.set")]
+    BookMetadataSet {
+        book: String,
+        field: String,
+        value: Value,
+    },
+
+    #[serde(rename = "highlight.add")]
+    HighlightAdd(HighlightPayload),
+    #[serde(rename = "highlight.delete")]
+    HighlightDelete { id: String },
+    #[serde(rename = "highlight.color.set")]
+    HighlightColorSet { id: String, color: String },
+    #[serde(rename = "highlight.note.set")]
+    HighlightNoteSet {
+        id: String,
+        note: Option<String>,
+    },
+
+    #[serde(rename = "bookmark.add")]
+    BookmarkAdd(BookmarkPayload),
+    #[serde(rename = "bookmark.delete")]
+    BookmarkDelete { id: String },
+
+    #[serde(rename = "vocab.add")]
+    VocabAdd(VocabPayload),
+    #[serde(rename = "vocab.mastery.set")]
+    VocabMasterySet {
+        id: String,
+        mastery: String,
+        next_review_at: Option<i64>,
+    },
+    #[serde(rename = "vocab.delete")]
+    VocabDelete { id: String },
+
+    #[serde(rename = "translation.add")]
+    TranslationAdd(TranslationPayload),
+    #[serde(rename = "translation.delete")]
+    TranslationDelete { id: String },
+
+    #[serde(rename = "collection.create")]
+    CollectionCreate {
+        id: String,
+        name: String,
+        sort_order: i32,
+    },
+    #[serde(rename = "collection.rename")]
+    CollectionRename { id: String, name: String },
+    #[serde(rename = "collection.reorder")]
+    CollectionReorder { id: String, sort_order: i32 },
+    #[serde(rename = "collection.delete")]
+    CollectionDelete { id: String },
+    #[serde(rename = "collection.book.add")]
+    CollectionBookAdd { collection: String, book: String },
+    #[serde(rename = "collection.book.remove")]
+    CollectionBookRemove { collection: String, book: String },
+
+    #[serde(rename = "chat.create")]
+    ChatCreate {
+        id: String,
+        book: String,
+        title: String,
+        model: Option<String>,
+    },
+    #[serde(rename = "chat.rename")]
+    ChatRename { id: String, title: String },
+    #[serde(rename = "chat.delete")]
+    ChatDelete { id: String },
+    #[serde(rename = "chat.message.add")]
+    ChatMessageAdd(ChatMessagePayload),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BookImportPayload {
+    pub id: String,
+    pub title: String,
+    pub author: String,
+    pub description: Option<String>,
+    pub cover_path: Option<String>,
+    pub file_path: String,
+    pub format: String,
+    pub genre: Option<String>,
+    pub pages: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HighlightPayload {
+    pub id: String,
+    pub book_id: String,
+    pub cfi_range: String,
+    pub color: String,
+    pub note: Option<String>,
+    pub text_content: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BookmarkPayload {
+    pub id: String,
+    pub book_id: String,
+    pub cfi: String,
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VocabPayload {
+    pub id: String,
+    pub book_id: String,
+    pub word: String,
+    pub definition: String,
+    pub context_sentence: Option<String>,
+    pub cfi: Option<String>,
+    pub mastery: String,
+    pub review_count: i64,
+    pub next_review_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TranslationPayload {
+    pub id: String,
+    pub book_id: String,
+    pub source_text: String,
+    pub translated_text: String,
+    pub target_language: String,
+    pub cfi: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatMessagePayload {
+    pub id: String,
+    pub chat_id: String,
+    pub role: String,
+    pub content: String,
+    pub context: Option<String>,
+    pub metadata: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn mk(body: EventBody) -> Event {
+        Event {
+            id: "01HYZX0000000000000000EVT1".to_string(),
+            ts: 1_714_770_000_000,
+            device: "11111111-2222-3333-4444-555555555555".to_string(),
+            v: EVENT_SCHEMA_VERSION,
+            body,
+            extra: Map::new(),
+        }
+    }
+
+    fn roundtrip(ev: &Event) {
+        let json = serde_json::to_string(ev).unwrap();
+        let back: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(ev, &back, "roundtrip mismatch; wire form was: {json}");
+    }
+
+    #[test]
+    fn roundtrip_book_events() {
+        roundtrip(&mk(EventBody::BookImport(BookImportPayload {
+            id: "b1".into(),
+            title: "War and Peace".into(),
+            author: "Tolstoy".into(),
+            description: Some("long".into()),
+            cover_path: Some("covers/b1.png".into()),
+            file_path: "books/b1.epub".into(),
+            format: "epub".into(),
+            genre: None,
+            pages: Some(1225),
+        })));
+        roundtrip(&mk(EventBody::BookDelete { id: "b1".into() }));
+        roundtrip(&mk(EventBody::BookProgressSet {
+            book: "b1".into(),
+            progress: 42,
+            cfi: Some("epubcfi(/6/4!/2[c01])".into()),
+        }));
+        roundtrip(&mk(EventBody::BookStatusSet {
+            book: "b1".into(),
+            status: "finished".into(),
+        }));
+        roundtrip(&mk(EventBody::BookMetadataSet {
+            book: "b1".into(),
+            field: "author".into(),
+            value: json!("Leo Tolstoy"),
+        }));
+    }
+
+    #[test]
+    fn roundtrip_highlight_events() {
+        roundtrip(&mk(EventBody::HighlightAdd(HighlightPayload {
+            id: "h1".into(),
+            book_id: "b1".into(),
+            cfi_range: "epubcfi(/6/4!/2,/1:10,/1:20)".into(),
+            color: "yellow".into(),
+            note: Some("important".into()),
+            text_content: Some("All happy families".into()),
+        })));
+        roundtrip(&mk(EventBody::HighlightDelete { id: "h1".into() }));
+        roundtrip(&mk(EventBody::HighlightColorSet {
+            id: "h1".into(),
+            color: "pink".into(),
+        }));
+        roundtrip(&mk(EventBody::HighlightNoteSet {
+            id: "h1".into(),
+            note: None,
+        }));
+    }
+
+    #[test]
+    fn roundtrip_bookmark_events() {
+        roundtrip(&mk(EventBody::BookmarkAdd(BookmarkPayload {
+            id: "bm1".into(),
+            book_id: "b1".into(),
+            cfi: "epubcfi(/6/4!)".into(),
+            label: Some("Chapter 1".into()),
+        })));
+        roundtrip(&mk(EventBody::BookmarkDelete { id: "bm1".into() }));
+    }
+
+    #[test]
+    fn roundtrip_vocab_events() {
+        roundtrip(&mk(EventBody::VocabAdd(VocabPayload {
+            id: "v1".into(),
+            book_id: "b1".into(),
+            word: "serendipity".into(),
+            definition: "a fortunate accident".into(),
+            context_sentence: Some("What serendipity!".into()),
+            cfi: None,
+            mastery: "new".into(),
+            review_count: 0,
+            next_review_at: Some(1_714_856_400_000),
+        })));
+        roundtrip(&mk(EventBody::VocabMasterySet {
+            id: "v1".into(),
+            mastery: "learning".into(),
+            next_review_at: Some(1_714_942_800_000),
+        }));
+        roundtrip(&mk(EventBody::VocabDelete { id: "v1".into() }));
+    }
+
+    #[test]
+    fn roundtrip_translation_events() {
+        roundtrip(&mk(EventBody::TranslationAdd(TranslationPayload {
+            id: "t1".into(),
+            book_id: "b1".into(),
+            source_text: "hello".into(),
+            translated_text: "你好".into(),
+            target_language: "zh".into(),
+            cfi: None,
+        })));
+        roundtrip(&mk(EventBody::TranslationDelete { id: "t1".into() }));
+    }
+
+    #[test]
+    fn roundtrip_collection_events() {
+        roundtrip(&mk(EventBody::CollectionCreate {
+            id: "c1".into(),
+            name: "Favorites".into(),
+            sort_order: 0,
+        }));
+        roundtrip(&mk(EventBody::CollectionRename {
+            id: "c1".into(),
+            name: "Top Reads".into(),
+        }));
+        roundtrip(&mk(EventBody::CollectionReorder {
+            id: "c1".into(),
+            sort_order: 3,
+        }));
+        roundtrip(&mk(EventBody::CollectionDelete { id: "c1".into() }));
+        roundtrip(&mk(EventBody::CollectionBookAdd {
+            collection: "c1".into(),
+            book: "b1".into(),
+        }));
+        roundtrip(&mk(EventBody::CollectionBookRemove {
+            collection: "c1".into(),
+            book: "b1".into(),
+        }));
+    }
+
+    #[test]
+    fn roundtrip_chat_events() {
+        roundtrip(&mk(EventBody::ChatCreate {
+            id: "ch1".into(),
+            book: "b1".into(),
+            title: "New chat".into(),
+            model: Some("claude-opus-4-6".into()),
+        }));
+        roundtrip(&mk(EventBody::ChatRename {
+            id: "ch1".into(),
+            title: "About Tolstoy".into(),
+        }));
+        roundtrip(&mk(EventBody::ChatDelete { id: "ch1".into() }));
+        roundtrip(&mk(EventBody::ChatMessageAdd(ChatMessagePayload {
+            id: "m1".into(),
+            chat_id: "ch1".into(),
+            role: "user".into(),
+            content: "hi".into(),
+            context: None,
+            metadata: None,
+        })));
+    }
+
+    #[test]
+    fn wire_format_matches_spec() {
+        // Frozen wire format — if someone changes this, iOS parsers break.
+        let ev = mk(EventBody::BookDelete { id: "b1".into() });
+        let v: Value = serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["type"], "book.delete");
+        assert_eq!(v["payload"]["id"], "b1");
+        assert_eq!(v["v"], 1);
+        assert_eq!(v["ts"], 1_714_770_000_000_i64);
+    }
+
+    #[test]
+    fn unknown_top_level_fields_preserved() {
+        // Forward-compat: a future client writes an extra top-level field.
+        // We read it, hold it in `extra`, and write it back verbatim.
+        let src = json!({
+            "id": "01HYZX0000000000000000EVT1",
+            "ts": 1_714_770_000_000_i64,
+            "device": "dev-a",
+            "v": 2,
+            "type": "book.delete",
+            "payload": { "id": "b1" },
+            "future_flag": "keep-me",
+            "future_obj": { "nested": true }
+        });
+        let ev: Event = serde_json::from_value(src.clone()).unwrap();
+        assert!(matches!(ev.body, EventBody::BookDelete { .. }));
+        assert_eq!(ev.extra.get("future_flag"), Some(&json!("keep-me")));
+        assert_eq!(ev.extra.get("future_obj"), Some(&json!({ "nested": true })));
+        let reserialized: Value = serde_json::to_value(&ev).unwrap();
+        assert_eq!(reserialized["future_flag"], "keep-me");
+        assert_eq!(reserialized["future_obj"]["nested"], true);
+    }
+
+    #[test]
+    fn empty_extra_is_omitted_from_wire() {
+        let ev = mk(EventBody::BookDelete { id: "b1".into() });
+        let json = serde_json::to_string(&ev).unwrap();
+        // No stray fields past the tagged body + envelope.
+        let v: Value = serde_json::from_str(&json).unwrap();
+        let keys: Vec<&String> = v.as_object().unwrap().keys().collect();
+        let expected: std::collections::HashSet<&str> =
+            ["id", "ts", "device", "v", "type", "payload"].into_iter().collect();
+        for k in keys {
+            assert!(expected.contains(k.as_str()), "unexpected key in wire form: {k}");
+        }
+    }
+}

--- a/src-tauri/src/sync/log.rs
+++ b/src-tauri/src/sync/log.rs
@@ -1,12 +1,20 @@
 //! Append-only JSONL log per device.
 //!
-//! Lives at `<shared>/logs/<device-uuid>.jsonl`. One line per event. Appends
-//! are serialized through a `Mutex<ulid::Generator>` so IDs stay monotonic
-//! within a process even under bursts, and fsync'd per batch for durability.
+//! Lives at `<shared>/logs/<device-uuid>.jsonl`. One line per event.
 //!
-//! On macOS every append is wrapped in `NSFileCoordinator` — see
-//! `sync/mod.rs` and `docs/impls/31-sync.md` for why. Non-macOS platforms
-//! use a plain POSIX append path.
+//! A single `Mutex<Inner>` covers both the `ulid::Generator` and the file
+//! append. This is load-bearing: without it two concurrent appends can
+//! generate IDs `id_A < id_B` but reach the file in the other order
+//! (`id_B\nid_A\n`), which permanently hides `id_A` from
+//! `read_after(last_id=id_B)`. Holding the lock across generation AND the
+//! write keeps the on-disk order strictly monotonic with the ID order.
+//!
+//! `NSFileCoordinator` wrapping is opt-in via `use_coordinator`. It's only
+//! meaningful when the file lives inside an iCloud ubiquity container —
+//! elsewhere the coordinator has no presenters to notify, so it's just
+//! overhead and (on some machines) a source of spurious
+//! `NSFileWriteUnknownError`. Callers pass `true` only when sync is enabled
+//! and writing to the iCloud path.
 
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
@@ -23,15 +31,22 @@ use super::events::{Event, EventBody, EVENT_SCHEMA_VERSION};
 pub struct EventLog {
     path: PathBuf,
     device: String,
-    gen: Mutex<ulid::Generator>,
+    use_coordinator: bool,
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    gen: ulid::Generator,
 }
 
 impl EventLog {
-    /// Open (or create) the log at `path`. Creates parent dirs. Safe to call
-    /// many times; each call yields an independent `EventLog` with its own
-    /// monotonic generator — callers are expected to hold one long-lived
-    /// instance and share it.
-    pub fn open(path: &Path, device: &str) -> AppResult<Self> {
+    /// Open (or create) the log at `path`. Creates parent dirs.
+    ///
+    /// `use_coordinator = true` wraps each append in `NSFileCoordinator` on
+    /// macOS; pass `true` when writing to an iCloud ubiquity container and
+    /// `false` for local-only paths (tests, future non-iCloud backends).
+    /// The flag is silently ignored on non-macOS platforms.
+    pub fn open(path: &Path, device: &str, use_coordinator: bool) -> AppResult<Self> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -40,7 +55,10 @@ impl EventLog {
         Ok(Self {
             path: path.to_path_buf(),
             device: device.to_string(),
-            gen: Mutex::new(ulid::Generator::new()),
+            use_coordinator,
+            inner: Mutex::new(Inner {
+                gen: ulid::Generator::new(),
+            }),
         })
     }
 
@@ -56,39 +74,40 @@ impl EventLog {
         Ok(out.pop().expect("append_batch returns one for one input"))
     }
 
-    /// Append many events atomically against the coordinator (single file
-    /// open + fsync). All events share the same `ts`; IDs are drawn from the
-    /// monotonic generator in order.
+    /// Append many events atomically (single file open + fsync).
+    ///
+    /// The `Inner` mutex is held for the entire method — both ULID
+    /// generation and the file write happen under it. See the module
+    /// docstring for why that's required.
     pub fn append_batch(&self, bodies: Vec<EventBody>, ts: i64) -> AppResult<Vec<Event>> {
         if bodies.is_empty() {
             return Ok(Vec::new());
         }
 
-        let events = {
-            let mut gen = self
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| AppError::Other(format!("EventLog inner lock poisoned: {e}")))?;
+
+        // ULID timestamps come from wall clock to preserve generator
+        // monotonicity across process restarts; `ts` on the event is the
+        // caller-supplied value (usually a few milliseconds earlier).
+        let now = SystemTime::now();
+        let mut events = Vec::with_capacity(bodies.len());
+        for body in bodies {
+            let ulid = inner
                 .gen
-                .lock()
-                .map_err(|e| AppError::Other(format!("EventLog gen lock poisoned: {e}")))?;
-            // ULID timestamps come from wall clock to preserve generator
-            // monotonicity across process restarts; `ts` on the event is the
-            // caller-supplied value (usually a few milliseconds earlier).
-            let now = SystemTime::now();
-            let mut events = Vec::with_capacity(bodies.len());
-            for body in bodies {
-                let ulid = gen
-                    .generate_from_datetime(now)
-                    .map_err(|e| AppError::Other(format!("ulid generate: {e:?}")))?;
-                events.push(Event {
-                    id: ulid.to_string(),
-                    ts,
-                    device: self.device.clone(),
-                    v: EVENT_SCHEMA_VERSION,
-                    body,
-                    extra: Map::new(),
-                });
-            }
-            events
-        };
+                .generate_from_datetime(now)
+                .map_err(|e| AppError::Other(format!("ulid generate: {e:?}")))?;
+            events.push(Event {
+                id: ulid.to_string(),
+                ts,
+                device: self.device.clone(),
+                v: EVENT_SCHEMA_VERSION,
+                body,
+                extra: Map::new(),
+            });
+        }
 
         let mut buf = Vec::with_capacity(events.len() * 256);
         for ev in &events {
@@ -96,7 +115,7 @@ impl EventLog {
                 .map_err(|e| AppError::Other(format!("event serialize: {e}")))?;
             buf.push(b'\n');
         }
-        append_bytes(&self.path, &buf)?;
+        append_bytes(&self.path, &buf, self.use_coordinator)?;
 
         Ok(events)
     }
@@ -144,18 +163,18 @@ impl EventLog {
     }
 }
 
-fn append_bytes(path: &Path, bytes: &[u8]) -> AppResult<()> {
+fn append_bytes(path: &Path, bytes: &[u8], use_coordinator: bool) -> AppResult<()> {
     #[cfg(target_os = "macos")]
     {
-        coordinated_append(path, bytes).map_err(AppError::Io)
+        if use_coordinator {
+            return coordinated_append(path, bytes).map_err(AppError::Io);
+        }
     }
     #[cfg(not(target_os = "macos"))]
-    {
-        naive_append(path, bytes).map_err(AppError::Io)
-    }
+    let _ = use_coordinator; // silence unused on non-macOS
+    naive_append(path, bytes).map_err(AppError::Io)
 }
 
-#[cfg(not(target_os = "macos"))]
 fn naive_append(path: &Path, bytes: &[u8]) -> io::Result<()> {
     let mut f = OpenOptions::new().create(true).append(true).open(path)?;
     f.write_all(bytes)?;
@@ -173,6 +192,9 @@ fn naive_append(path: &Path, bytes: &[u8]) -> io::Result<()> {
 // NSFileCoordinator's writing accessor tells presenters (including the
 // daemon) to pause, waits for in-flight downloads/uploads, materializes
 // placeholders, and hands us a URL to write through.
+//
+// Only meaningful on paths inside a ubiquity container. Callers gate via
+// `use_coordinator`.
 // -------------------------------------------------------------------------
 #[cfg(target_os = "macos")]
 fn coordinated_append(path: &Path, bytes: &[u8]) -> io::Result<()> {
@@ -205,12 +227,7 @@ fn coordinated_append(path: &Path, bytes: &[u8]) -> io::Result<()> {
                 return;
             }
         };
-        *inner_result.borrow_mut() = (|| -> io::Result<()> {
-            let mut f = OpenOptions::new().create(true).append(true).open(&target)?;
-            f.write_all(bytes)?;
-            f.sync_all()?;
-            Ok(())
-        })();
+        *inner_result.borrow_mut() = naive_append(&target, bytes);
     });
 
     let mut nserror: Option<objc2::rc::Retained<objc2_foundation::NSError>> = None;
@@ -233,6 +250,7 @@ fn coordinated_append(path: &Path, bytes: &[u8]) -> io::Result<()> {
 mod tests {
     use super::*;
     use crate::sync::events::BookImportPayload;
+    use std::sync::Arc;
     use tempfile::TempDir;
 
     fn sample_body(n: usize) -> EventBody {
@@ -249,15 +267,18 @@ mod tests {
         })
     }
 
-    fn open(tmp: &TempDir) -> EventLog {
+    /// Tests run against TempDir — no ubiquity container, no file presenters,
+    /// nothing for NSFileCoordinator to coordinate with. We always pass
+    /// `use_coordinator = false` so tests are hermetic and fast.
+    fn open_log(tmp: &TempDir) -> EventLog {
         let p = tmp.path().join("logs").join("dev-A.jsonl");
-        EventLog::open(&p, "dev-A").unwrap()
+        EventLog::open(&p, "dev-A", false).unwrap()
     }
 
     #[test]
     fn open_creates_parent_dirs() {
         let tmp = TempDir::new().unwrap();
-        let log = open(&tmp);
+        let log = open_log(&tmp);
         assert!(log.path().exists());
         assert!(log.path().parent().unwrap().exists());
     }
@@ -265,7 +286,7 @@ mod tests {
     #[test]
     fn append_then_read_all_one_event() {
         let tmp = TempDir::new().unwrap();
-        let log = open(&tmp);
+        let log = open_log(&tmp);
         let ev = log.append(sample_body(1), 1_714_770_000_000).unwrap();
         let events = log.read_all().unwrap();
         assert_eq!(events.len(), 1);
@@ -275,7 +296,7 @@ mod tests {
     #[test]
     fn append_preserves_order_and_monotonic_ids() {
         let tmp = TempDir::new().unwrap();
-        let log = open(&tmp);
+        let log = open_log(&tmp);
         for i in 0..10 {
             log.append(sample_body(i), 1_714_770_000_000 + i as i64)
                 .unwrap();
@@ -290,7 +311,7 @@ mod tests {
     #[test]
     fn append_batch_shares_ts_and_generates_distinct_ids() {
         let tmp = TempDir::new().unwrap();
-        let log = open(&tmp);
+        let log = open_log(&tmp);
         let bodies = vec![sample_body(1), sample_body(2), sample_body(3)];
         let ts = 1_714_770_000_000;
         let evs = log.append_batch(bodies, ts).unwrap();
@@ -301,7 +322,6 @@ mod tests {
         let ids: std::collections::HashSet<&str> =
             evs.iter().map(|e| e.id.as_str()).collect();
         assert_eq!(ids.len(), 3, "ulid collision in batch");
-        // Read-back matches.
         let read = log.read_all().unwrap();
         assert_eq!(read, evs);
     }
@@ -309,7 +329,7 @@ mod tests {
     #[test]
     fn read_after_filters_by_last_id() {
         let tmp = TempDir::new().unwrap();
-        let log = open(&tmp);
+        let log = open_log(&tmp);
         let mut ids = Vec::new();
         for i in 0..5 {
             ids.push(
@@ -330,9 +350,8 @@ mod tests {
     #[test]
     fn read_all_on_missing_file_returns_empty() {
         let tmp = TempDir::new().unwrap();
-        // Construct EventLog on a path we'll then delete to simulate never-written.
         let p = tmp.path().join("nope.jsonl");
-        let log = EventLog::open(&p, "dev-A").unwrap();
+        let log = EventLog::open(&p, "dev-A", false).unwrap();
         std::fs::remove_file(&p).unwrap();
         let events = log.read_all().unwrap();
         assert_eq!(events.len(), 0);
@@ -341,15 +360,12 @@ mod tests {
     #[test]
     fn torn_write_tail_is_skipped() {
         let tmp = TempDir::new().unwrap();
-        let log = open(&tmp);
+        let log = open_log(&tmp);
         log.append(sample_body(1), 1_714_770_000_000).unwrap();
         log.append(sample_body(2), 1_714_770_000_001).unwrap();
         log.append(sample_body(3), 1_714_770_000_002).unwrap();
 
-        // Chop the last line mid-JSON to simulate a crash between write_all
-        // and fsync (or a crash mid-buffer before the newline reached disk).
         let mut bytes = std::fs::read(log.path()).unwrap();
-        // Find the newline before the last line, truncate 20 bytes past it.
         let last_nl = bytes[..bytes.len() - 1]
             .iter()
             .rposition(|&b| b == b'\n')
@@ -364,8 +380,7 @@ mod tests {
     #[test]
     fn read_preserves_unknown_top_level_fields() {
         let tmp = TempDir::new().unwrap();
-        let log = open(&tmp);
-        // Write a raw JSONL line with an extra field that didn't exist in our schema.
+        let log = open_log(&tmp);
         let raw = r#"{"id":"01HYZX0000000000000000EVTZ","ts":1714770000000,"device":"dev-A","v":2,"type":"bookmark.add","payload":{"id":"bm1","book_id":"b1","cfi":"epubcfi(/6/4!)","label":null},"future_field":"keep-me"}"#;
         let mut bytes = Vec::new();
         bytes.extend_from_slice(raw.as_bytes());
@@ -383,20 +398,16 @@ mod tests {
 
     #[test]
     fn ids_increase_across_processes_via_wall_clock_prefix() {
-        // Two EventLog instances against the same file — simulates a restart.
-        // Each has its own monotonic generator; but because both draw ULIDs
-        // from wall time, later one's ids strictly sort after the first.
         let tmp = TempDir::new().unwrap();
         let p = tmp.path().join("dev-A.jsonl");
-        let log_a = EventLog::open(&p, "dev-A").unwrap();
+        let log_a = EventLog::open(&p, "dev-A", false).unwrap();
         let id_a = log_a
             .append(sample_body(1), 1_714_770_000_000)
             .unwrap()
             .id;
-        // Sleep 2ms so the wall-clock prefix differs.
         std::thread::sleep(std::time::Duration::from_millis(2));
         drop(log_a);
-        let log_b = EventLog::open(&p, "dev-A").unwrap();
+        let log_b = EventLog::open(&p, "dev-A", false).unwrap();
         let id_b = log_b
             .append(sample_body(2), 1_714_770_000_002)
             .unwrap()
@@ -407,4 +418,42 @@ mod tests {
         );
     }
 
+    #[test]
+    fn concurrent_appends_preserve_id_file_order() {
+        // Regression test for finding #1: previously the mutex only covered
+        // ULID generation, not the file write. That let two threads generate
+        // id_A < id_B but write in the reverse order, permanently hiding
+        // id_A from read_after(id_B). This test stresses that race and
+        // verifies file order matches id order.
+        let tmp = TempDir::new().unwrap();
+        let log = Arc::new(open_log(&tmp));
+
+        let mut handles = Vec::new();
+        for t in 0..8 {
+            let log = Arc::clone(&log);
+            handles.push(std::thread::spawn(move || {
+                let mut ids = Vec::new();
+                for i in 0..50 {
+                    let ev = log
+                        .append(sample_body(t * 100 + i), 1_714_770_000_000 + i as i64)
+                        .unwrap();
+                    ids.push(ev.id);
+                }
+                ids
+            }));
+        }
+        let _: Vec<Vec<String>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // Read the file back; verify ids are strictly increasing in file order.
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 8 * 50);
+        for w in events.windows(2) {
+            assert!(
+                w[0].id < w[1].id,
+                "file order broke: {} then {}",
+                w[0].id,
+                w[1].id
+            );
+        }
+    }
 }

--- a/src-tauri/src/sync/log.rs
+++ b/src-tauri/src/sync/log.rs
@@ -456,4 +456,28 @@ mod tests {
             );
         }
     }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "manual smoke test against the real iCloud ubiquity container"]
+    fn coordinated_append_smoke_on_real_icloud_path() {
+        let shared_dir = crate::icloud::icloud_data_dir_fast()
+            .or_else(crate::icloud::icloud_data_dir)
+            .expect("expected a local iCloud Documents container");
+        let logs_dir = shared_dir.join("logs");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+
+        let file = logs_dir.join(format!(
+            "_codex-sync-smoke-{}.jsonl",
+            uuid::Uuid::new_v4()
+        ));
+        let log = EventLog::open(&file, "dev-smoke", true).unwrap();
+
+        let ev = log.append(sample_body(1), 1_714_770_000_000).unwrap();
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0], ev);
+
+        std::fs::remove_file(file).unwrap();
+    }
 }

--- a/src-tauri/src/sync/log.rs
+++ b/src-tauri/src/sync/log.rs
@@ -1,3 +1,410 @@
-//! Append-only JSONL log per device, owned by `EventLog`. Handles ULID
-//! generation, line framing, fsync, and (on macOS) NSFileCoordinator-wrapped
-//! appends into the iCloud ubiquity container. Populated in Chunk 3.
+//! Append-only JSONL log per device.
+//!
+//! Lives at `<shared>/logs/<device-uuid>.jsonl`. One line per event. Appends
+//! are serialized through a `Mutex<ulid::Generator>` so IDs stay monotonic
+//! within a process even under bursts, and fsync'd per batch for durability.
+//!
+//! On macOS every append is wrapped in `NSFileCoordinator` — see
+//! `sync/mod.rs` and `docs/impls/31-sync.md` for why. Non-macOS platforms
+//! use a plain POSIX append path.
+
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use serde_json::Map;
+
+use crate::error::{AppError, AppResult};
+
+use super::events::{Event, EventBody, EVENT_SCHEMA_VERSION};
+
+pub struct EventLog {
+    path: PathBuf,
+    device: String,
+    gen: Mutex<ulid::Generator>,
+}
+
+impl EventLog {
+    /// Open (or create) the log at `path`. Creates parent dirs. Safe to call
+    /// many times; each call yields an independent `EventLog` with its own
+    /// monotonic generator — callers are expected to hold one long-lived
+    /// instance and share it.
+    pub fn open(path: &Path, device: &str) -> AppResult<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        // Touch the file so subsequent reads don't fail before any write.
+        let _ = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            device: device.to_string(),
+            gen: Mutex::new(ulid::Generator::new()),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append one event. `ts` is the caller-chosen logical timestamp
+    /// (unix millis) — typically the SQL `updated_at` value so the event
+    /// mirrors the row it describes.
+    pub fn append(&self, body: EventBody, ts: i64) -> AppResult<Event> {
+        let mut out = self.append_batch(vec![body], ts)?;
+        Ok(out.pop().expect("append_batch returns one for one input"))
+    }
+
+    /// Append many events atomically against the coordinator (single file
+    /// open + fsync). All events share the same `ts`; IDs are drawn from the
+    /// monotonic generator in order.
+    pub fn append_batch(&self, bodies: Vec<EventBody>, ts: i64) -> AppResult<Vec<Event>> {
+        if bodies.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let events = {
+            let mut gen = self
+                .gen
+                .lock()
+                .map_err(|e| AppError::Other(format!("EventLog gen lock poisoned: {e}")))?;
+            // ULID timestamps come from wall clock to preserve generator
+            // monotonicity across process restarts; `ts` on the event is the
+            // caller-supplied value (usually a few milliseconds earlier).
+            let now = SystemTime::now();
+            let mut events = Vec::with_capacity(bodies.len());
+            for body in bodies {
+                let ulid = gen
+                    .generate_from_datetime(now)
+                    .map_err(|e| AppError::Other(format!("ulid generate: {e:?}")))?;
+                events.push(Event {
+                    id: ulid.to_string(),
+                    ts,
+                    device: self.device.clone(),
+                    v: EVENT_SCHEMA_VERSION,
+                    body,
+                    extra: Map::new(),
+                });
+            }
+            events
+        };
+
+        let mut buf = Vec::with_capacity(events.len() * 256);
+        for ev in &events {
+            serde_json::to_writer(&mut buf, ev)
+                .map_err(|e| AppError::Other(format!("event serialize: {e}")))?;
+            buf.push(b'\n');
+        }
+        append_bytes(&self.path, &buf)?;
+
+        Ok(events)
+    }
+
+    /// Parse every event in the log. Malformed or truncated lines are
+    /// skipped with a `eprintln!` warning so a partial tail (from a crash
+    /// mid-write) doesn't poison the whole read.
+    pub fn read_all(&self) -> AppResult<Vec<Event>> {
+        let bytes = match fs::read(&self.path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(AppError::Io(e)),
+        };
+        let mut out = Vec::new();
+        for (idx, line) in bytes.split(|&b| b == b'\n').enumerate() {
+            if line.is_empty() {
+                continue;
+            }
+            match serde_json::from_slice::<Event>(line) {
+                Ok(ev) => out.push(ev),
+                Err(e) => {
+                    eprintln!(
+                        "sync: skipping malformed log line {} in {}: {e}",
+                        idx + 1,
+                        self.path.display()
+                    );
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Stream events with `id > last_id`. Passing `None` returns every event.
+    ///
+    /// ULIDs are lexicographically sortable — their 48-bit timestamp prefix
+    /// dominates, so string `>` is equivalent to "later than" for IDs from
+    /// a single monotonic generator. Across peers we tiebreak in the replay
+    /// engine by `(ts, device)`.
+    pub fn read_after(&self, last_id: Option<&str>) -> AppResult<Vec<Event>> {
+        let all = self.read_all()?;
+        match last_id {
+            None => Ok(all),
+            Some(lid) => Ok(all.into_iter().filter(|e| e.id.as_str() > lid).collect()),
+        }
+    }
+}
+
+fn append_bytes(path: &Path, bytes: &[u8]) -> AppResult<()> {
+    #[cfg(target_os = "macos")]
+    {
+        coordinated_append(path, bytes).map_err(AppError::Io)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        naive_append(path, bytes).map_err(AppError::Io)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn naive_append(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let mut f = OpenOptions::new().create(true).append(true).open(path)?;
+    f.write_all(bytes)?;
+    f.sync_all()?;
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// macOS: NSFileCoordinator-wrapped append.
+//
+// Apple's iCloud daemon (`bird`) is a silent second writer on every file in
+// the ubiquity container — it uploads, re-downloads, evicts, and rematerializes
+// without notifying us. A naive POSIX append races with it: the daemon can
+// upload a partial write, or we can append over a stub that was evicted.
+// NSFileCoordinator's writing accessor tells presenters (including the
+// daemon) to pause, waits for in-flight downloads/uploads, materializes
+// placeholders, and hands us a URL to write through.
+// -------------------------------------------------------------------------
+#[cfg(target_os = "macos")]
+fn coordinated_append(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    use block2::StackBlock;
+    use objc2_foundation::{
+        NSFileCoordinator, NSFileCoordinatorWritingOptions, NSString, NSURL,
+    };
+    use std::cell::RefCell;
+    use std::ptr::NonNull;
+
+    let path_str = path.to_string_lossy();
+    let ns_path = NSString::from_str(&path_str);
+    let url = NSURL::fileURLWithPath(&ns_path);
+    let coord = NSFileCoordinator::new();
+
+    // The accessor runs synchronously on the calling thread before
+    // coordinateWriting… returns, so a RefCell is sufficient (no cross-thread
+    // sharing, no locking overhead).
+    let inner_result: RefCell<io::Result<()>> = RefCell::new(Ok(()));
+
+    let writer_block = StackBlock::new(|coordinated_url: NonNull<NSURL>| {
+        let url_ref: &NSURL = unsafe { coordinated_url.as_ref() };
+        let p_ns = url_ref.path();
+        let target = match p_ns {
+            Some(s) => PathBuf::from(s.to_string()),
+            None => {
+                *inner_result.borrow_mut() = Err(io::Error::other(
+                    "NSFileCoordinator: coordinated URL has no .path",
+                ));
+                return;
+            }
+        };
+        *inner_result.borrow_mut() = (|| -> io::Result<()> {
+            let mut f = OpenOptions::new().create(true).append(true).open(&target)?;
+            f.write_all(bytes)?;
+            f.sync_all()?;
+            Ok(())
+        })();
+    });
+
+    let mut nserror: Option<objc2::rc::Retained<objc2_foundation::NSError>> = None;
+    coord.coordinateWritingItemAtURL_options_error_byAccessor(
+        &url,
+        NSFileCoordinatorWritingOptions::empty(),
+        Some(&mut nserror),
+        &writer_block,
+    );
+
+    if let Some(err) = nserror {
+        return Err(io::Error::other(format!(
+            "NSFileCoordinator writing error: {err:?}"
+        )));
+    }
+    inner_result.into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::events::BookImportPayload;
+    use tempfile::TempDir;
+
+    fn sample_body(n: usize) -> EventBody {
+        EventBody::BookImport(BookImportPayload {
+            id: format!("b{n}"),
+            title: format!("Book {n}"),
+            author: "Someone".into(),
+            description: None,
+            cover_path: None,
+            file_path: format!("books/b{n}.epub"),
+            format: "epub".into(),
+            genre: None,
+            pages: None,
+        })
+    }
+
+    fn open(tmp: &TempDir) -> EventLog {
+        let p = tmp.path().join("logs").join("dev-A.jsonl");
+        EventLog::open(&p, "dev-A").unwrap()
+    }
+
+    #[test]
+    fn open_creates_parent_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let log = open(&tmp);
+        assert!(log.path().exists());
+        assert!(log.path().parent().unwrap().exists());
+    }
+
+    #[test]
+    fn append_then_read_all_one_event() {
+        let tmp = TempDir::new().unwrap();
+        let log = open(&tmp);
+        let ev = log.append(sample_body(1), 1_714_770_000_000).unwrap();
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0], ev);
+    }
+
+    #[test]
+    fn append_preserves_order_and_monotonic_ids() {
+        let tmp = TempDir::new().unwrap();
+        let log = open(&tmp);
+        for i in 0..10 {
+            log.append(sample_body(i), 1_714_770_000_000 + i as i64)
+                .unwrap();
+        }
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 10);
+        for w in events.windows(2) {
+            assert!(w[0].id < w[1].id, "ids not strictly increasing");
+        }
+    }
+
+    #[test]
+    fn append_batch_shares_ts_and_generates_distinct_ids() {
+        let tmp = TempDir::new().unwrap();
+        let log = open(&tmp);
+        let bodies = vec![sample_body(1), sample_body(2), sample_body(3)];
+        let ts = 1_714_770_000_000;
+        let evs = log.append_batch(bodies, ts).unwrap();
+        assert_eq!(evs.len(), 3);
+        for e in &evs {
+            assert_eq!(e.ts, ts);
+        }
+        let ids: std::collections::HashSet<&str> =
+            evs.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids.len(), 3, "ulid collision in batch");
+        // Read-back matches.
+        let read = log.read_all().unwrap();
+        assert_eq!(read, evs);
+    }
+
+    #[test]
+    fn read_after_filters_by_last_id() {
+        let tmp = TempDir::new().unwrap();
+        let log = open(&tmp);
+        let mut ids = Vec::new();
+        for i in 0..5 {
+            ids.push(
+                log.append(sample_body(i), 1_714_770_000_000 + i as i64)
+                    .unwrap()
+                    .id,
+            );
+        }
+        let tail = log.read_after(Some(&ids[2])).unwrap();
+        assert_eq!(tail.len(), 2);
+        assert_eq!(tail[0].id, ids[3]);
+        assert_eq!(tail[1].id, ids[4]);
+
+        let all = log.read_after(None).unwrap();
+        assert_eq!(all.len(), 5);
+    }
+
+    #[test]
+    fn read_all_on_missing_file_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        // Construct EventLog on a path we'll then delete to simulate never-written.
+        let p = tmp.path().join("nope.jsonl");
+        let log = EventLog::open(&p, "dev-A").unwrap();
+        std::fs::remove_file(&p).unwrap();
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 0);
+    }
+
+    #[test]
+    fn torn_write_tail_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let log = open(&tmp);
+        log.append(sample_body(1), 1_714_770_000_000).unwrap();
+        log.append(sample_body(2), 1_714_770_000_001).unwrap();
+        log.append(sample_body(3), 1_714_770_000_002).unwrap();
+
+        // Chop the last line mid-JSON to simulate a crash between write_all
+        // and fsync (or a crash mid-buffer before the newline reached disk).
+        let mut bytes = std::fs::read(log.path()).unwrap();
+        // Find the newline before the last line, truncate 20 bytes past it.
+        let last_nl = bytes[..bytes.len() - 1]
+            .iter()
+            .rposition(|&b| b == b'\n')
+            .unwrap();
+        bytes.truncate(last_nl + 20);
+        std::fs::write(log.path(), &bytes).unwrap();
+
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 2, "truncated last line should be skipped");
+    }
+
+    #[test]
+    fn read_preserves_unknown_top_level_fields() {
+        let tmp = TempDir::new().unwrap();
+        let log = open(&tmp);
+        // Write a raw JSONL line with an extra field that didn't exist in our schema.
+        let raw = r#"{"id":"01HYZX0000000000000000EVTZ","ts":1714770000000,"device":"dev-A","v":2,"type":"bookmark.add","payload":{"id":"bm1","book_id":"b1","cfi":"epubcfi(/6/4!)","label":null},"future_field":"keep-me"}"#;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(raw.as_bytes());
+        bytes.push(b'\n');
+        std::fs::write(log.path(), &bytes).unwrap();
+
+        let events = log.read_all().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].body, EventBody::BookmarkAdd(_)));
+        assert_eq!(
+            events[0].extra.get("future_field"),
+            Some(&serde_json::json!("keep-me"))
+        );
+    }
+
+    #[test]
+    fn ids_increase_across_processes_via_wall_clock_prefix() {
+        // Two EventLog instances against the same file — simulates a restart.
+        // Each has its own monotonic generator; but because both draw ULIDs
+        // from wall time, later one's ids strictly sort after the first.
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join("dev-A.jsonl");
+        let log_a = EventLog::open(&p, "dev-A").unwrap();
+        let id_a = log_a
+            .append(sample_body(1), 1_714_770_000_000)
+            .unwrap()
+            .id;
+        // Sleep 2ms so the wall-clock prefix differs.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        drop(log_a);
+        let log_b = EventLog::open(&p, "dev-A").unwrap();
+        let id_b = log_b
+            .append(sample_body(2), 1_714_770_000_002)
+            .unwrap()
+            .id;
+        assert!(
+            id_b > id_a,
+            "post-restart id {id_b} should sort after pre-restart id {id_a}"
+        );
+    }
+
+}

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -1,9 +1,13 @@
 //! Per-device event-log sync engine (issue #185).
 //!
-//! Scaffolding only — submodules are empty stubs here; each will be filled
-//! out in its own chunk per `docs/impls/31-sync.md`. Keeping them present
-//! from the start lets callers and tests land incrementally without a
-//! mega-PR.
+//! Scaffolding grows chunk by chunk per `docs/impls/31-sync.md`. Keeping the
+//! submodules present from the start lets callers and tests land
+//! incrementally without a mega-PR.
+//!
+//! `dead_code` is silenced module-wide until Chunk 5 wires `SyncWriter` into
+//! the command layer; at that point every symbol has a caller and this
+//! allow can be removed.
+#![allow(dead_code)]
 
 pub mod device;
 pub mod events;


### PR DESCRIPTION
## Summary

Chunk 3 of issue #185. Pure data + I/O — no command wiring yet, so the app still behaves identically. Base branch is the umbrella \`feat/event-log-sync\`, not main.

- **\`sync/events.rs\`** — \`Event\` envelope + all 26 \`EventBody\` variants + 6 payload structs. Unknown top-level fields preserved via \`#[serde(flatten)] extra\` for forward-compat with iOS and future schema versions. Frozen wire format test so nobody silently breaks interop.
- **\`sync/device.rs\`** — \`DeviceIdentity::load_or_create\` persists \`device.json\` atomically (tmp + rename).
- **\`sync/log.rs\`** — \`EventLog::{open, append, append_batch, read_all, read_after}\` with a monotonic \`ulid::Generator\`. On macOS every append is wrapped in \`NSFileCoordinator.coordinateWritingItemAtURL\` so iCloud's daemon (\`bird\`) pauses sync while we write — naive POSIX appends race with the daemon and can corrupt the tail. Non-macOS platforms use a plain POSIX append path.
- **\`Cargo.toml\`** — adds \`block2 = \"0.6\"\` and enables \`NSFileCoordinator\` + \`block2\` features on \`objc2-foundation\`.
- **\`sync/mod.rs\`** — module-level \`#[allow(dead_code)]\` until Chunk 5 wires \`SyncWriter\` in; the attr is removed at that point.

## Test plan
- [ ] 23 new unit tests pass under \`cargo test --lib sync::\`
- [ ] Full suite (91 tests) still green
- [ ] \`cargo clippy --lib\` clean (zero warnings)
- [ ] Manual: no runtime behavior change — build, launch the app, confirm it opens, lists books, reads, highlights; nothing written to the ubiquity container

## Follow-ups (next chunks on the umbrella branch)
- Chunk 4: \`merge::apply_event\`, \`ReplayEngine::tick\`, \`Snapshot::{from_log, apply_peer}\`
- Chunk 5: \`SyncWriter\` + command instrumentation (removes the dead_code allow)
- Chunk 6: launch-time migration routine + fs watcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)