### PR TITLE
feat(sync): Chunk 4 — merge engine, snapshot, replay (#185)

### DIFF
--- a/src-tauri/migrations/011_lww_tiebreak_and_outbox.sql
+++ b/src-tauri/migrations/011_lww_tiebreak_and_outbox.sql
@@ -1,0 +1,43 @@
+-- Migration 011 — LWW tiebreak column + outbox table.
+--
+-- Two sync-engine prerequisites land together:
+--
+-- 1. `updated_by_device TEXT NOT NULL DEFAULT 'migration'` on every LWW-backed
+--    table. The merge engine's tuple compare is
+--      `(stored.updated_at, stored.updated_by_device) < (event.ts, event.device)`,
+--    so without this column equal-millisecond writes from two devices would
+--    resolve nondeterministically. The default `'migration'` is a sentinel that
+--    sorts before any real device UUID hex string (UUIDv4s start with 0-9/a-f),
+--    which matches the intent: pre-sync rows lose any same-ms tie to a real
+--    sync write.
+--
+-- 2. `_pending_publish` outbox. Step 3 of `docs/impls/sync/31-sync.md` writes
+--    pending events into this table inside the SQL transaction, then flushes
+--    them to the device log after commit. If the post-commit append fails, the
+--    next `ReplayEngine::tick()` drains the outbox. This bounds partial-failure
+--    outcomes to "peers lag the origin," never the reverse — see
+--    `31-sync-known-problems.md` §1.
+--
+-- Bundled because both additions are prerequisites for Chunk 4's merge engine
+-- and Chunk 5's `SyncWriter`. Splitting them across two migration numbers
+-- would put a no-op step in the sync series for no benefit.
+
+-- ---------------------------------------------------------------------------
+-- 1. updated_by_device — six LWW-backed tables.
+-- ---------------------------------------------------------------------------
+ALTER TABLE books            ADD COLUMN updated_by_device TEXT NOT NULL DEFAULT 'migration';
+ALTER TABLE highlights       ADD COLUMN updated_by_device TEXT NOT NULL DEFAULT 'migration';
+ALTER TABLE collections      ADD COLUMN updated_by_device TEXT NOT NULL DEFAULT 'migration';
+ALTER TABLE collection_books ADD COLUMN updated_by_device TEXT NOT NULL DEFAULT 'migration';
+ALTER TABLE vocab_words      ADD COLUMN updated_by_device TEXT NOT NULL DEFAULT 'migration';
+ALTER TABLE chats            ADD COLUMN updated_by_device TEXT NOT NULL DEFAULT 'migration';
+
+-- ---------------------------------------------------------------------------
+-- 2. _pending_publish outbox.
+-- ---------------------------------------------------------------------------
+CREATE TABLE _pending_publish (
+  id         TEXT PRIMARY KEY,             -- local outbox row id (UUIDv4)
+  ts         INTEGER NOT NULL,              -- event timestamp to publish (unix ms)
+  body_json  TEXT NOT NULL,                 -- serialized EventBody JSON
+  created_at INTEGER NOT NULL               -- unix millis when enqueued
+);

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -16,6 +16,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (8, include_str!("../migrations/008_drop_book_settings.sql")),
     (9, include_str!("../migrations/009_normalize_timestamps.sql")),
     (10, include_str!("../migrations/010_replay_state.sql")),
+    (11, include_str!("../migrations/011_lww_tiebreak_and_outbox.sql")),
 ];
 
 pub struct Db {
@@ -89,8 +90,10 @@ impl Db {
         }
     }
 
-    /// Run migrations on an already-open connection (for testing).
-    #[cfg(test)]
+    /// Run migrations on an already-open connection. Public so the sync
+    /// snapshot module can spin up an in-memory DB to materialize state
+    /// without going through `Db::init` (which assumes a real on-disk
+    /// data dir layout).
     pub fn run_migrations_on(conn: &Connection) -> AppResult<()> {
         Self::run_migrations(conn)
     }
@@ -182,7 +185,7 @@ mod tests {
         let conn = db.conn.lock().unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 10);
+        assert_eq!(version, 11);
     }
 
     #[test]
@@ -207,6 +210,7 @@ mod tests {
         assert!(tables.contains(&"schema_version".to_string()));
         assert!(tables.contains(&"_replay_state".to_string()));
         assert!(tables.contains(&"_tombstones".to_string()));
+        assert!(tables.contains(&"_pending_publish".to_string()));
     }
 
     #[test]
@@ -217,7 +221,7 @@ mod tests {
         Db::run_migrations_on(&conn).unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 10);
+        assert_eq!(version, 11);
     }
 
     #[test]
@@ -523,6 +527,86 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |r| r.get(0))
             .unwrap();
         assert_eq!(violations, 0, "foreign key violations after migration");
+    }
+
+    // -----------------------------------------------------------------------
+    // Migration 011 integrity — `updated_by_device` backfill + `_pending_publish`
+    // creation. Seeds a v10 DB with rows on every LWW-backed table, runs 011,
+    // verifies the new column defaults to 'migration' on every legacy row and
+    // the outbox is empty.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_011_backfills_updated_by_device_and_creates_outbox() {
+        let dir = TempDir::new().unwrap();
+        let conn = Connection::open(dir.path().join("quill.db")).unwrap();
+        conn.execute_batch("PRAGMA journal_mode=DELETE; PRAGMA foreign_keys=ON;").unwrap();
+        Db::run_migrations_up_to(&conn, 10).unwrap();
+
+        let ts = chrono::Utc::now().timestamp_millis();
+
+        // Seed one row on every LWW-backed table (parents first).
+        conn.execute(
+            "INSERT INTO books (id, title, author, file_path, status, progress, created_at, updated_at)
+             VALUES ('b1', 'T', 'A', 'books/x.epub', 'reading', 0, ?1, ?1)",
+            params![ts],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO collections (id, name, sort_order, created_at, updated_at) VALUES ('c1', 'Top', 0, ?1, ?1)",
+            params![ts],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO collection_books (collection_id, book_id, created_at, updated_at) VALUES ('c1', 'b1', ?1, ?1)",
+            params![ts],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO highlights (id, book_id, cfi_range, color, created_at, updated_at)
+             VALUES ('h1', 'b1', 'epubcfi(/6/4!/2)', 'yellow', ?1, ?1)",
+            params![ts],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO vocab_words (id, book_id, word, definition, mastery, review_count, created_at, updated_at)
+             VALUES ('v1', 'b1', 'serendipity', 'fortunate accident', 'new', 0, ?1, ?1)",
+            params![ts],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO chats (id, book_id, title, pinned, created_at, updated_at)
+             VALUES ('ch1', 'b1', 'New chat', 0, ?1, ?1)",
+            params![ts],
+        ).unwrap();
+
+        // Apply migration 011.
+        Db::run_migrations_up_to(&conn, 11).unwrap();
+
+        // Every legacy row got the sentinel.
+        for (sql, expected) in [
+            ("SELECT updated_by_device FROM books WHERE id = 'b1'", "migration"),
+            ("SELECT updated_by_device FROM collections WHERE id = 'c1'", "migration"),
+            ("SELECT updated_by_device FROM collection_books WHERE collection_id = 'c1' AND book_id = 'b1'", "migration"),
+            ("SELECT updated_by_device FROM highlights WHERE id = 'h1'", "migration"),
+            ("SELECT updated_by_device FROM vocab_words WHERE id = 'v1'", "migration"),
+            ("SELECT updated_by_device FROM chats WHERE id = 'ch1'", "migration"),
+        ] {
+            let got: String = conn.query_row(sql, [], |r| r.get(0)).unwrap();
+            assert_eq!(got, expected, "{sql}");
+        }
+
+        // Column declared NOT NULL — INSERT without it should fail.
+        let err = conn.execute(
+            "INSERT INTO highlights (id, book_id, cfi_range, color, created_at, updated_at, updated_by_device)
+             VALUES ('h2', 'b1', 'epubcfi(/6/4!/4)', 'pink', ?1, ?1, NULL)",
+            params![ts],
+        );
+        assert!(err.is_err(), "NULL into NOT NULL column should fail");
+
+        // _pending_publish exists and is empty.
+        let outbox_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM _pending_publish", [], |r| r.get(0)).unwrap();
+        assert_eq!(outbox_count, 0);
+
+        // schema_version advanced.
+        let v: i64 = conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
+        assert_eq!(v, 11);
     }
 
     #[test]

--- a/src-tauri/src/sync/log.rs
+++ b/src-tauri/src/sync/log.rs
@@ -124,28 +124,7 @@ impl EventLog {
     /// skipped with a `eprintln!` warning so a partial tail (from a crash
     /// mid-write) doesn't poison the whole read.
     pub fn read_all(&self) -> AppResult<Vec<Event>> {
-        let bytes = match fs::read(&self.path) {
-            Ok(b) => b,
-            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
-            Err(e) => return Err(AppError::Io(e)),
-        };
-        let mut out = Vec::new();
-        for (idx, line) in bytes.split(|&b| b == b'\n').enumerate() {
-            if line.is_empty() {
-                continue;
-            }
-            match serde_json::from_slice::<Event>(line) {
-                Ok(ev) => out.push(ev),
-                Err(e) => {
-                    eprintln!(
-                        "sync: skipping malformed log line {} in {}: {e}",
-                        idx + 1,
-                        self.path.display()
-                    );
-                }
-            }
-        }
-        Ok(out)
+        read_log_file(&self.path)
     }
 
     /// Stream events with `id > last_id`. Passing `None` returns every event.
@@ -155,11 +134,46 @@ impl EventLog {
     /// a single monotonic generator. Across peers we tiebreak in the replay
     /// engine by `(ts, device)`.
     pub fn read_after(&self, last_id: Option<&str>) -> AppResult<Vec<Event>> {
-        let all = self.read_all()?;
-        match last_id {
-            None => Ok(all),
-            Some(lid) => Ok(all.into_iter().filter(|e| e.id.as_str() > lid).collect()),
+        read_log_file_after(&self.path, last_id)
+    }
+}
+
+/// Read every event from a log file at `path` without opening an `EventLog`
+/// (no writer, no generator). Used by `ReplayEngine` to ingest peer logs
+/// without touching them. Missing files return an empty vec — a peer that
+/// hasn't published a log yet is the same as a peer with zero events.
+pub fn read_log_file(path: &Path) -> AppResult<Vec<Event>> {
+    let bytes = match fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(AppError::Io(e)),
+    };
+    let mut out = Vec::new();
+    for (idx, line) in bytes.split(|&b| b == b'\n').enumerate() {
+        if line.is_empty() {
+            continue;
         }
+        match serde_json::from_slice::<Event>(line) {
+            Ok(ev) => out.push(ev),
+            Err(e) => {
+                eprintln!(
+                    "sync: skipping malformed log line {} in {}: {e}",
+                    idx + 1,
+                    path.display()
+                );
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Like `read_log_file` but skips events with `id <= last_id`. ULIDs sort
+/// lexicographically, so a string compare is equivalent to "later than".
+pub fn read_log_file_after(path: &Path, last_id: Option<&str>) -> AppResult<Vec<Event>> {
+    let all = read_log_file(path)?;
+    match last_id {
+        None => Ok(all),
+        Some(lid) => Ok(all.into_iter().filter(|e| e.id.as_str() > lid).collect()),
     }
 }
 

--- a/src-tauri/src/sync/merge.rs
+++ b/src-tauri/src/sync/merge.rs
@@ -134,6 +134,107 @@ pub fn insert_tombstone(tx: &Transaction, entity: &str, id: &str, ts: i64) -> Ap
     Ok(())
 }
 
+/// Drop the row identified by `(entity, id)` plus every FK-child the event
+/// path would cascade to. Does NOT write the tombstone — callers that want
+/// the suppress-future-adds behavior must call `insert_tombstone`
+/// separately. Idempotent: if the row is already gone, every DELETE is a
+/// no-op.
+///
+/// Used by both the event-path delete arms and `Snapshot::apply_peer`'s
+/// tombstone pass so the two paths stay byte-equivalent. For the composite
+/// `collection_book` entity, `id` must be `"<col>:<book>"` — the same
+/// format the merge engine uses when writing those tombstones.
+pub fn cascade_delete(tx: &Transaction, entity: &str, id: &str) -> AppResult<()> {
+    match entity {
+        entity::BOOK => cascade_delete_book(tx, id),
+        entity::COLLECTION => cascade_delete_collection(tx, id),
+        entity::CHAT => cascade_delete_chat(tx, id),
+        entity::COLLECTION_BOOK => cascade_delete_collection_book(tx, id),
+        entity::HIGHLIGHT => {
+            tx.execute("DELETE FROM highlights WHERE id = ?1", params![id])?;
+            Ok(())
+        }
+        entity::BOOKMARK => {
+            tx.execute("DELETE FROM bookmarks WHERE id = ?1", params![id])?;
+            Ok(())
+        }
+        entity::VOCAB => {
+            tx.execute("DELETE FROM vocab_words WHERE id = ?1", params![id])?;
+            Ok(())
+        }
+        entity::TRANSLATION => {
+            tx.execute("DELETE FROM translations WHERE id = ?1", params![id])?;
+            Ok(())
+        }
+        entity::CHAT_MESSAGE => {
+            tx.execute("DELETE FROM chat_messages WHERE id = ?1", params![id])?;
+            Ok(())
+        }
+        other => {
+            eprintln!("sync: cascade_delete called with unknown entity {other:?}");
+            Ok(())
+        }
+    }
+}
+
+fn cascade_delete_book(tx: &Transaction, id: &str) -> AppResult<()> {
+    // Mirror the `apply_book_delete` cascade exactly. Replay runs with FK
+    // off, so we can't rely on ON DELETE CASCADE.
+    tx.execute("DELETE FROM bookmarks WHERE book_id = ?1", params![id])?;
+    tx.execute("DELETE FROM highlights WHERE book_id = ?1", params![id])?;
+    tx.execute("DELETE FROM vocab_words WHERE book_id = ?1", params![id])?;
+    tx.execute(
+        "DELETE FROM collection_books WHERE book_id = ?1",
+        params![id],
+    )?;
+    tx.execute("DELETE FROM translations WHERE book_id = ?1", params![id])?;
+    let chat_ids: Vec<String> = {
+        let mut stmt = tx.prepare("SELECT id FROM chats WHERE book_id = ?1")?;
+        let collected: Vec<String> = stmt
+            .query_map(params![id], |r| r.get::<_, String>(0))?
+            .collect::<Result<_, _>>()?;
+        collected
+    };
+    for chat_id in &chat_ids {
+        tx.execute(
+            "DELETE FROM chat_messages WHERE chat_id = ?1",
+            params![chat_id],
+        )?;
+    }
+    tx.execute("DELETE FROM chats WHERE book_id = ?1", params![id])?;
+    tx.execute("DELETE FROM books WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+fn cascade_delete_collection(tx: &Transaction, id: &str) -> AppResult<()> {
+    tx.execute(
+        "DELETE FROM collection_books WHERE collection_id = ?1",
+        params![id],
+    )?;
+    tx.execute("DELETE FROM collections WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+fn cascade_delete_chat(tx: &Transaction, id: &str) -> AppResult<()> {
+    tx.execute("DELETE FROM chat_messages WHERE chat_id = ?1", params![id])?;
+    tx.execute("DELETE FROM chats WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+fn cascade_delete_collection_book(tx: &Transaction, key: &str) -> AppResult<()> {
+    let Some((col, book)) = key.split_once(':') else {
+        eprintln!(
+            "sync: cascade_delete_collection_book got malformed key {key:?}, expected '<col>:<book>'"
+        );
+        return Ok(());
+    };
+    tx.execute(
+        "DELETE FROM collection_books WHERE collection_id = ?1 AND book_id = ?2",
+        params![col, book],
+    )?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // books
 // ---------------------------------------------------------------------------
@@ -165,35 +266,7 @@ fn apply_book_import(tx: &Transaction, event: &Event, p: &BookImportPayload) -> 
 }
 
 fn apply_book_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
-    // Manual cascade — replay runs with FK off; we walk every child table
-    // explicitly so the UI doesn't see orphan rows hanging off a deleted book.
-    tx.execute("DELETE FROM bookmarks WHERE book_id = ?1", params![id])?;
-    tx.execute("DELETE FROM highlights WHERE book_id = ?1", params![id])?;
-    tx.execute("DELETE FROM vocab_words WHERE book_id = ?1", params![id])?;
-    tx.execute(
-        "DELETE FROM collection_books WHERE book_id = ?1",
-        params![id],
-    )?;
-    tx.execute("DELETE FROM translations WHERE book_id = ?1", params![id])?;
-    // Chat messages reference chats, not books — but chats reference books, so
-    // wipe both in order. No FK declared between chats↔chat_messages, so we
-    // collect chat ids first and delete messages per chat.
-    let chat_ids: Vec<String> = {
-        let mut stmt = tx.prepare("SELECT id FROM chats WHERE book_id = ?1")?;
-        let collected: Vec<String> = stmt
-            .query_map(params![id], |r| r.get::<_, String>(0))?
-            .collect::<Result<_, _>>()?;
-        collected
-    };
-    for chat_id in &chat_ids {
-        tx.execute(
-            "DELETE FROM chat_messages WHERE chat_id = ?1",
-            params![chat_id],
-        )?;
-    }
-    tx.execute("DELETE FROM chats WHERE book_id = ?1", params![id])?;
-    tx.execute("DELETE FROM books WHERE id = ?1", params![id])?;
-
+    cascade_delete(tx, entity::BOOK, id)?;
     insert_tombstone(tx, entity::BOOK, id, event.ts)?;
     Ok(())
 }
@@ -245,11 +318,18 @@ fn apply_book_metadata(
         }
     };
 
+    // Use `<=` rather than `<`: the live `update_book_metadata` command
+    // emits one event per field changed (see Step 3 of the spec), so a
+    // multi-field edit like "rename + author" produces two events with
+    // identical `(ts, device)`. With strict `<` the second would lose the
+    // tuple compare and be silently skipped. `<=` lets every event in the
+    // group land while staying idempotent on re-apply (the column already
+    // holds `value`, so the UPDATE is a no-op write).
     let sql = format!(
         "UPDATE books
          SET {column} = ?1, updated_at = ?2, updated_by_device = ?3
          WHERE id = ?4
-           AND (updated_at < ?2 OR (updated_at = ?2 AND updated_by_device < ?3))"
+           AND (updated_at < ?2 OR (updated_at = ?2 AND updated_by_device <= ?3))"
     );
 
     if column == "pages" {
@@ -508,9 +588,8 @@ fn apply_collection_reorder(
 }
 
 fn apply_collection_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
-    // Manual cascade: drop the join rows, then the collection itself. Tombstone
-    // each join under the composite-key entity so a delayed `collection.book.add`
-    // for the same pair stays suppressed.
+    // Tombstone each join row first so a delayed `collection.book.add` for
+    // the same pair stays suppressed. cascade_delete then drops the rows.
     let pairs: Vec<String> = {
         let mut stmt =
             tx.prepare("SELECT book_id FROM collection_books WHERE collection_id = ?1")?;
@@ -523,11 +602,7 @@ fn apply_collection_delete(tx: &Transaction, event: &Event, id: &str) -> AppResu
         let key = format!("{id}:{book_id}");
         insert_tombstone(tx, entity::COLLECTION_BOOK, &key, event.ts)?;
     }
-    tx.execute(
-        "DELETE FROM collection_books WHERE collection_id = ?1",
-        params![id],
-    )?;
-    tx.execute("DELETE FROM collections WHERE id = ?1", params![id])?;
+    cascade_delete(tx, entity::COLLECTION, id)?;
     insert_tombstone(tx, entity::COLLECTION, id, event.ts)?;
     Ok(())
 }
@@ -557,11 +632,8 @@ fn apply_collection_book_remove(
     collection: &str,
     book: &str,
 ) -> AppResult<()> {
-    tx.execute(
-        "DELETE FROM collection_books WHERE collection_id = ?1 AND book_id = ?2",
-        params![collection, book],
-    )?;
     let key = format!("{collection}:{book}");
+    cascade_delete(tx, entity::COLLECTION_BOOK, &key)?;
     insert_tombstone(tx, entity::COLLECTION_BOOK, &key, event.ts)?;
     Ok(())
 }
@@ -602,8 +674,7 @@ fn apply_chat_rename(tx: &Transaction, event: &Event, id: &str, title: &str) -> 
 }
 
 fn apply_chat_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
-    tx.execute("DELETE FROM chat_messages WHERE chat_id = ?1", params![id])?;
-    tx.execute("DELETE FROM chats WHERE id = ?1", params![id])?;
+    cascade_delete(tx, entity::CHAT, id)?;
     insert_tombstone(tx, entity::CHAT, id, event.ts)?;
     Ok(())
 }
@@ -629,6 +700,17 @@ fn apply_chat_message_add(
             p.metadata,
             event.ts,
         ],
+    )?;
+    // Mirror the live `add_chat_message` command's side effect — the parent
+    // chat's recency drives chat-list ordering, so peers must see the bump
+    // too. LWW guard prevents an older message event from dragging
+    // `updated_at` backwards if the chat has been renamed since.
+    tx.execute(
+        "UPDATE chats
+         SET updated_at = ?1, updated_by_device = ?2
+         WHERE id = ?3
+           AND (updated_at < ?1 OR (updated_at = ?1 AND updated_by_device < ?2))",
+        params![event.ts, event.device, p.chat_id],
     )?;
     Ok(())
 }
@@ -1293,6 +1375,146 @@ mod tests {
     // -----------------------------------------------------------------------
     // Idempotency under repeated apply
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Regression tests for PR #189 review findings.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn chat_message_add_bumps_parent_chat_updated_at() {
+        // Mirrors the live `add_chat_message` command's two-table write —
+        // the chat's recency drives chat-list ordering on every device, so
+        // peers must see the bump.
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::ChatCreate {
+                        id: "ch1".into(),
+                        book: "b1".into(),
+                        title: "New chat".into(),
+                        model: None,
+                    },
+                ),
+                ev(
+                    5000,
+                    "dev-A",
+                    EventBody::ChatMessageAdd(ChatMessagePayload {
+                        id: "m1".into(),
+                        chat_id: "ch1".into(),
+                        role: "user".into(),
+                        content: "hi".into(),
+                        context: None,
+                        metadata: None,
+                    }),
+                ),
+            ],
+        );
+        let (chat_ts, by): (i64, String) = db
+            .query_row(
+                "SELECT updated_at, updated_by_device FROM chats WHERE id = 'ch1'",
+                [], |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(chat_ts, 5000, "message ts should bump parent chat");
+        assert_eq!(by, "dev-A");
+    }
+
+    #[test]
+    fn chat_message_add_does_not_drag_chat_updated_at_backward() {
+        // Rename happens at T=10_000 on dev-A; older message arrives at
+        // T=5_000 from dev-B. Chat updated_at must stay at the rename ts.
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::ChatCreate {
+                        id: "ch1".into(),
+                        book: "b1".into(),
+                        title: "Old".into(),
+                        model: None,
+                    },
+                ),
+                ev(
+                    10_000,
+                    "dev-A",
+                    EventBody::ChatRename {
+                        id: "ch1".into(),
+                        title: "New".into(),
+                    },
+                ),
+                ev(
+                    5_000,
+                    "dev-B",
+                    EventBody::ChatMessageAdd(ChatMessagePayload {
+                        id: "m1".into(),
+                        chat_id: "ch1".into(),
+                        role: "user".into(),
+                        content: "hi".into(),
+                        context: None,
+                        metadata: None,
+                    }),
+                ),
+            ],
+        );
+        let chat_ts: i64 = db
+            .query_row(
+                "SELECT updated_at FROM chats WHERE id = 'ch1'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(chat_ts, 10_000, "older message must not drag chat backward");
+    }
+
+    #[test]
+    fn book_metadata_multi_field_same_tx_both_apply() {
+        // The live `update_book_metadata` command can rewrite title and
+        // author in one transaction, producing two `book.metadata.set`
+        // events with identical (ts, device). With strict `<` LWW the
+        // second event's field would silently fail to land. This test
+        // pins the `<=` relaxation.
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    2000,
+                    "dev-A",
+                    EventBody::BookMetadataSet {
+                        book: "b1".into(),
+                        field: "title".into(),
+                        value: json!("New Title"),
+                    },
+                ),
+                ev(
+                    2000,
+                    "dev-A",
+                    EventBody::BookMetadataSet {
+                        book: "b1".into(),
+                        field: "author".into(),
+                        value: json!("New Author"),
+                    },
+                ),
+            ],
+        );
+        let (title, author): (String, String) = db
+            .query_row(
+                "SELECT title, author FROM books WHERE id = 'b1'",
+                [], |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(title, "New Title", "first metadata.set must land");
+        assert_eq!(author, "New Author", "second metadata.set must also land");
+    }
 
     #[test]
     fn double_apply_is_a_noop() {

--- a/src-tauri/src/sync/merge.rs
+++ b/src-tauri/src/sync/merge.rs
@@ -696,9 +696,17 @@ fn apply_chat_create(
     title: &str,
     model: Option<&str>,
 ) -> AppResult<()> {
-    if is_tombstoned(tx, entity::CHAT, id)?
-        || parent_tombstoned(tx, &[(entity::BOOK, book)])?
-    {
+    if is_tombstoned(tx, entity::CHAT, id)? {
+        return Ok(());
+    }
+    if parent_tombstoned(tx, &[(entity::BOOK, book)])? {
+        // Parent book is tombstoned — suppress the chat AND leave a chat
+        // tombstone so any delayed `chat.message.add` for this id is also
+        // dropped. The message arm only consults `('chat', chat_id)`
+        // tombstones; without this, a stale (chat.create + chat.message.add)
+        // pair from an offline peer would slip the message in as an
+        // orphan after the create was silently discarded.
+        insert_tombstone(tx, entity::CHAT, id, event.ts)?;
         return Ok(());
     }
     tx.execute(
@@ -1726,6 +1734,82 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM chat_messages", [], |r| r.get(0))
             .unwrap();
         assert_eq!(n, 0, "message for cascade-deleted chat must be suppressed");
+    }
+
+    #[test]
+    fn suppressed_chat_create_writes_tombstone_blocking_late_message() {
+        // Exact scenario from the second review pass:
+        //   tick 1: book.delete(b1) applied — book is tombstoned, no
+        //     chat existed locally so cascade_delete_book wrote nothing.
+        //   tick 2: stale chat.create(ch1, b1) arrives. Parent book is
+        //     tombstoned → suppressed. Without this fix, no chat tombstone
+        //     gets written.
+        //   tick 3: stale chat.message.add(m1, chat_id=ch1) arrives. The
+        //     message arm checks (chat, ch1) tombstone, sees nothing, and
+        //     would insert an orphan.
+        let mut db = open_db();
+        // Tick 1: book imported, then deleted.
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(2000, "dev-B", EventBody::BookDelete { id: "b1".into() }),
+            ],
+        );
+        // Tick 2: late chat.create arrives.
+        apply_all(
+            &mut db,
+            &[ev(
+                1500,
+                "dev-A",
+                EventBody::ChatCreate {
+                    id: "ch1".into(),
+                    book: "b1".into(),
+                    title: "T".into(),
+                    model: None,
+                },
+            )],
+        );
+        let n_chats: i64 = db
+            .query_row("SELECT COUNT(*) FROM chats WHERE id = 'ch1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_chats, 0, "chat.create must be suppressed by book tombstone");
+
+        let chat_tomb: i64 = db
+            .query_row(
+                "SELECT COUNT(*) FROM _tombstones WHERE entity = 'chat' AND id = 'ch1'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            chat_tomb, 1,
+            "suppressed chat.create must leave a chat tombstone"
+        );
+
+        // Tick 3: late chat.message.add arrives. The chat tombstone from
+        // tick 2 must block the orphan insert.
+        apply_all(
+            &mut db,
+            &[ev(
+                1600,
+                "dev-A",
+                EventBody::ChatMessageAdd(ChatMessagePayload {
+                    id: "m1".into(),
+                    chat_id: "ch1".into(),
+                    role: "user".into(),
+                    content: "hi".into(),
+                    context: None,
+                    metadata: None,
+                }),
+            )],
+        );
+        let n_msgs: i64 = db
+            .query_row("SELECT COUNT(*) FROM chat_messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            n_msgs, 0,
+            "message for suppressed chat must not slip in as an orphan"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sync/merge.rs
+++ b/src-tauri/src/sync/merge.rs
@@ -134,6 +134,22 @@ pub fn insert_tombstone(tx: &Transaction, entity: &str, id: &str, ts: i64) -> Ap
     Ok(())
 }
 
+/// True if any of the given `(entity, id)` pairs has a tombstone. Used by
+/// child `*.add` arms to suppress events whose parent has been deleted —
+/// otherwise a late event published by an offline peer can re-create
+/// orphan rows for a permanently-tombstoned book/collection/chat (the
+/// own-tombstone check on the child id alone is not enough because the
+/// child may never have existed locally, so it has no tombstone of its
+/// own).
+fn parent_tombstoned(tx: &Transaction, parents: &[(&str, &str)]) -> AppResult<bool> {
+    for (entity, id) in parents {
+        if is_tombstoned(tx, entity, id)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Drop the row identified by `(entity, id)` plus every FK-child the event
 /// path would cascade to. Does NOT write the tombstone — callers that want
 /// the suppress-future-adds behavior must call `insert_tombstone`
@@ -180,6 +196,16 @@ pub fn cascade_delete(tx: &Transaction, entity: &str, id: &str) -> AppResult<()>
 fn cascade_delete_book(tx: &Transaction, id: &str) -> AppResult<()> {
     // Mirror the `apply_book_delete` cascade exactly. Replay runs with FK
     // off, so we can't rely on ON DELETE CASCADE.
+    //
+    // For the direct-child tables (highlights, bookmarks, vocab_words,
+    // collection_books, translations) we don't write per-row tombstones —
+    // late `*.add` events for those tables are caught by their parent-
+    // tombstone check on `('book', id)`.
+    //
+    // For chats we DO tombstone each cascaded chat, because the chat-
+    // message merge arm checks `('chat', chat_id)`, not `('book', book_id)`,
+    // so without this an orphan chat.message.add could resurrect after the
+    // book is gone.
     tx.execute("DELETE FROM bookmarks WHERE book_id = ?1", params![id])?;
     tx.execute("DELETE FROM highlights WHERE book_id = ?1", params![id])?;
     tx.execute("DELETE FROM vocab_words WHERE book_id = ?1", params![id])?;
@@ -195,11 +221,18 @@ fn cascade_delete_book(tx: &Transaction, id: &str) -> AppResult<()> {
             .collect::<Result<_, _>>()?;
         collected
     };
+    // Use the cascaded chat's own ts isn't known here — the caller supplies
+    // the parent-delete event ts. We pass it through the surrounding
+    // transaction context implicitly by writing tombstones with `now` as a
+    // monotonic-enough value. (The exact ts on the tombstone is informational
+    // only; what matters is that the row exists — see `is_tombstoned`.)
+    let now_ts = chrono::Utc::now().timestamp_millis();
     for chat_id in &chat_ids {
         tx.execute(
             "DELETE FROM chat_messages WHERE chat_id = ?1",
             params![chat_id],
         )?;
+        insert_tombstone(tx, entity::CHAT, chat_id, now_ts)?;
     }
     tx.execute("DELETE FROM chats WHERE book_id = ?1", params![id])?;
     tx.execute("DELETE FROM books WHERE id = ?1", params![id])?;
@@ -369,7 +402,9 @@ fn apply_book_metadata(
 // ---------------------------------------------------------------------------
 
 fn apply_highlight_add(tx: &Transaction, event: &Event, p: &HighlightPayload) -> AppResult<()> {
-    if is_tombstoned(tx, entity::HIGHLIGHT, &p.id)? {
+    if is_tombstoned(tx, entity::HIGHLIGHT, &p.id)?
+        || parent_tombstoned(tx, &[(entity::BOOK, &p.book_id)])?
+    {
         return Ok(());
     }
     tx.execute(
@@ -429,7 +464,9 @@ fn apply_highlight_note(
 // ---------------------------------------------------------------------------
 
 fn apply_bookmark_add(tx: &Transaction, event: &Event, p: &BookmarkPayload) -> AppResult<()> {
-    if is_tombstoned(tx, entity::BOOKMARK, &p.id)? {
+    if is_tombstoned(tx, entity::BOOKMARK, &p.id)?
+        || parent_tombstoned(tx, &[(entity::BOOK, &p.book_id)])?
+    {
         return Ok(());
     }
     tx.execute(
@@ -451,7 +488,9 @@ fn apply_bookmark_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult
 // ---------------------------------------------------------------------------
 
 fn apply_vocab_add(tx: &Transaction, event: &Event, p: &VocabPayload) -> AppResult<()> {
-    if is_tombstoned(tx, entity::VOCAB, &p.id)? {
+    if is_tombstoned(tx, entity::VOCAB, &p.id)?
+        || parent_tombstoned(tx, &[(entity::BOOK, &p.book_id)])?
+    {
         return Ok(());
     }
     tx.execute(
@@ -510,7 +549,9 @@ fn apply_vocab_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()
 // ---------------------------------------------------------------------------
 
 fn apply_translation_add(tx: &Transaction, event: &Event, p: &TranslationPayload) -> AppResult<()> {
-    if is_tombstoned(tx, entity::TRANSLATION, &p.id)? {
+    if is_tombstoned(tx, entity::TRANSLATION, &p.id)?
+        || parent_tombstoned(tx, &[(entity::BOOK, &p.book_id)])?
+    {
         return Ok(());
     }
     tx.execute(
@@ -614,7 +655,12 @@ fn apply_collection_book_add(
     book: &str,
 ) -> AppResult<()> {
     let key = format!("{collection}:{book}");
-    if is_tombstoned(tx, entity::COLLECTION_BOOK, &key)? {
+    if is_tombstoned(tx, entity::COLLECTION_BOOK, &key)?
+        || parent_tombstoned(
+            tx,
+            &[(entity::COLLECTION, collection), (entity::BOOK, book)],
+        )?
+    {
         return Ok(());
     }
     tx.execute(
@@ -650,7 +696,9 @@ fn apply_chat_create(
     title: &str,
     model: Option<&str>,
 ) -> AppResult<()> {
-    if is_tombstoned(tx, entity::CHAT, id)? {
+    if is_tombstoned(tx, entity::CHAT, id)?
+        || parent_tombstoned(tx, &[(entity::BOOK, book)])?
+    {
         return Ok(());
     }
     tx.execute(
@@ -684,7 +732,9 @@ fn apply_chat_message_add(
     event: &Event,
     p: &ChatMessagePayload,
 ) -> AppResult<()> {
-    if is_tombstoned(tx, entity::CHAT_MESSAGE, &p.id)? {
+    if is_tombstoned(tx, entity::CHAT_MESSAGE, &p.id)?
+        || parent_tombstoned(tx, &[(entity::CHAT, &p.chat_id)])?
+    {
         return Ok(());
     }
     tx.execute(
@@ -1514,6 +1564,168 @@ mod tests {
             .unwrap();
         assert_eq!(title, "New Title", "first metadata.set must land");
         assert_eq!(author, "New Author", "second metadata.set must also land");
+    }
+
+    // -----------------------------------------------------------------------
+    // Late-child-add suppression after a parent delete.
+    //
+    // Scenario from PR #189 review: device-A creates the join row before
+    // going offline, device-B deletes the parent and publishes, devices
+    // converge, then device-A comes back and publishes its older event.
+    // Without parent-tombstone checks the older event resurrects the join
+    // and inflates `list_collections` counts. The same shape applies to
+    // every child entity (highlights, bookmarks, vocab, translations,
+    // chats, chat messages).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn late_collection_book_add_after_book_delete_is_suppressed() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::CollectionCreate {
+                        id: "c1".into(),
+                        name: "Top".into(),
+                        sort_order: 0,
+                    },
+                ),
+                // dev-B deletes the book at T=2000.
+                ev(2000, "dev-B", EventBody::BookDelete { id: "b1".into() }),
+                // dev-A's older `collection.book.add(c1, b1)` arrives late
+                // (T=1500 < 2000). Sorted-apply order is delete-then-add,
+                // but cross-tick this ordering breaks down — assert the add
+                // is suppressed regardless.
+                ev(
+                    1500,
+                    "dev-A",
+                    EventBody::CollectionBookAdd {
+                        collection: "c1".into(),
+                        book: "b1".into(),
+                    },
+                ),
+            ],
+        );
+        let n: i64 = db
+            .query_row(
+                "SELECT COUNT(*) FROM collection_books WHERE collection_id = 'c1' AND book_id = 'b1'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            n, 0,
+            "collection.book.add must not resurrect a tombstoned book's join row"
+        );
+    }
+
+    #[test]
+    fn late_collection_book_add_suppressed_across_ticks() {
+        // The same scenario but across two apply batches — mirrors the
+        // multi-tick replay path described in the review (dev-B's delete
+        // event applied in tick 1; dev-A's stale add arrives in tick 2).
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::CollectionCreate {
+                        id: "c1".into(),
+                        name: "Top".into(),
+                        sort_order: 0,
+                    },
+                ),
+                ev(2000, "dev-B", EventBody::BookDelete { id: "b1".into() }),
+            ],
+        );
+        // Now a second tick brings the late add.
+        apply_all(
+            &mut db,
+            &[ev(
+                1500,
+                "dev-A",
+                EventBody::CollectionBookAdd {
+                    collection: "c1".into(),
+                    book: "b1".into(),
+                },
+            )],
+        );
+        let n: i64 = db
+            .query_row(
+                "SELECT COUNT(*) FROM collection_books WHERE collection_id = 'c1' AND book_id = 'b1'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 0, "late tick must still see the parent tombstone");
+    }
+
+    #[test]
+    fn late_highlight_add_after_book_delete_is_suppressed() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(2000, "dev-B", EventBody::BookDelete { id: "b1".into() }),
+            ],
+        );
+        apply_all(
+            &mut db,
+            &[ev(1500, "dev-A", add_highlight("h-late", "b1", "yellow"))],
+        );
+        let n: i64 = db
+            .query_row("SELECT COUNT(*) FROM highlights", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "highlight on a tombstoned book must be suppressed");
+    }
+
+    #[test]
+    fn late_chat_message_after_book_delete_is_suppressed() {
+        // Cascade-deleting a book also tombstones each cascaded chat, so a
+        // delayed `chat.message.add` for one of those chats stays out.
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::ChatCreate {
+                        id: "ch1".into(),
+                        book: "b1".into(),
+                        title: "T".into(),
+                        model: None,
+                    },
+                ),
+                ev(2000, "dev-B", EventBody::BookDelete { id: "b1".into() }),
+            ],
+        );
+        apply_all(
+            &mut db,
+            &[ev(
+                1500,
+                "dev-A",
+                EventBody::ChatMessageAdd(ChatMessagePayload {
+                    id: "m1".into(),
+                    chat_id: "ch1".into(),
+                    role: "user".into(),
+                    content: "hi".into(),
+                    context: None,
+                    metadata: None,
+                }),
+            )],
+        );
+        let n: i64 = db
+            .query_row("SELECT COUNT(*) FROM chat_messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "message for cascade-deleted chat must be suppressed");
     }
 
     #[test]

--- a/src-tauri/src/sync/merge.rs
+++ b/src-tauri/src/sync/merge.rs
@@ -151,18 +151,24 @@ fn parent_tombstoned(tx: &Transaction, parents: &[(&str, &str)]) -> AppResult<bo
 }
 
 /// Drop the row identified by `(entity, id)` plus every FK-child the event
-/// path would cascade to. Does NOT write the tombstone — callers that want
-/// the suppress-future-adds behavior must call `insert_tombstone`
-/// separately. Idempotent: if the row is already gone, every DELETE is a
-/// no-op.
+/// path would cascade to. Does NOT write the tombstone for `(entity, id)`
+/// itself — callers must call `insert_tombstone` separately for that.
+/// Idempotent: if the row is already gone, every DELETE is a no-op.
+///
+/// `ts` is the deletion timestamp threaded through to any per-child
+/// tombstones we have to write inline (e.g. cascaded chats — see
+/// `cascade_delete_book`). Using the event's ts (and snapshot tombstones'
+/// stored ts) instead of wall-clock keeps `_tombstones` rows
+/// byte-identical across replay runs, which the design doc calls out as
+/// a Chunk 4 invariant for snapshot equivalence.
 ///
 /// Used by both the event-path delete arms and `Snapshot::apply_peer`'s
 /// tombstone pass so the two paths stay byte-equivalent. For the composite
 /// `collection_book` entity, `id` must be `"<col>:<book>"` — the same
 /// format the merge engine uses when writing those tombstones.
-pub fn cascade_delete(tx: &Transaction, entity: &str, id: &str) -> AppResult<()> {
+pub fn cascade_delete(tx: &Transaction, entity: &str, id: &str, ts: i64) -> AppResult<()> {
     match entity {
-        entity::BOOK => cascade_delete_book(tx, id),
+        entity::BOOK => cascade_delete_book(tx, id, ts),
         entity::COLLECTION => cascade_delete_collection(tx, id),
         entity::CHAT => cascade_delete_chat(tx, id),
         entity::COLLECTION_BOOK => cascade_delete_collection_book(tx, id),
@@ -193,7 +199,7 @@ pub fn cascade_delete(tx: &Transaction, entity: &str, id: &str) -> AppResult<()>
     }
 }
 
-fn cascade_delete_book(tx: &Transaction, id: &str) -> AppResult<()> {
+fn cascade_delete_book(tx: &Transaction, id: &str, ts: i64) -> AppResult<()> {
     // Mirror the `apply_book_delete` cascade exactly. Replay runs with FK
     // off, so we can't rely on ON DELETE CASCADE.
     //
@@ -205,7 +211,9 @@ fn cascade_delete_book(tx: &Transaction, id: &str) -> AppResult<()> {
     // For chats we DO tombstone each cascaded chat, because the chat-
     // message merge arm checks `('chat', chat_id)`, not `('book', book_id)`,
     // so without this an orphan chat.message.add could resurrect after the
-    // book is gone.
+    // book is gone. The tombstone ts must be the parent-delete event ts
+    // (not wall-clock) — `_tombstones` rows ride along in snapshots and
+    // need to be byte-identical across replay runs.
     tx.execute("DELETE FROM bookmarks WHERE book_id = ?1", params![id])?;
     tx.execute("DELETE FROM highlights WHERE book_id = ?1", params![id])?;
     tx.execute("DELETE FROM vocab_words WHERE book_id = ?1", params![id])?;
@@ -221,18 +229,12 @@ fn cascade_delete_book(tx: &Transaction, id: &str) -> AppResult<()> {
             .collect::<Result<_, _>>()?;
         collected
     };
-    // Use the cascaded chat's own ts isn't known here — the caller supplies
-    // the parent-delete event ts. We pass it through the surrounding
-    // transaction context implicitly by writing tombstones with `now` as a
-    // monotonic-enough value. (The exact ts on the tombstone is informational
-    // only; what matters is that the row exists — see `is_tombstoned`.)
-    let now_ts = chrono::Utc::now().timestamp_millis();
     for chat_id in &chat_ids {
         tx.execute(
             "DELETE FROM chat_messages WHERE chat_id = ?1",
             params![chat_id],
         )?;
-        insert_tombstone(tx, entity::CHAT, chat_id, now_ts)?;
+        insert_tombstone(tx, entity::CHAT, chat_id, ts)?;
     }
     tx.execute("DELETE FROM chats WHERE book_id = ?1", params![id])?;
     tx.execute("DELETE FROM books WHERE id = ?1", params![id])?;
@@ -299,7 +301,7 @@ fn apply_book_import(tx: &Transaction, event: &Event, p: &BookImportPayload) -> 
 }
 
 fn apply_book_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
-    cascade_delete(tx, entity::BOOK, id)?;
+    cascade_delete(tx, entity::BOOK, id, event.ts)?;
     insert_tombstone(tx, entity::BOOK, id, event.ts)?;
     Ok(())
 }
@@ -643,7 +645,7 @@ fn apply_collection_delete(tx: &Transaction, event: &Event, id: &str) -> AppResu
         let key = format!("{id}:{book_id}");
         insert_tombstone(tx, entity::COLLECTION_BOOK, &key, event.ts)?;
     }
-    cascade_delete(tx, entity::COLLECTION, id)?;
+    cascade_delete(tx, entity::COLLECTION, id, event.ts)?;
     insert_tombstone(tx, entity::COLLECTION, id, event.ts)?;
     Ok(())
 }
@@ -679,7 +681,7 @@ fn apply_collection_book_remove(
     book: &str,
 ) -> AppResult<()> {
     let key = format!("{collection}:{book}");
-    cascade_delete(tx, entity::COLLECTION_BOOK, &key)?;
+    cascade_delete(tx, entity::COLLECTION_BOOK, &key, event.ts)?;
     insert_tombstone(tx, entity::COLLECTION_BOOK, &key, event.ts)?;
     Ok(())
 }
@@ -730,7 +732,7 @@ fn apply_chat_rename(tx: &Transaction, event: &Event, id: &str, title: &str) -> 
 }
 
 fn apply_chat_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
-    cascade_delete(tx, entity::CHAT, id)?;
+    cascade_delete(tx, entity::CHAT, id, event.ts)?;
     insert_tombstone(tx, entity::CHAT, id, event.ts)?;
     Ok(())
 }
@@ -1809,6 +1811,61 @@ mod tests {
         assert_eq!(
             n_msgs, 0,
             "message for suppressed chat must not slip in as an orphan"
+        );
+    }
+
+    #[test]
+    fn cascaded_chat_tombstones_carry_event_ts_not_wall_clock() {
+        // Regression for the determinism finding. cascade_delete_book
+        // previously stamped per-chat tombstones with `Utc::now()`, which
+        // diverges across replay runs and corrupts snapshot equivalence.
+        // Pin: the cascaded chat's `_tombstones.ts` must equal the
+        // book.delete event's ts.
+        let mut db = open_db();
+        const DELETE_TS: i64 = 5_000;
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::ChatCreate {
+                        id: "ch1".into(),
+                        book: "b1".into(),
+                        title: "T".into(),
+                        model: None,
+                    },
+                ),
+                ev(
+                    1200,
+                    "dev-A",
+                    EventBody::ChatCreate {
+                        id: "ch2".into(),
+                        book: "b1".into(),
+                        title: "T2".into(),
+                        model: None,
+                    },
+                ),
+                ev(DELETE_TS, "dev-B", EventBody::BookDelete { id: "b1".into() }),
+            ],
+        );
+
+        let rows: Vec<(String, i64)> = {
+            let mut stmt = db
+                .prepare(
+                    "SELECT id, ts FROM _tombstones WHERE entity = 'chat' ORDER BY id",
+                )
+                .unwrap();
+            stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect()
+        };
+        assert_eq!(
+            rows,
+            vec![("ch1".to_string(), DELETE_TS), ("ch2".to_string(), DELETE_TS)],
+            "cascaded chat tombstones must use the book.delete event ts"
         );
     }
 

--- a/src-tauri/src/sync/merge.rs
+++ b/src-tauri/src/sync/merge.rs
@@ -1,3 +1,1329 @@
-//! Deterministic merge rules — `apply_event(tx, event)` folds one peer event
-//! into the local SQLite materialized view. LWW on updates, tombstone-guarded
-//! INSERT OR IGNORE on adds. Populated in Chunk 4.
+//! Deterministic per-event merge.
+//!
+//! `apply_event(tx, event)` folds one peer event into the local SQLite
+//! materialized view. Three rules:
+//!
+//! 1. **Add events** (`*.add`, `*.create`, `*.import`) use `INSERT OR IGNORE`
+//!    and are guarded by a tombstone check on the entity's id. Once a row is
+//!    deleted, a later add with the same id never resurrects it — the user
+//!    must mint a new id.
+//! 2. **LWW updates** (`*.set`, `*.rename`, `*.color.set`, …) compare the
+//!    tuple `(stored.updated_at, stored.updated_by_device)` against
+//!    `(event.ts, event.device)`. Strict-less-than wins; equality means we've
+//!    already applied this exact write. The compare lives in the `WHERE`
+//!    clause so SQLite skips the row in one statement.
+//! 3. **Deletes** drop the row plus all FK-children manually (the replay
+//!    engine runs with `PRAGMA foreign_keys = OFF` so cascades don't fire),
+//!    then `INSERT OR IGNORE` a tombstone keyed `(entity, id)`.
+//!
+//! Foreign keys are deliberately off during apply because cross-device
+//! ordering can deliver a child event before its parent (e.g. a clock-skewed
+//! `highlight.add` arriving before `book.import`). Letting the orphan land
+//! and then catching up when the parent appears is safer than failing the
+//! whole replay tick. The UI joins through parents, so orphans are invisible
+//! until the parent shows up.
+
+use rusqlite::{params, Transaction};
+use serde_json::Value;
+
+use crate::error::{AppError, AppResult};
+
+use super::events::{
+    BookImportPayload, BookmarkPayload, ChatMessagePayload, Event, EventBody, HighlightPayload,
+    TranslationPayload, VocabPayload,
+};
+
+/// Fold `event` into `tx`. Idempotent — applying the same event twice is a
+/// no-op (LWW equality and `INSERT OR IGNORE` both short-circuit).
+pub fn apply_event(tx: &Transaction, event: &Event) -> AppResult<()> {
+    match &event.body {
+        EventBody::BookImport(p) => apply_book_import(tx, event, p),
+        EventBody::BookDelete { id } => apply_book_delete(tx, event, id),
+        EventBody::BookProgressSet { book, progress, cfi } => {
+            apply_book_progress(tx, event, book, *progress, cfi.as_deref())
+        }
+        EventBody::BookStatusSet { book, status } => {
+            apply_book_status(tx, event, book, status)
+        }
+        EventBody::BookMetadataSet { book, field, value } => {
+            apply_book_metadata(tx, event, book, field, value)
+        }
+
+        EventBody::HighlightAdd(p) => apply_highlight_add(tx, event, p),
+        EventBody::HighlightDelete { id } => apply_highlight_delete(tx, event, id),
+        EventBody::HighlightColorSet { id, color } => {
+            apply_highlight_color(tx, event, id, color)
+        }
+        EventBody::HighlightNoteSet { id, note } => {
+            apply_highlight_note(tx, event, id, note.as_deref())
+        }
+
+        EventBody::BookmarkAdd(p) => apply_bookmark_add(tx, event, p),
+        EventBody::BookmarkDelete { id } => apply_bookmark_delete(tx, event, id),
+
+        EventBody::VocabAdd(p) => apply_vocab_add(tx, event, p),
+        EventBody::VocabMasterySet {
+            id,
+            mastery,
+            next_review_at,
+            review_count,
+        } => apply_vocab_mastery(tx, event, id, mastery, *next_review_at, *review_count),
+        EventBody::VocabDelete { id } => apply_vocab_delete(tx, event, id),
+
+        EventBody::TranslationAdd(p) => apply_translation_add(tx, event, p),
+        EventBody::TranslationDelete { id } => apply_translation_delete(tx, event, id),
+
+        EventBody::CollectionCreate { id, name, sort_order } => {
+            apply_collection_create(tx, event, id, name, *sort_order)
+        }
+        EventBody::CollectionRename { id, name } => apply_collection_rename(tx, event, id, name),
+        EventBody::CollectionReorder { id, sort_order } => {
+            apply_collection_reorder(tx, event, id, *sort_order)
+        }
+        EventBody::CollectionDelete { id } => apply_collection_delete(tx, event, id),
+        EventBody::CollectionBookAdd { collection, book } => {
+            apply_collection_book_add(tx, event, collection, book)
+        }
+        EventBody::CollectionBookRemove { collection, book } => {
+            apply_collection_book_remove(tx, event, collection, book)
+        }
+
+        EventBody::ChatCreate { id, book, title, model } => {
+            apply_chat_create(tx, event, id, book, title, model.as_deref())
+        }
+        EventBody::ChatRename { id, title } => apply_chat_rename(tx, event, id, title),
+        EventBody::ChatDelete { id } => apply_chat_delete(tx, event, id),
+        EventBody::ChatMessageAdd(p) => apply_chat_message_add(tx, event, p),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tombstone helpers.
+// ---------------------------------------------------------------------------
+
+/// Tombstone entity tags. Stable strings — they appear on disk in
+/// `_tombstones.entity` and inside snapshots, so don't rename casually.
+pub mod entity {
+    pub const BOOK: &str = "book";
+    pub const HIGHLIGHT: &str = "highlight";
+    pub const BOOKMARK: &str = "bookmark";
+    pub const VOCAB: &str = "vocab";
+    pub const TRANSLATION: &str = "translation";
+    pub const COLLECTION: &str = "collection";
+    /// Composite-key entity for `collection_books`. Id format:
+    /// `"<collection_id>:<book_id>"`.
+    pub const COLLECTION_BOOK: &str = "collection_book";
+    pub const CHAT: &str = "chat";
+    pub const CHAT_MESSAGE: &str = "chat_message";
+}
+
+pub fn is_tombstoned(tx: &Transaction, entity: &str, id: &str) -> AppResult<bool> {
+    let exists: bool = tx.query_row(
+        "SELECT EXISTS(SELECT 1 FROM _tombstones WHERE entity = ?1 AND id = ?2)",
+        params![entity, id],
+        |r| r.get(0),
+    )?;
+    Ok(exists)
+}
+
+pub fn insert_tombstone(tx: &Transaction, entity: &str, id: &str, ts: i64) -> AppResult<()> {
+    tx.execute(
+        "INSERT OR IGNORE INTO _tombstones (entity, id, ts) VALUES (?1, ?2, ?3)",
+        params![entity, id, ts],
+    )?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// books
+// ---------------------------------------------------------------------------
+
+fn apply_book_import(tx: &Transaction, event: &Event, p: &BookImportPayload) -> AppResult<()> {
+    if is_tombstoned(tx, entity::BOOK, &p.id)? {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO books
+         (id, title, author, description, cover_path, file_path, genre, pages,
+          format, status, progress, current_cfi, created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'unread', 0, NULL, ?10, ?10, ?11)",
+        params![
+            p.id,
+            p.title,
+            p.author,
+            p.description,
+            p.cover_path,
+            p.file_path,
+            p.genre,
+            p.pages,
+            p.format,
+            event.ts,
+            event.device,
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_book_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
+    // Manual cascade — replay runs with FK off; we walk every child table
+    // explicitly so the UI doesn't see orphan rows hanging off a deleted book.
+    tx.execute("DELETE FROM bookmarks WHERE book_id = ?1", params![id])?;
+    tx.execute("DELETE FROM highlights WHERE book_id = ?1", params![id])?;
+    tx.execute("DELETE FROM vocab_words WHERE book_id = ?1", params![id])?;
+    tx.execute(
+        "DELETE FROM collection_books WHERE book_id = ?1",
+        params![id],
+    )?;
+    tx.execute("DELETE FROM translations WHERE book_id = ?1", params![id])?;
+    // Chat messages reference chats, not books — but chats reference books, so
+    // wipe both in order. No FK declared between chats↔chat_messages, so we
+    // collect chat ids first and delete messages per chat.
+    let chat_ids: Vec<String> = {
+        let mut stmt = tx.prepare("SELECT id FROM chats WHERE book_id = ?1")?;
+        let collected: Vec<String> = stmt
+            .query_map(params![id], |r| r.get::<_, String>(0))?
+            .collect::<Result<_, _>>()?;
+        collected
+    };
+    for chat_id in &chat_ids {
+        tx.execute(
+            "DELETE FROM chat_messages WHERE chat_id = ?1",
+            params![chat_id],
+        )?;
+    }
+    tx.execute("DELETE FROM chats WHERE book_id = ?1", params![id])?;
+    tx.execute("DELETE FROM books WHERE id = ?1", params![id])?;
+
+    insert_tombstone(tx, entity::BOOK, id, event.ts)?;
+    Ok(())
+}
+
+fn apply_book_progress(
+    tx: &Transaction,
+    event: &Event,
+    book: &str,
+    progress: i32,
+    cfi: Option<&str>,
+) -> AppResult<()> {
+    tx.execute(
+        "UPDATE books
+         SET progress = ?1, current_cfi = ?2, updated_at = ?3, updated_by_device = ?4
+         WHERE id = ?5
+           AND (updated_at < ?3 OR (updated_at = ?3 AND updated_by_device < ?4))",
+        params![progress, cfi, event.ts, event.device, book],
+    )?;
+    Ok(())
+}
+
+fn apply_book_status(tx: &Transaction, event: &Event, book: &str, status: &str) -> AppResult<()> {
+    tx.execute(
+        "UPDATE books
+         SET status = ?1, updated_at = ?2, updated_by_device = ?3
+         WHERE id = ?4
+           AND (updated_at < ?2 OR (updated_at = ?2 AND updated_by_device < ?3))",
+        params![status, event.ts, event.device, book],
+    )?;
+    Ok(())
+}
+
+fn apply_book_metadata(
+    tx: &Transaction,
+    event: &Event,
+    book: &str,
+    field: &str,
+    value: &Value,
+) -> AppResult<()> {
+    // Allowlist — only fields the metadata-set event is allowed to touch.
+    // Unknown fields (e.g. from a future schema) are dropped silently rather
+    // than blowing up a whole replay tick.
+    let column = match field {
+        "title" | "author" | "description" | "cover_path" | "genre" | "file_path" => field,
+        "pages" => "pages",
+        _ => {
+            eprintln!("sync: unknown book.metadata.set field {field:?}, skipping");
+            return Ok(());
+        }
+    };
+
+    let sql = format!(
+        "UPDATE books
+         SET {column} = ?1, updated_at = ?2, updated_by_device = ?3
+         WHERE id = ?4
+           AND (updated_at < ?2 OR (updated_at = ?2 AND updated_by_device < ?3))"
+    );
+
+    if column == "pages" {
+        let int_val: Option<i64> = match value {
+            Value::Null => None,
+            Value::Number(n) => n.as_i64().or_else(|| n.as_u64().map(|u| u as i64)),
+            other => {
+                return Err(AppError::Other(format!(
+                    "book.metadata.set pages expects number/null, got {other:?}"
+                )));
+            }
+        };
+        tx.execute(
+            &sql,
+            params![int_val, event.ts, event.device, book],
+        )?;
+    } else {
+        let str_val: Option<String> = match value {
+            Value::Null => None,
+            Value::String(s) => Some(s.clone()),
+            other => {
+                return Err(AppError::Other(format!(
+                    "book.metadata.set {field} expects string/null, got {other:?}"
+                )));
+            }
+        };
+        tx.execute(
+            &sql,
+            params![str_val, event.ts, event.device, book],
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// highlights
+// ---------------------------------------------------------------------------
+
+fn apply_highlight_add(tx: &Transaction, event: &Event, p: &HighlightPayload) -> AppResult<()> {
+    if is_tombstoned(tx, entity::HIGHLIGHT, &p.id)? {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO highlights
+         (id, book_id, cfi_range, color, note, text_content,
+          created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8)",
+        params![
+            p.id,
+            p.book_id,
+            p.cfi_range,
+            p.color,
+            p.note,
+            p.text_content,
+            event.ts,
+            event.device,
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_highlight_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
+    tx.execute("DELETE FROM highlights WHERE id = ?1", params![id])?;
+    insert_tombstone(tx, entity::HIGHLIGHT, id, event.ts)?;
+    Ok(())
+}
+
+fn apply_highlight_color(tx: &Transaction, event: &Event, id: &str, color: &str) -> AppResult<()> {
+    tx.execute(
+        "UPDATE highlights
+         SET color = ?1, updated_at = ?2, updated_by_device = ?3
+         WHERE id = ?4
+           AND (updated_at < ?2 OR (updated_at = ?2 AND updated_by_device < ?3))",
+        params![color, event.ts, event.device, id],
+    )?;
+    Ok(())
+}
+
+fn apply_highlight_note(
+    tx: &Transaction,
+    event: &Event,
+    id: &str,
+    note: Option<&str>,
+) -> AppResult<()> {
+    tx.execute(
+        "UPDATE highlights
+         SET note = ?1, updated_at = ?2, updated_by_device = ?3
+         WHERE id = ?4
+           AND (updated_at < ?2 OR (updated_at = ?2 AND updated_by_device < ?3))",
+        params![note, event.ts, event.device, id],
+    )?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// bookmarks (append-only — no LWW, no updated_by_device)
+// ---------------------------------------------------------------------------
+
+fn apply_bookmark_add(tx: &Transaction, event: &Event, p: &BookmarkPayload) -> AppResult<()> {
+    if is_tombstoned(tx, entity::BOOKMARK, &p.id)? {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO bookmarks (id, book_id, cfi, label, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
+        params![p.id, p.book_id, p.cfi, p.label, event.ts],
+    )?;
+    Ok(())
+}
+
+fn apply_bookmark_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
+    tx.execute("DELETE FROM bookmarks WHERE id = ?1", params![id])?;
+    insert_tombstone(tx, entity::BOOKMARK, id, event.ts)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// vocab
+// ---------------------------------------------------------------------------
+
+fn apply_vocab_add(tx: &Transaction, event: &Event, p: &VocabPayload) -> AppResult<()> {
+    if is_tombstoned(tx, entity::VOCAB, &p.id)? {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO vocab_words
+         (id, book_id, word, definition, context_sentence, cfi,
+          mastery, review_count, next_review_at,
+          created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10, ?11)",
+        params![
+            p.id,
+            p.book_id,
+            p.word,
+            p.definition,
+            p.context_sentence,
+            p.cfi,
+            p.mastery,
+            p.review_count,
+            p.next_review_at,
+            event.ts,
+            event.device,
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_vocab_mastery(
+    tx: &Transaction,
+    event: &Event,
+    id: &str,
+    mastery: &str,
+    next_review_at: Option<i64>,
+    review_count: i64,
+) -> AppResult<()> {
+    tx.execute(
+        "UPDATE vocab_words
+         SET mastery = ?1,
+             next_review_at = ?2,
+             review_count = ?3,
+             updated_at = ?4,
+             updated_by_device = ?5
+         WHERE id = ?6
+           AND (updated_at < ?4 OR (updated_at = ?4 AND updated_by_device < ?5))",
+        params![mastery, next_review_at, review_count, event.ts, event.device, id],
+    )?;
+    Ok(())
+}
+
+fn apply_vocab_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
+    tx.execute("DELETE FROM vocab_words WHERE id = ?1", params![id])?;
+    insert_tombstone(tx, entity::VOCAB, id, event.ts)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// translations (append-only)
+// ---------------------------------------------------------------------------
+
+fn apply_translation_add(tx: &Transaction, event: &Event, p: &TranslationPayload) -> AppResult<()> {
+    if is_tombstoned(tx, entity::TRANSLATION, &p.id)? {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO translations
+         (id, book_id, source_text, translated_text, target_language, cfi,
+          created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
+        params![
+            p.id,
+            p.book_id,
+            p.source_text,
+            p.translated_text,
+            p.target_language,
+            p.cfi,
+            event.ts,
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_translation_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
+    tx.execute("DELETE FROM translations WHERE id = ?1", params![id])?;
+    insert_tombstone(tx, entity::TRANSLATION, id, event.ts)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// collections + collection_books
+// ---------------------------------------------------------------------------
+
+fn apply_collection_create(
+    tx: &Transaction,
+    event: &Event,
+    id: &str,
+    name: &str,
+    sort_order: i32,
+) -> AppResult<()> {
+    if is_tombstoned(tx, entity::COLLECTION, id)? {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO collections
+         (id, name, sort_order, created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?4, ?5)",
+        params![id, name, sort_order, event.ts, event.device],
+    )?;
+    Ok(())
+}
+
+fn apply_collection_rename(tx: &Transaction, event: &Event, id: &str, name: &str) -> AppResult<()> {
+    tx.execute(
+        "UPDATE collections
+         SET name = ?1, updated_at = ?2, updated_by_device = ?3
+         WHERE id = ?4
+           AND (updated_at < ?2 OR (updated_at = ?2 AND updated_by_device < ?3))",
+        params![name, event.ts, event.device, id],
+    )?;
+    Ok(())
+}
+
+fn apply_collection_reorder(
+    tx: &Transaction,
+    event: &Event,
+    id: &str,
+    sort_order: i32,
+) -> AppResult<()> {
+    tx.execute(
+        "UPDATE collections
+         SET sort_order = ?1, updated_at = ?2, updated_by_device = ?3
+         WHERE id = ?4
+           AND (updated_at < ?2 OR (updated_at = ?2 AND updated_by_device < ?3))",
+        params![sort_order, event.ts, event.device, id],
+    )?;
+    Ok(())
+}
+
+fn apply_collection_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
+    // Manual cascade: drop the join rows, then the collection itself. Tombstone
+    // each join under the composite-key entity so a delayed `collection.book.add`
+    // for the same pair stays suppressed.
+    let pairs: Vec<String> = {
+        let mut stmt =
+            tx.prepare("SELECT book_id FROM collection_books WHERE collection_id = ?1")?;
+        let collected: Vec<String> = stmt
+            .query_map(params![id], |r| r.get::<_, String>(0))?
+            .collect::<Result<_, _>>()?;
+        collected
+    };
+    for book_id in pairs {
+        let key = format!("{id}:{book_id}");
+        insert_tombstone(tx, entity::COLLECTION_BOOK, &key, event.ts)?;
+    }
+    tx.execute(
+        "DELETE FROM collection_books WHERE collection_id = ?1",
+        params![id],
+    )?;
+    tx.execute("DELETE FROM collections WHERE id = ?1", params![id])?;
+    insert_tombstone(tx, entity::COLLECTION, id, event.ts)?;
+    Ok(())
+}
+
+fn apply_collection_book_add(
+    tx: &Transaction,
+    event: &Event,
+    collection: &str,
+    book: &str,
+) -> AppResult<()> {
+    let key = format!("{collection}:{book}");
+    if is_tombstoned(tx, entity::COLLECTION_BOOK, &key)? {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO collection_books
+         (collection_id, book_id, created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?3, ?4)",
+        params![collection, book, event.ts, event.device],
+    )?;
+    Ok(())
+}
+
+fn apply_collection_book_remove(
+    tx: &Transaction,
+    event: &Event,
+    collection: &str,
+    book: &str,
+) -> AppResult<()> {
+    tx.execute(
+        "DELETE FROM collection_books WHERE collection_id = ?1 AND book_id = ?2",
+        params![collection, book],
+    )?;
+    let key = format!("{collection}:{book}");
+    insert_tombstone(tx, entity::COLLECTION_BOOK, &key, event.ts)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// chats + chat_messages
+// ---------------------------------------------------------------------------
+
+fn apply_chat_create(
+    tx: &Transaction,
+    event: &Event,
+    id: &str,
+    book: &str,
+    title: &str,
+    model: Option<&str>,
+) -> AppResult<()> {
+    if is_tombstoned(tx, entity::CHAT, id)? {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO chats
+         (id, book_id, title, model, pinned, created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, 0, ?5, ?5, ?6)",
+        params![id, book, title, model, event.ts, event.device],
+    )?;
+    Ok(())
+}
+
+fn apply_chat_rename(tx: &Transaction, event: &Event, id: &str, title: &str) -> AppResult<()> {
+    tx.execute(
+        "UPDATE chats
+         SET title = ?1, updated_at = ?2, updated_by_device = ?3
+         WHERE id = ?4
+           AND (updated_at < ?2 OR (updated_at = ?2 AND updated_by_device < ?3))",
+        params![title, event.ts, event.device, id],
+    )?;
+    Ok(())
+}
+
+fn apply_chat_delete(tx: &Transaction, event: &Event, id: &str) -> AppResult<()> {
+    tx.execute("DELETE FROM chat_messages WHERE chat_id = ?1", params![id])?;
+    tx.execute("DELETE FROM chats WHERE id = ?1", params![id])?;
+    insert_tombstone(tx, entity::CHAT, id, event.ts)?;
+    Ok(())
+}
+
+fn apply_chat_message_add(
+    tx: &Transaction,
+    event: &Event,
+    p: &ChatMessagePayload,
+) -> AppResult<()> {
+    if is_tombstoned(tx, entity::CHAT_MESSAGE, &p.id)? {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT OR IGNORE INTO chat_messages
+         (id, chat_id, role, content, context, metadata, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
+        params![
+            p.id,
+            p.chat_id,
+            p.role,
+            p.content,
+            p.context,
+            p.metadata,
+            event.ts,
+        ],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Each test follows the same shape: open an in-memory DB, run migrations
+    //! up to 11, build events, apply, assert SQL state. We toggle FK off for
+    //! the apply tx because the replay engine does the same — see the module
+    //! docstring for the rationale.
+
+    use super::*;
+    use crate::db::Db;
+    use crate::sync::events::*;
+    use rusqlite::Connection;
+    use serde_json::json;
+
+    fn open_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        Db::run_migrations_on(&conn).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=OFF;").unwrap();
+        conn
+    }
+
+    fn ev(ts: i64, device: &str, body: EventBody) -> Event {
+        Event {
+            id: format!("01HYZX0000000000000000{:04X}", ts as u16),
+            ts,
+            device: device.to_string(),
+            v: EVENT_SCHEMA_VERSION,
+            body,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    fn apply_all(conn: &mut Connection, events: &[Event]) {
+        let tx = conn.transaction().unwrap();
+        for e in events {
+            apply_event(&tx, e).expect("apply_event failed");
+        }
+        tx.commit().unwrap();
+    }
+
+    fn import_book(id: &str) -> EventBody {
+        EventBody::BookImport(BookImportPayload {
+            id: id.into(),
+            title: "T".into(),
+            author: "A".into(),
+            description: None,
+            cover_path: None,
+            file_path: format!("books/{id}.epub"),
+            format: "epub".into(),
+            genre: None,
+            pages: Some(100),
+        })
+    }
+
+    fn add_highlight(id: &str, book: &str, color: &str) -> EventBody {
+        EventBody::HighlightAdd(HighlightPayload {
+            id: id.into(),
+            book_id: book.into(),
+            cfi_range: "epubcfi(/6/4!/2,/1:0,/1:5)".into(),
+            color: color.into(),
+            note: None,
+            text_content: None,
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // book.import / book.delete + tombstone semantics
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn book_import_inserts_with_event_metadata() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[ev(1000, "dev-A", import_book("b1"))],
+        );
+
+        let (title, ts, dev): (String, i64, String) = db
+            .query_row(
+                "SELECT title, updated_at, updated_by_device FROM books WHERE id = 'b1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(title, "T");
+        assert_eq!(ts, 1000);
+        assert_eq!(dev, "dev-A");
+    }
+
+    #[test]
+    fn book_delete_removes_row_and_writes_tombstone() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(2000, "dev-A", EventBody::BookDelete { id: "b1".into() }),
+            ],
+        );
+
+        let n: i64 = db
+            .query_row("SELECT COUNT(*) FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0);
+        let tomb: i64 = db
+            .query_row(
+                "SELECT COUNT(*) FROM _tombstones WHERE entity = 'book' AND id = 'b1'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(tomb, 1);
+    }
+
+    #[test]
+    fn tombstone_blocks_resurrection() {
+        // delete then add (later ts, same id) → row stays gone.
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(2000, "dev-A", EventBody::BookDelete { id: "b1".into() }),
+                ev(3000, "dev-A", import_book("b1")),
+            ],
+        );
+        let n: i64 = db
+            .query_row("SELECT COUNT(*) FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "tombstone should block re-import even at higher ts");
+    }
+
+    #[test]
+    fn book_delete_cascades_to_children() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(1001, "dev-A", add_highlight("h1", "b1", "yellow")),
+                ev(
+                    1002,
+                    "dev-A",
+                    EventBody::BookmarkAdd(BookmarkPayload {
+                        id: "bm1".into(),
+                        book_id: "b1".into(),
+                        cfi: "epubcfi(/6/4!)".into(),
+                        label: None,
+                    }),
+                ),
+                ev(2000, "dev-A", EventBody::BookDelete { id: "b1".into() }),
+            ],
+        );
+        for table in ["books", "highlights", "bookmarks"] {
+            let n: i64 = db
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(n, 0, "{table} should be empty after book delete");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // LWW correctness
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn book_progress_lww_higher_ts_wins_regardless_of_order() {
+        // Apply lower-ts last; LWW guard rejects it, so progress stays at the
+        // higher-ts value.
+        let mut db1 = open_db();
+        apply_all(
+            &mut db1,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    1500,
+                    "dev-A",
+                    EventBody::BookProgressSet {
+                        book: "b1".into(),
+                        progress: 50,
+                        cfi: Some("c50".into()),
+                    },
+                ),
+                ev(
+                    2000,
+                    "dev-A",
+                    EventBody::BookProgressSet {
+                        book: "b1".into(),
+                        progress: 80,
+                        cfi: Some("c80".into()),
+                    },
+                ),
+            ],
+        );
+        let mut db2 = open_db();
+        apply_all(
+            &mut db2,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    2000,
+                    "dev-A",
+                    EventBody::BookProgressSet {
+                        book: "b1".into(),
+                        progress: 80,
+                        cfi: Some("c80".into()),
+                    },
+                ),
+                ev(
+                    1500,
+                    "dev-A",
+                    EventBody::BookProgressSet {
+                        book: "b1".into(),
+                        progress: 50,
+                        cfi: Some("c50".into()),
+                    },
+                ),
+            ],
+        );
+
+        for db in [&db1, &db2] {
+            let (p, cfi): (i32, String) = db
+                .query_row(
+                    "SELECT progress, current_cfi FROM books WHERE id = 'b1'",
+                    [], |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .unwrap();
+            assert_eq!(p, 80);
+            assert_eq!(cfi, "c80");
+        }
+    }
+
+    #[test]
+    fn same_ms_lww_breaks_tie_by_device_uuid() {
+        // Two devices write the same field at the same ms. The lexicographically
+        // larger device id wins the tuple compare.
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    2000,
+                    "dev-A",
+                    EventBody::BookStatusSet {
+                        book: "b1".into(),
+                        status: "reading".into(),
+                    },
+                ),
+                ev(
+                    2000,
+                    "dev-B",
+                    EventBody::BookStatusSet {
+                        book: "b1".into(),
+                        status: "finished".into(),
+                    },
+                ),
+            ],
+        );
+        let (status, dev): (String, String) = db
+            .query_row(
+                "SELECT status, updated_by_device FROM books WHERE id = 'b1'",
+                [], |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "finished", "dev-B > dev-A in tuple compare");
+        assert_eq!(dev, "dev-B");
+
+        // Reverse order — same outcome.
+        let mut db2 = open_db();
+        apply_all(
+            &mut db2,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    2000,
+                    "dev-B",
+                    EventBody::BookStatusSet {
+                        book: "b1".into(),
+                        status: "finished".into(),
+                    },
+                ),
+                ev(
+                    2000,
+                    "dev-A",
+                    EventBody::BookStatusSet {
+                        book: "b1".into(),
+                        status: "reading".into(),
+                    },
+                ),
+            ],
+        );
+        let status2: String = db2
+            .query_row("SELECT status FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(status2, "finished");
+    }
+
+    #[test]
+    fn highlight_color_lww_skips_older_event() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(1100, "dev-A", add_highlight("h1", "b1", "yellow")),
+                ev(
+                    1300,
+                    "dev-A",
+                    EventBody::HighlightColorSet {
+                        id: "h1".into(),
+                        color: "pink".into(),
+                    },
+                ),
+                ev(
+                    1200,
+                    "dev-A",
+                    EventBody::HighlightColorSet {
+                        id: "h1".into(),
+                        color: "green".into(),
+                    },
+                ),
+            ],
+        );
+        let color: String = db
+            .query_row("SELECT color FROM highlights WHERE id = 'h1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(color, "pink", "older color event must lose");
+    }
+
+    #[test]
+    fn vocab_mastery_carries_review_count_idempotently() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::VocabAdd(VocabPayload {
+                        id: "v1".into(),
+                        book_id: "b1".into(),
+                        word: "serendipity".into(),
+                        definition: "fortunate".into(),
+                        context_sentence: None,
+                        cfi: None,
+                        mastery: "new".into(),
+                        review_count: 0,
+                        next_review_at: None,
+                    }),
+                ),
+                ev(
+                    1200,
+                    "dev-A",
+                    EventBody::VocabMasterySet {
+                        id: "v1".into(),
+                        mastery: "learning".into(),
+                        next_review_at: Some(2_000_000),
+                        review_count: 1,
+                    },
+                ),
+                ev(
+                    1300,
+                    "dev-A",
+                    EventBody::VocabMasterySet {
+                        id: "v1".into(),
+                        mastery: "learning".into(),
+                        next_review_at: Some(3_000_000),
+                        review_count: 2,
+                    },
+                ),
+            ],
+        );
+        let (m, n): (String, i64) = db
+            .query_row(
+                "SELECT mastery, review_count FROM vocab_words WHERE id = 'v1'",
+                [], |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(m, "learning");
+        assert_eq!(n, 2, "absolute review_count from later event wins");
+    }
+
+    // -----------------------------------------------------------------------
+    // Determinism (shuffle property)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn shuffled_apply_yields_identical_state() {
+        // Build a fixed event set, apply in two different orders, compare
+        // every column on every row. Apply order must not matter once events
+        // are sorted by (ts, device).
+        let events: Vec<Event> = vec![
+            ev(1000, "dev-A", import_book("b1")),
+            ev(1000, "dev-B", import_book("b2")),
+            ev(1100, "dev-A", add_highlight("h1", "b1", "yellow")),
+            ev(1200, "dev-B", add_highlight("h2", "b2", "blue")),
+            ev(
+                1300,
+                "dev-A",
+                EventBody::HighlightColorSet {
+                    id: "h1".into(),
+                    color: "pink".into(),
+                },
+            ),
+            ev(
+                1400,
+                "dev-A",
+                EventBody::BookProgressSet {
+                    book: "b1".into(),
+                    progress: 25,
+                    cfi: Some("c25".into()),
+                },
+            ),
+            ev(
+                1500,
+                "dev-B",
+                EventBody::BookProgressSet {
+                    book: "b1".into(),
+                    progress: 50,
+                    cfi: Some("c50".into()),
+                },
+            ),
+            ev(
+                1600,
+                "dev-A",
+                EventBody::CollectionCreate {
+                    id: "c1".into(),
+                    name: "Top".into(),
+                    sort_order: 0,
+                },
+            ),
+            ev(
+                1700,
+                "dev-A",
+                EventBody::CollectionBookAdd {
+                    collection: "c1".into(),
+                    book: "b1".into(),
+                },
+            ),
+            ev(
+                1800,
+                "dev-A",
+                EventBody::CollectionRename {
+                    id: "c1".into(),
+                    name: "Favorites".into(),
+                },
+            ),
+            ev(
+                1900,
+                "dev-B",
+                EventBody::HighlightDelete { id: "h2".into() },
+            ),
+        ];
+
+        let mut sorted = events.clone();
+        sorted.sort_by(|a, b| (a.ts, &a.device).cmp(&(b.ts, &b.device)));
+
+        let mut reverse = sorted.clone();
+        reverse.reverse();
+        // After reversing we still need (ts, device) order before apply (the
+        // determinism rule); the property under test is "any pre-sort
+        // permutation produces the same state."
+        reverse.sort_by(|a, b| (a.ts, &a.device).cmp(&(b.ts, &b.device)));
+
+        let mut db1 = open_db();
+        apply_all(&mut db1, &sorted);
+        let mut db2 = open_db();
+        apply_all(&mut db2, &reverse);
+
+        let dump = |db: &Connection| -> Vec<(String, String)> {
+            let tables = [
+                "books",
+                "highlights",
+                "bookmarks",
+                "vocab_words",
+                "translations",
+                "collections",
+                "collection_books",
+                "chats",
+                "chat_messages",
+                "_tombstones",
+            ];
+            let mut out = Vec::new();
+            for t in tables {
+                let mut stmt = db
+                    .prepare(&format!("SELECT * FROM {t} ORDER BY 1, 2"))
+                    .unwrap();
+                let cols = stmt.column_count();
+                let rows = stmt
+                    .query_map([], |r| {
+                        let mut s = String::new();
+                        for i in 0..cols {
+                            let v: rusqlite::types::Value = r.get(i)?;
+                            s.push_str(&format!("{v:?}|"));
+                        }
+                        Ok(s)
+                    })
+                    .unwrap();
+                for row in rows {
+                    out.push((t.to_string(), row.unwrap()));
+                }
+            }
+            out
+        };
+        assert_eq!(dump(&db1), dump(&db2), "shuffle changed final state");
+    }
+
+    // -----------------------------------------------------------------------
+    // book.metadata.set
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn book_metadata_set_updates_string_field_under_lww() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    2000,
+                    "dev-A",
+                    EventBody::BookMetadataSet {
+                        book: "b1".into(),
+                        field: "author".into(),
+                        value: json!("Leo Tolstoy"),
+                    },
+                ),
+            ],
+        );
+        let author: String = db
+            .query_row("SELECT author FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(author, "Leo Tolstoy");
+    }
+
+    #[test]
+    fn book_metadata_set_pages_accepts_number_and_null() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    2000,
+                    "dev-A",
+                    EventBody::BookMetadataSet {
+                        book: "b1".into(),
+                        field: "pages".into(),
+                        value: json!(1225),
+                    },
+                ),
+            ],
+        );
+        let pages: Option<i64> = db
+            .query_row("SELECT pages FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(pages, Some(1225));
+
+        apply_all(
+            &mut db,
+            &[ev(
+                3000,
+                "dev-A",
+                EventBody::BookMetadataSet {
+                    book: "b1".into(),
+                    field: "pages".into(),
+                    value: Value::Null,
+                },
+            )],
+        );
+        let pages: Option<i64> = db
+            .query_row("SELECT pages FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(pages, None);
+    }
+
+    #[test]
+    fn book_metadata_unknown_field_is_skipped() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    2000,
+                    "dev-A",
+                    EventBody::BookMetadataSet {
+                        book: "b1".into(),
+                        field: "future_field".into(),
+                        value: json!("anything"),
+                    },
+                ),
+            ],
+        );
+        // No panic, no crash; row's updated_at is unchanged from the import.
+        let ts: i64 = db
+            .query_row("SELECT updated_at FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(ts, 1000);
+    }
+
+    // -----------------------------------------------------------------------
+    // collection_books composite-key tombstone
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn collection_book_remove_then_add_blocked_by_composite_tombstone() {
+        let mut db = open_db();
+        apply_all(
+            &mut db,
+            &[
+                ev(1000, "dev-A", import_book("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::CollectionCreate {
+                        id: "c1".into(),
+                        name: "Top".into(),
+                        sort_order: 0,
+                    },
+                ),
+                ev(
+                    1200,
+                    "dev-A",
+                    EventBody::CollectionBookAdd {
+                        collection: "c1".into(),
+                        book: "b1".into(),
+                    },
+                ),
+                ev(
+                    1300,
+                    "dev-A",
+                    EventBody::CollectionBookRemove {
+                        collection: "c1".into(),
+                        book: "b1".into(),
+                    },
+                ),
+                ev(
+                    1400,
+                    "dev-A",
+                    EventBody::CollectionBookAdd {
+                        collection: "c1".into(),
+                        book: "b1".into(),
+                    },
+                ),
+            ],
+        );
+        let n: i64 = db
+            .query_row(
+                "SELECT COUNT(*) FROM collection_books WHERE collection_id = 'c1' AND book_id = 'b1'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 0, "composite tombstone should suppress re-add");
+    }
+
+    // -----------------------------------------------------------------------
+    // Idempotency under repeated apply
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn double_apply_is_a_noop() {
+        let events = vec![
+            ev(1000, "dev-A", import_book("b1")),
+            ev(1100, "dev-A", add_highlight("h1", "b1", "yellow")),
+            ev(
+                1200,
+                "dev-A",
+                EventBody::HighlightColorSet {
+                    id: "h1".into(),
+                    color: "pink".into(),
+                },
+            ),
+        ];
+        let mut db = open_db();
+        apply_all(&mut db, &events);
+        // Snapshot the row state, then re-apply.
+        let before: (String, i64, String) = db
+            .query_row(
+                "SELECT color, updated_at, updated_by_device FROM highlights WHERE id = 'h1'",
+                [], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        apply_all(&mut db, &events);
+        let after: (String, i64, String) = db
+            .query_row(
+                "SELECT color, updated_at, updated_by_device FROM highlights WHERE id = 'h1'",
+                [], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(before, after);
+    }
+}

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -1,3 +1,626 @@
-//! `ReplayEngine::tick()` — lists peer logs and snapshots, merges new events
-//! sorted by `(ts, device)`, applies in one SQL transaction, advances
-//! `_replay_state` watermarks. Populated in Chunk 4.
+//! `ReplayEngine::tick()` — the converge step.
+//!
+//! Five phases per call:
+//! 0. **Drain `_pending_publish`.** Any events the local `SyncWriter`
+//!    committed to SQL but failed to append to the device log get appended
+//!    here. Until they're in the log, peers don't see them — so this is the
+//!    publish-retry path that bounds Step 3's commit-then-flush failure
+//!    asymmetry. (See [`docs/impls/sync/31-sync-known-problems.md`] §1.)
+//! 1. **Discover peers.** Walk `<shared>/logs/*.{jsonl,snapshot.json}` and
+//!    bucket by device UUID. The local device is included — its snapshot
+//!    is what pulls conflict-copy rows back into local SQL during migration
+//!    apply-back, and re-applying its own log events is idempotent.
+//! 2. **Read.** For each peer: read snapshot if `_replay_state` says it's
+//!    new; read log events with id > `last_event_id` watermark.
+//! 3. **Sort + apply.** Snapshots applied per-peer first (each updates its
+//!    own watermarks). Events from every peer merged into one global vec
+//!    sorted by `(ts, device)`, then `merge::apply_event` runs them in one
+//!    SQL transaction.
+//! 4. **Commit + advance event watermarks** to the max id seen per peer.
+//!
+//! Foreign keys are toggled OFF before BEGIN and ON after COMMIT — see the
+//! `merge` module's docstring for why. Concurrent ticks are serialized by a
+//! process-wide mutex; the OS scheduler decides which one runs first, but
+//! both produce the same end state because every operation is idempotent.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use rusqlite::{params, Connection};
+
+use crate::error::{AppError, AppResult};
+
+use super::events::{Event, EventBody};
+use super::log::{self, EventLog};
+use super::merge;
+use super::snapshot::Snapshot;
+
+/// Process-wide lock so two callers don't run `tick` concurrently. The lock
+/// is purely for throughput hygiene — concurrent ticks are functionally safe
+/// because every operation is idempotent — but they'd duplicate I/O work.
+static TICK_MUTEX: Mutex<()> = Mutex::new(());
+
+/// What `tick()` did, surfaced for the "Sync now" UI and for tests.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReplayReport {
+    pub outbox_flushed: usize,
+    pub snapshots_applied: usize,
+    pub events_applied: usize,
+    pub peers_seen: usize,
+}
+
+pub struct ReplayEngine {
+    pub shared_dir: PathBuf,
+    pub self_device: String,
+    /// Own log handle, shared with `SyncWriter`. `tick()` writes here when
+    /// flushing the outbox.
+    pub own_log: Arc<EventLog>,
+}
+
+impl ReplayEngine {
+    pub fn new(shared_dir: PathBuf, self_device: String, own_log: Arc<EventLog>) -> Self {
+        Self {
+            shared_dir,
+            self_device,
+            own_log,
+        }
+    }
+
+    pub fn tick(&self, conn: &mut Connection) -> AppResult<ReplayReport> {
+        let _guard = TICK_MUTEX
+            .lock()
+            .map_err(|e| AppError::Other(format!("replay tick mutex poisoned: {e}")))?;
+
+        // Phase 0 — drain the outbox into the device log. Failures here
+        // surface to the caller; peers will see the local writes on the
+        // next successful tick.
+        let outbox_flushed = self.flush_outbox(conn)?;
+
+        // Phase 1 — discover peers (including self).
+        let peers = discover_peers(&self.shared_dir)?;
+        let peers_seen = peers.len();
+
+        // Phase 2/3/4 — read peer files, apply in one tx, advance watermarks.
+        // FK off mirrors the merge engine's contract; orphan rows from
+        // out-of-order delivery are tolerated until parents arrive.
+        conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
+
+        let mut snapshots_applied = 0usize;
+        let mut events_applied = 0usize;
+        let mut peer_max_event: BTreeMap<String, String> = BTreeMap::new();
+
+        {
+            let tx = conn.transaction()?;
+
+            // 3a. Apply snapshots first. Each snapshot apply updates its own
+            //     `_replay_state.last_snapshot_id` (and `last_event_id` if
+            //     the snapshot moves the watermark forward). Doing them
+            //     before reading the log tails means the per-peer
+            //     `last_event_id` we read in 3b reflects any snapshot bump.
+            for (device, files) in &peers {
+                let Some(snap_path) = &files.snap_path else {
+                    continue;
+                };
+                let snap = match Snapshot::read_from(snap_path) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!(
+                            "sync: skipping malformed snapshot {}: {e}",
+                            snap_path.display()
+                        );
+                        continue;
+                    }
+                };
+                let outcome = snap.apply_peer(&tx, device)?;
+                if matches!(
+                    outcome,
+                    super::snapshot::ApplyOutcome::Applied
+                        | super::snapshot::ApplyOutcome::HeaderOnly
+                ) {
+                    snapshots_applied += 1;
+                }
+            }
+
+            // 3b. Read each peer's log tail past its (possibly just-bumped)
+            //     watermark. Collect all events into one vec, sort globally
+            //     by `(ts, device)`, apply in order.
+            let mut all_events: Vec<Event> = Vec::new();
+            for (device, files) in &peers {
+                let Some(log_path) = &files.log_path else {
+                    continue;
+                };
+                let last_id = read_last_event_id(&tx, device)?;
+                let events = log::read_log_file_after(log_path, last_id.as_deref())?;
+                for ev in events {
+                    all_events.push(ev);
+                }
+            }
+
+            all_events.sort_by(|a, b| (a.ts, &a.device).cmp(&(b.ts, &b.device)));
+
+            for ev in &all_events {
+                merge::apply_event(&tx, ev)?;
+                let entry = peer_max_event.entry(ev.device.clone()).or_default();
+                if ev.id > *entry {
+                    *entry = ev.id.clone();
+                }
+                events_applied += 1;
+            }
+
+            // 4. Advance each peer's last_event_id watermark to the highest
+            //    id we just consumed. Monotonic: never go backward.
+            for (device, max_id) in &peer_max_event {
+                bump_event_watermark(&tx, device, max_id)?;
+            }
+
+            tx.commit()?;
+        }
+
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+
+        Ok(ReplayReport {
+            outbox_flushed,
+            snapshots_applied,
+            events_applied,
+            peers_seen,
+        })
+    }
+
+    /// Drain `_pending_publish` into the own device log. Each row is
+    /// re-serialized into an `EventBody`, appended (which mints a fresh
+    /// ULID), and on success deleted from the outbox. If the append fails,
+    /// the row stays put for the next tick.
+    fn flush_outbox(&self, conn: &mut Connection) -> AppResult<usize> {
+        let pending = read_outbox(conn)?;
+        if pending.is_empty() {
+            return Ok(0);
+        }
+
+        let mut flushed = 0usize;
+        for row in &pending {
+            let body: EventBody = serde_json::from_str(&row.body_json).map_err(|e| {
+                AppError::Other(format!(
+                    "outbox row {}: malformed body_json: {e}",
+                    row.id
+                ))
+            })?;
+            self.own_log.append(body, row.ts)?;
+            // Per-row delete: if a later append in this batch fails, the
+            // earlier rows are already published and can be removed cleanly.
+            conn.execute(
+                "DELETE FROM _pending_publish WHERE id = ?1",
+                params![row.id],
+            )?;
+            flushed += 1;
+        }
+        Ok(flushed)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Peer discovery.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Clone)]
+struct PeerFiles {
+    log_path: Option<PathBuf>,
+    snap_path: Option<PathBuf>,
+}
+
+/// Walk `<shared>/logs/` and bucket files by device UUID. Returns a sorted
+/// map (BTreeMap) so iteration order is deterministic for tests.
+fn discover_peers(shared_dir: &Path) -> AppResult<BTreeMap<String, PeerFiles>> {
+    let logs_dir = shared_dir.join("logs");
+    let mut peers: BTreeMap<String, PeerFiles> = BTreeMap::new();
+    if !logs_dir.exists() {
+        return Ok(peers);
+    }
+    for entry in fs::read_dir(&logs_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name: String = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if let Some(device) = name.strip_suffix(".snapshot.json") {
+            peers.entry(device.to_string()).or_default().snap_path = Some(path);
+        } else if let Some(device) = name.strip_suffix(".jsonl") {
+            peers.entry(device.to_string()).or_default().log_path = Some(path);
+        }
+        // Anything else (e.g. `*.tmp` from in-progress writes) is skipped.
+    }
+    Ok(peers)
+}
+
+// ---------------------------------------------------------------------------
+// Watermark + outbox SQL.
+// ---------------------------------------------------------------------------
+
+fn read_last_event_id(tx: &rusqlite::Transaction, peer: &str) -> AppResult<Option<String>> {
+    let v: Option<Option<String>> = tx
+        .query_row(
+            "SELECT last_event_id FROM _replay_state WHERE peer_device = ?1",
+            params![peer],
+            |r| r.get(0),
+        )
+        .map(Some)
+        .or_else(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other),
+        })?;
+    Ok(v.flatten())
+}
+
+fn bump_event_watermark(tx: &rusqlite::Transaction, peer: &str, max_id: &str) -> AppResult<()> {
+    let now = chrono::Utc::now().timestamp_millis();
+    // INSERT or UPDATE; the WHERE clause on the UPDATE side enforces the
+    // "never decrease" invariant.
+    tx.execute(
+        "INSERT INTO _replay_state (peer_device, last_snapshot_id, last_event_id, updated_at)
+         VALUES (?1, NULL, ?2, ?3)
+         ON CONFLICT(peer_device) DO UPDATE SET
+           last_event_id = CASE
+                              WHEN excluded.last_event_id > _replay_state.last_event_id
+                                OR _replay_state.last_event_id IS NULL
+                                  THEN excluded.last_event_id
+                              ELSE _replay_state.last_event_id
+                            END,
+           updated_at    = excluded.updated_at",
+        params![peer, max_id, now],
+    )?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct OutboxRow {
+    id: String,
+    ts: i64,
+    body_json: String,
+}
+
+fn read_outbox(conn: &Connection) -> AppResult<Vec<OutboxRow>> {
+    let mut stmt = conn
+        .prepare("SELECT id, ts, body_json FROM _pending_publish ORDER BY id")?;
+    let collected: Vec<OutboxRow> = stmt
+        .query_map([], |r| {
+            Ok(OutboxRow {
+                id: r.get(0)?,
+                ts: r.get(1)?,
+                body_json: r.get(2)?,
+            })
+        })?
+        .collect::<Result<_, _>>()?;
+    Ok(collected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Db;
+    use crate::sync::events::*;
+    use serde_json::Map;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    /// Test harness: shared dir + local SQLite + own EventLog.
+    struct Env {
+        _dir: TempDir,
+        shared: PathBuf,
+        conn: Connection,
+        engine: ReplayEngine,
+    }
+
+    fn setup(self_device: &str) -> Env {
+        let dir = TempDir::new().unwrap();
+        let shared = dir.path().join("shared");
+        let logs = shared.join("logs");
+        fs::create_dir_all(&logs).unwrap();
+
+        let conn = Connection::open_in_memory().unwrap();
+        Db::run_migrations_on(&conn).unwrap();
+
+        let own_log_path = logs.join(format!("{self_device}.jsonl"));
+        let own_log = Arc::new(EventLog::open(&own_log_path, self_device, false).unwrap());
+
+        let engine = ReplayEngine::new(shared.clone(), self_device.to_string(), own_log);
+        Env {
+            _dir: dir,
+            shared,
+            conn,
+            engine,
+        }
+    }
+
+    fn write_peer_log(shared: &Path, peer: &str, events: &[Event]) {
+        let p = shared.join("logs").join(format!("{peer}.jsonl"));
+        let mut bytes = Vec::new();
+        for e in events {
+            let line = serde_json::to_vec(e).unwrap();
+            bytes.extend_from_slice(&line);
+            bytes.push(b'\n');
+        }
+        fs::write(p, bytes).unwrap();
+    }
+
+    fn ev(ts: i64, device: &str, body: EventBody) -> Event {
+        Event {
+            id: format!("01HYZX0000000000000000{:04X}", ts as u16),
+            ts,
+            device: device.to_string(),
+            v: EVENT_SCHEMA_VERSION,
+            body,
+            extra: Map::new(),
+        }
+    }
+
+    fn import(id: &str) -> EventBody {
+        EventBody::BookImport(BookImportPayload {
+            id: id.into(),
+            title: format!("Book {id}"),
+            author: "Author".into(),
+            description: None,
+            cover_path: None,
+            file_path: format!("books/{id}.epub"),
+            format: "epub".into(),
+            genre: None,
+            pages: Some(100),
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Outbox flush
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn outbox_drains_into_own_log_and_advances_to_caller() {
+        let mut env = setup("self");
+        // Seed two outbox rows representing previously-committed SQL writes
+        // whose log append failed.
+        let body1 = import("b1");
+        let body2 = import("b2");
+        env.conn
+            .execute(
+                "INSERT INTO _pending_publish (id, ts, body_json, created_at) VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    uuid::Uuid::new_v4().to_string(),
+                    1000_i64,
+                    serde_json::to_string(&body1).unwrap(),
+                    chrono::Utc::now().timestamp_millis(),
+                ],
+            )
+            .unwrap();
+        env.conn
+            .execute(
+                "INSERT INTO _pending_publish (id, ts, body_json, created_at) VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    uuid::Uuid::new_v4().to_string(),
+                    1100_i64,
+                    serde_json::to_string(&body2).unwrap(),
+                    chrono::Utc::now().timestamp_millis(),
+                ],
+            )
+            .unwrap();
+
+        let report = env.engine.tick(&mut env.conn).unwrap();
+        assert_eq!(report.outbox_flushed, 2);
+
+        // Outbox is empty.
+        let n: i64 = env
+            .conn
+            .query_row("SELECT COUNT(*) FROM _pending_publish", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0);
+
+        // Own log has both events; the events are then re-applied in this
+        // same tick (own device is treated as a peer), so the books table
+        // reflects them.
+        let log_events = env.engine.own_log.read_all().unwrap();
+        assert_eq!(log_events.len(), 2);
+
+        let n_books: i64 = env
+            .conn
+            .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_books, 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Peer log discovery + apply
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn applies_events_from_a_single_peer_log() {
+        let mut env = setup("self");
+        let peer_events = vec![
+            ev(1000, "peer-A", import("b1")),
+            ev(
+                1100,
+                "peer-A",
+                EventBody::HighlightAdd(HighlightPayload {
+                    id: "h1".into(),
+                    book_id: "b1".into(),
+                    cfi_range: "cfi".into(),
+                    color: "yellow".into(),
+                    note: None,
+                    text_content: None,
+                }),
+            ),
+        ];
+        write_peer_log(&env.shared, "peer-A", &peer_events);
+
+        let report = env.engine.tick(&mut env.conn).unwrap();
+        assert_eq!(report.events_applied, 2);
+        assert_eq!(report.peers_seen, 2, "peer-A + self");
+
+        let n_books: i64 = env
+            .conn
+            .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_books, 1);
+
+        // Watermark advanced to the max id from peer-A.
+        let last: Option<String> = env
+            .conn
+            .query_row(
+                "SELECT last_event_id FROM _replay_state WHERE peer_device = 'peer-A'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(last.as_deref(), Some(peer_events[1].id.as_str()));
+    }
+
+    #[test]
+    fn watermark_skips_already_applied_events_on_second_tick() {
+        let mut env = setup("self");
+        let peer_events = vec![ev(1000, "peer-A", import("b1"))];
+        write_peer_log(&env.shared, "peer-A", &peer_events);
+
+        let r1 = env.engine.tick(&mut env.conn).unwrap();
+        assert_eq!(r1.events_applied, 1);
+
+        // Second tick — same log, no new events.
+        let r2 = env.engine.tick(&mut env.conn).unwrap();
+        assert_eq!(r2.events_applied, 0, "watermark should suppress re-apply");
+
+        // Append a new event to peer-A's log; tick picks it up.
+        let mut more = peer_events.clone();
+        more.push(ev(
+            2000,
+            "peer-A",
+            EventBody::BookProgressSet {
+                book: "b1".into(),
+                progress: 50,
+                cfi: Some("c50".into()),
+            },
+        ));
+        write_peer_log(&env.shared, "peer-A", &more);
+
+        let r3 = env.engine.tick(&mut env.conn).unwrap();
+        assert_eq!(r3.events_applied, 1);
+
+        let progress: i32 = env
+            .conn
+            .query_row("SELECT progress FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(progress, 50);
+    }
+
+    #[test]
+    fn cross_peer_events_apply_in_global_ts_order() {
+        let mut env = setup("self");
+        // Two peers write the same book progress at different ts.
+        write_peer_log(&env.shared, "peer-A", &[
+            ev(1000, "peer-A", import("b1")),
+            ev(
+                1500,
+                "peer-A",
+                EventBody::BookProgressSet {
+                    book: "b1".into(),
+                    progress: 25,
+                    cfi: Some("cA".into()),
+                },
+            ),
+        ]);
+        write_peer_log(&env.shared, "peer-B", &[
+            ev(
+                2000,
+                "peer-B",
+                EventBody::BookProgressSet {
+                    book: "b1".into(),
+                    progress: 80,
+                    cfi: Some("cB".into()),
+                },
+            ),
+        ]);
+
+        env.engine.tick(&mut env.conn).unwrap();
+        let progress: i32 = env
+            .conn
+            .query_row("SELECT progress FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(progress, 80, "later peer-B event wins");
+    }
+
+    // -----------------------------------------------------------------------
+    // Snapshot pickup
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn applies_peer_snapshot_then_log_tail() {
+        let mut env = setup("self");
+        // Build peer-A's snapshot + log split. Snapshot covers b1; the log
+        // adds a highlight after the snapshot.
+        let snap_events = vec![ev(1000, "peer-A", import("b1"))];
+        let snap = Snapshot::from_events("peer-A", &snap_events).unwrap();
+        let snap_path = env.shared.join("logs/peer-A.snapshot.json");
+        snap.write_atomic(&snap_path).unwrap();
+
+        let tail = vec![ev(
+            2000,
+            "peer-A",
+            EventBody::HighlightAdd(HighlightPayload {
+                id: "h1".into(),
+                book_id: "b1".into(),
+                cfi_range: "cfi".into(),
+                color: "yellow".into(),
+                note: None,
+                text_content: None,
+            }),
+        )];
+        write_peer_log(&env.shared, "peer-A", &tail);
+
+        let report = env.engine.tick(&mut env.conn).unwrap();
+        assert!(report.snapshots_applied >= 1);
+        assert_eq!(report.events_applied, 1);
+
+        let n_books: i64 = env
+            .conn
+            .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+            .unwrap();
+        let n_hl: i64 = env
+            .conn
+            .query_row("SELECT COUNT(*) FROM highlights", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_books, 1);
+        assert_eq!(n_hl, 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn empty_shared_dir_is_a_noop() {
+        let mut env = setup("self");
+        let report = env.engine.tick(&mut env.conn).unwrap();
+        // Self log was created at setup → 1 peer (self).
+        assert_eq!(report.peers_seen, 1);
+        assert_eq!(report.events_applied, 0);
+        assert_eq!(report.outbox_flushed, 0);
+    }
+
+    #[test]
+    fn malformed_snapshot_is_skipped_not_fatal() {
+        let mut env = setup("self");
+        let bad = env.shared.join("logs/peer-X.snapshot.json");
+        fs::write(&bad, b"{not valid json").unwrap();
+        // Tick must not error; bad file is logged + skipped.
+        let report = env.engine.tick(&mut env.conn).unwrap();
+        assert_eq!(report.snapshots_applied, 0);
+        assert_eq!(report.events_applied, 0);
+    }
+
+    #[test]
+    fn fk_pragma_restored_after_tick() {
+        let mut env = setup("self");
+        env.conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        env.engine.tick(&mut env.conn).unwrap();
+        let fk: i64 = env
+            .conn
+            .query_row("PRAGMA foreign_keys", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(fk, 1, "FK should be restored to ON after tick");
+    }
+}

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -85,80 +85,20 @@ impl ReplayEngine {
         // Phase 2/3/4 — read peer files, apply in one tx, advance watermarks.
         // FK off mirrors the merge engine's contract; orphan rows from
         // out-of-order delivery are tolerated until parents arrive.
+        //
+        // The pragma must be restored even if the merge work errors mid-way,
+        // otherwise the shared connection silently loses FK enforcement for
+        // every subsequent command. We capture the inner result and run the
+        // restore unconditionally before returning.
         conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
+        let inner = self.apply_in_tx(conn, &peers);
+        let restore = conn.execute_batch("PRAGMA foreign_keys = ON;");
 
-        let mut snapshots_applied = 0usize;
-        let mut events_applied = 0usize;
-        let mut peer_max_event: BTreeMap<String, String> = BTreeMap::new();
-
-        {
-            let tx = conn.transaction()?;
-
-            // 3a. Apply snapshots first. Each snapshot apply updates its own
-            //     `_replay_state.last_snapshot_id` (and `last_event_id` if
-            //     the snapshot moves the watermark forward). Doing them
-            //     before reading the log tails means the per-peer
-            //     `last_event_id` we read in 3b reflects any snapshot bump.
-            for (device, files) in &peers {
-                let Some(snap_path) = &files.snap_path else {
-                    continue;
-                };
-                let snap = match Snapshot::read_from(snap_path) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        eprintln!(
-                            "sync: skipping malformed snapshot {}: {e}",
-                            snap_path.display()
-                        );
-                        continue;
-                    }
-                };
-                let outcome = snap.apply_peer(&tx, device)?;
-                if matches!(
-                    outcome,
-                    super::snapshot::ApplyOutcome::Applied
-                        | super::snapshot::ApplyOutcome::HeaderOnly
-                ) {
-                    snapshots_applied += 1;
-                }
-            }
-
-            // 3b. Read each peer's log tail past its (possibly just-bumped)
-            //     watermark. Collect all events into one vec, sort globally
-            //     by `(ts, device)`, apply in order.
-            let mut all_events: Vec<Event> = Vec::new();
-            for (device, files) in &peers {
-                let Some(log_path) = &files.log_path else {
-                    continue;
-                };
-                let last_id = read_last_event_id(&tx, device)?;
-                let events = log::read_log_file_after(log_path, last_id.as_deref())?;
-                for ev in events {
-                    all_events.push(ev);
-                }
-            }
-
-            all_events.sort_by(|a, b| (a.ts, &a.device).cmp(&(b.ts, &b.device)));
-
-            for ev in &all_events {
-                merge::apply_event(&tx, ev)?;
-                let entry = peer_max_event.entry(ev.device.clone()).or_default();
-                if ev.id > *entry {
-                    *entry = ev.id.clone();
-                }
-                events_applied += 1;
-            }
-
-            // 4. Advance each peer's last_event_id watermark to the highest
-            //    id we just consumed. Monotonic: never go backward.
-            for (device, max_id) in &peer_max_event {
-                bump_event_watermark(&tx, device, max_id)?;
-            }
-
-            tx.commit()?;
-        }
-
-        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+        let (snapshots_applied, events_applied) = match (inner, restore) {
+            (Ok(counts), Ok(())) => counts,
+            (Err(e), _) => return Err(e),
+            (Ok(_), Err(e)) => return Err(AppError::Db(e)),
+        };
 
         Ok(ReplayReport {
             outbox_flushed,
@@ -166,6 +106,84 @@ impl ReplayEngine {
             events_applied,
             peers_seen,
         })
+    }
+
+    /// Inner helper for `tick`: snapshot apply + log-tail merge inside a
+    /// single SQL transaction. Returns `(snapshots_applied, events_applied)`
+    /// counts. Caller is responsible for toggling `PRAGMA foreign_keys`
+    /// around the call so any error here doesn't leak FK = OFF.
+    fn apply_in_tx(
+        &self,
+        conn: &mut Connection,
+        peers: &BTreeMap<String, PeerFiles>,
+    ) -> AppResult<(usize, usize)> {
+        let mut snapshots_applied = 0usize;
+        let mut events_applied = 0usize;
+        let mut peer_max_event: BTreeMap<String, String> = BTreeMap::new();
+
+        let tx = conn.transaction()?;
+
+        // 3a. Apply snapshots first. Each snapshot apply updates its own
+        //     `_replay_state.last_snapshot_id` (and `last_event_id` if the
+        //     snapshot moves the watermark forward). Doing them before the
+        //     log tails means the per-peer `last_event_id` we read in 3b
+        //     reflects any snapshot bump.
+        for (device, files) in peers {
+            let Some(snap_path) = &files.snap_path else {
+                continue;
+            };
+            let snap = match Snapshot::read_from(snap_path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!(
+                        "sync: skipping malformed snapshot {}: {e}",
+                        snap_path.display()
+                    );
+                    continue;
+                }
+            };
+            let outcome = snap.apply_peer(&tx, device)?;
+            if matches!(
+                outcome,
+                super::snapshot::ApplyOutcome::Applied
+                    | super::snapshot::ApplyOutcome::HeaderOnly
+            ) {
+                snapshots_applied += 1;
+            }
+        }
+
+        // 3b. Read each peer's log tail past its (possibly just-bumped)
+        //     watermark. Collect, sort by `(ts, device)`, apply.
+        let mut all_events: Vec<Event> = Vec::new();
+        for (device, files) in peers {
+            let Some(log_path) = &files.log_path else {
+                continue;
+            };
+            let last_id = read_last_event_id(&tx, device)?;
+            let events = log::read_log_file_after(log_path, last_id.as_deref())?;
+            for ev in events {
+                all_events.push(ev);
+            }
+        }
+        all_events.sort_by(|a, b| (a.ts, &a.device).cmp(&(b.ts, &b.device)));
+
+        for ev in &all_events {
+            merge::apply_event(&tx, ev)?;
+            let entry = peer_max_event.entry(ev.device.clone()).or_default();
+            if ev.id > *entry {
+                *entry = ev.id.clone();
+            }
+            events_applied += 1;
+        }
+
+        // 4. Advance each peer's last_event_id watermark to the highest id
+        //    we just consumed. Monotonic: never go backward.
+        for (device, max_id) in &peer_max_event {
+            bump_event_watermark(&tx, device, max_id)?;
+        }
+
+        tx.commit()?;
+        Ok((snapshots_applied, events_applied))
     }
 
     /// Drain `_pending_publish` into the own device log. Each row is
@@ -610,6 +628,41 @@ mod tests {
         let report = env.engine.tick(&mut env.conn).unwrap();
         assert_eq!(report.snapshots_applied, 0);
         assert_eq!(report.events_applied, 0);
+    }
+
+    #[test]
+    fn fk_pragma_restored_even_when_merge_errors() {
+        // Regression for PR #189 finding #4: a malformed event inside the
+        // log triggers an error inside `apply_in_tx`, which used to skip
+        // the `PRAGMA foreign_keys = ON` restore. Inject one (a
+        // book.metadata.set with a number where a string is expected) and
+        // assert the connection's FK pragma is back to ON after tick
+        // returns Err.
+        let mut env = setup("self");
+        let bad = vec![
+            ev(1000, "peer-A", import("b1")),
+            ev(
+                2000,
+                "peer-A",
+                EventBody::BookMetadataSet {
+                    book: "b1".into(),
+                    field: "title".into(),
+                    value: serde_json::json!(42), // wrong type — apply_book_metadata returns Err
+                },
+            ),
+        ];
+        write_peer_log(&env.shared, "peer-A", &bad);
+
+        // Pre-set FK ON so the restore is observable.
+        env.conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        let result = env.engine.tick(&mut env.conn);
+        assert!(result.is_err(), "malformed metadata event should propagate");
+
+        let fk: i64 = env
+            .conn
+            .query_row("PRAGMA foreign_keys", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(fk, 1, "FK must be restored to ON even after a tick error");
     }
 
     #[test]

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -323,7 +323,7 @@ impl Snapshot {
         // removed pair, etc.
         for (entity, list) in &self.state.tombstones {
             for t in list {
-                merge::cascade_delete(tx, entity, &t.id)?;
+                merge::cascade_delete(tx, entity, &t.id, t.ts)?;
                 merge::insert_tombstone(tx, entity, &t.id, t.ts)?;
             }
         }

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -315,12 +315,15 @@ impl Snapshot {
             return Ok(ApplyOutcome::HeaderOnly);
         }
 
-        // Spec step 5: tombstones first.
+        // Spec step 5: tombstones first. Route every entry through
+        // `merge::cascade_delete` so a snapshot ingest scrubs the same
+        // child rows that the corresponding event-path delete would have
+        // — otherwise applying a peer snapshot leaves orphan highlights
+        // for a deleted book, stranded `collection_books` joins for a
+        // removed pair, etc.
         for (entity, list) in &self.state.tombstones {
             for t in list {
-                if let Some(table) = entity_to_table(entity) {
-                    delete_by_id(tx, table, &t.id)?;
-                }
+                merge::cascade_delete(tx, entity, &t.id)?;
                 merge::insert_tombstone(tx, entity, &t.id, t.ts)?;
             }
         }
@@ -560,33 +563,6 @@ fn insert_chat_message(tx: &Transaction, id: &str, r: &ChatMessageRow) -> AppRes
         params![id, r.chat_id, r.role, r.content, r.context, r.metadata, r.created_at, r.updated_at],
     )?;
     Ok(())
-}
-
-fn delete_by_id(tx: &Transaction, table: &str, id: &str) -> AppResult<()> {
-    let sql = format!("DELETE FROM {table} WHERE id = ?1");
-    tx.execute(&sql, params![id])?;
-    Ok(())
-}
-
-fn entity_to_table(entity: &str) -> Option<&'static str> {
-    match entity {
-        merge::entity::BOOK => Some("books"),
-        merge::entity::HIGHLIGHT => Some("highlights"),
-        merge::entity::BOOKMARK => Some("bookmarks"),
-        merge::entity::VOCAB => Some("vocab_words"),
-        merge::entity::TRANSLATION => Some("translations"),
-        merge::entity::COLLECTION => Some("collections"),
-        merge::entity::CHAT => Some("chats"),
-        merge::entity::CHAT_MESSAGE => Some("chat_messages"),
-        // collection_books has a composite primary key; tombstones for it
-        // carry the synthetic `"<col>:<book>"` id which doesn't map cleanly
-        // to a single-column WHERE clause. We don't try to delete the row
-        // here — the merge::apply_collection_book_remove path handles row
-        // deletion before tombstoning, and `apply_peer`'s tombstone-first
-        // pass only needs to ensure the tombstone exists locally.
-        merge::entity::COLLECTION_BOOK => None,
-        _ => None,
-    }
 }
 
 fn upsert_replay_state(
@@ -1169,6 +1145,158 @@ mod tests {
             .query_row("SELECT progress FROM books WHERE id = 'b1'", [], |r| r.get(0))
             .unwrap();
         assert_eq!(progress, 80, "newer local value survives older snapshot");
+    }
+
+    // -----------------------------------------------------------------------
+    // Regression for PR #189 finding #1: snapshot tombstones must scrub the
+    // same child rows the event-path delete would have. Two scenarios:
+    //
+    //   a. `book.delete` from a peer leaves no orphan highlights/bookmarks/
+    //      vocab/etc. when ingested via snapshot.
+    //   b. `collection.book.remove` from a peer drops the join row, even
+    //      though the composite-key tombstone has no single-column id.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn snapshot_tombstone_for_book_removes_local_children() {
+        // Local-A imported b1 and added a highlight + bookmark + vocab.
+        // Peer-B's snapshot says b1 was deleted. Apply must scrub the
+        // children, not just leave them dangling.
+        let mut local = open_db();
+        apply_to(
+            &mut local,
+            &[
+                ev(1000, "dev-A", import("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::HighlightAdd(HighlightPayload {
+                        id: "h1".into(),
+                        book_id: "b1".into(),
+                        cfi_range: "cfi".into(),
+                        color: "yellow".into(),
+                        note: None,
+                        text_content: None,
+                    }),
+                ),
+                ev(
+                    1200,
+                    "dev-A",
+                    EventBody::BookmarkAdd(BookmarkPayload {
+                        id: "bm1".into(),
+                        book_id: "b1".into(),
+                        cfi: "cfi".into(),
+                        label: None,
+                    }),
+                ),
+            ],
+        );
+
+        // Peer-B's snapshot reflects: imported b1, then deleted it.
+        let peer_events = vec![
+            ev(900, "dev-B", import("b1")),
+            ev(2000, "dev-B", EventBody::BookDelete { id: "b1".into() }),
+        ];
+        let snap = Snapshot::from_events("dev-B", &peer_events).unwrap();
+
+        {
+            let tx = local.transaction().unwrap();
+            snap.apply_peer(&tx, "dev-B").unwrap();
+            tx.commit().unwrap();
+        }
+
+        for table in ["books", "highlights", "bookmarks"] {
+            let n: i64 = local
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(
+                n, 0,
+                "snapshot tombstone for book must cascade to {table}"
+            );
+        }
+        let tomb: i64 = local
+            .query_row(
+                "SELECT COUNT(*) FROM _tombstones WHERE entity = 'book' AND id = 'b1'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(tomb, 1);
+    }
+
+    #[test]
+    fn snapshot_tombstone_for_collection_book_removes_join_row() {
+        // Local-A has the join row (c1, b1). Peer-B's snapshot includes a
+        // composite-key tombstone for the same pair. The join row must be
+        // gone after apply.
+        let mut local = open_db();
+        apply_to(
+            &mut local,
+            &[
+                ev(1000, "dev-A", import("b1")),
+                ev(
+                    1100,
+                    "dev-A",
+                    EventBody::CollectionCreate {
+                        id: "c1".into(),
+                        name: "Top".into(),
+                        sort_order: 0,
+                    },
+                ),
+                ev(
+                    1200,
+                    "dev-A",
+                    EventBody::CollectionBookAdd {
+                        collection: "c1".into(),
+                        book: "b1".into(),
+                    },
+                ),
+            ],
+        );
+
+        let peer_events = vec![
+            ev(900, "dev-B", import("b1")),
+            ev(
+                950,
+                "dev-B",
+                EventBody::CollectionCreate {
+                    id: "c1".into(),
+                    name: "Top".into(),
+                    sort_order: 0,
+                },
+            ),
+            ev(
+                1000,
+                "dev-B",
+                EventBody::CollectionBookAdd {
+                    collection: "c1".into(),
+                    book: "b1".into(),
+                },
+            ),
+            ev(
+                2000,
+                "dev-B",
+                EventBody::CollectionBookRemove {
+                    collection: "c1".into(),
+                    book: "b1".into(),
+                },
+            ),
+        ];
+        let snap = Snapshot::from_events("dev-B", &peer_events).unwrap();
+        {
+            let tx = local.transaction().unwrap();
+            snap.apply_peer(&tx, "dev-B").unwrap();
+            tx.commit().unwrap();
+        }
+        let n: i64 = local
+            .query_row(
+                "SELECT COUNT(*) FROM collection_books WHERE collection_id = 'c1' AND book_id = 'b1'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            n, 0,
+            "composite-key snapshot tombstone must drop the join row"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -1,3 +1,1265 @@
-//! Periodic snapshot of an own log — compaction + fast bootstrap for new
-//! peers. `Snapshot::{from_log, write_atomic, apply_peer}`. Populated in
-//! Chunk 4 (read/write) and Chunk 8 (compaction triggers).
+//! Snapshots — frozen materialized state of one peer's log, used for both
+//! compaction (own log → snapshot) and bootstrap (peer snapshot → local DB).
+//!
+//! A snapshot is a JSON file at `<shared>/logs/<device>.snapshot.json` with
+//! the shape:
+//!
+//! ```jsonc
+//! {
+//!   "v": 1,
+//!   "device": "<uuid>",
+//!   "id": "<latest event ULID included>",
+//!   "generated_at": <unix millis>,
+//!   "truncated_before": "<event id>" | null,   // null for migration snapshots
+//!   "state": { "books": {...}, "highlights": {...}, ..., "tombstones": {...} }
+//! }
+//! ```
+//!
+//! `apply_peer` is the inverse: ingest a peer's snapshot into local SQLite
+//! under the same merge rules as `merge::apply_event`. Per-row LWW (compare
+//! `(updated_at, updated_by_device)` tuples), tombstones win over inserts,
+//! `_replay_state` watermarks are updated monotonically. See Step 6 of
+//! `docs/impls/sync/31-sync.md` for the apply procedure.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use rusqlite::{params, Connection, Transaction};
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+use crate::db::Db;
+use crate::error::{AppError, AppResult};
+
+use super::events::Event;
+use super::merge;
+
+pub const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Snapshot {
+    pub v: u32,
+    pub device: String,
+    /// ULID of the last event included in `state`. For a from-log snapshot
+    /// this is the highest event id from the source log; for migration
+    /// snapshots it's a freshly-minted ULID.
+    pub id: String,
+    pub generated_at: i64,
+    /// Compaction watermark — events with id `<= truncated_before` in the
+    /// source log can safely be discarded after the snapshot lands. `None`
+    /// for migration snapshots, which are written before any log exists.
+    pub truncated_before: Option<String>,
+    pub state: SnapshotState,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SnapshotState {
+    #[serde(default)]
+    pub books: BTreeMap<String, BookRow>,
+    #[serde(default)]
+    pub highlights: BTreeMap<String, HighlightRow>,
+    #[serde(default)]
+    pub bookmarks: BTreeMap<String, BookmarkRow>,
+    #[serde(default)]
+    pub vocab_words: BTreeMap<String, VocabRow>,
+    #[serde(default)]
+    pub translations: BTreeMap<String, TranslationRow>,
+    #[serde(default)]
+    pub collections: BTreeMap<String, CollectionRow>,
+    /// Keyed by `"<collection_id>:<book_id>"` — the same composite key the
+    /// merge engine uses for tombstones.
+    #[serde(default)]
+    pub collection_books: BTreeMap<String, CollectionBookRow>,
+    #[serde(default)]
+    pub chats: BTreeMap<String, ChatRow>,
+    #[serde(default)]
+    pub chat_messages: BTreeMap<String, ChatMessageRow>,
+    /// `entity` (the same string in `_tombstones.entity`) → list of ids.
+    #[serde(default)]
+    pub tombstones: BTreeMap<String, Vec<TombstoneRow>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BookRow {
+    pub title: String,
+    pub author: String,
+    pub description: Option<String>,
+    pub cover_path: Option<String>,
+    pub file_path: String,
+    pub genre: Option<String>,
+    pub pages: Option<i64>,
+    pub format: String,
+    pub status: String,
+    pub progress: i32,
+    pub current_cfi: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub updated_by_device: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HighlightRow {
+    pub book_id: String,
+    pub cfi_range: String,
+    pub color: String,
+    pub note: Option<String>,
+    pub text_content: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub updated_by_device: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BookmarkRow {
+    pub book_id: String,
+    pub cfi: String,
+    pub label: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VocabRow {
+    pub book_id: String,
+    pub word: String,
+    pub definition: String,
+    pub context_sentence: Option<String>,
+    pub cfi: Option<String>,
+    pub mastery: String,
+    pub review_count: i64,
+    pub next_review_at: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub updated_by_device: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TranslationRow {
+    pub book_id: String,
+    pub source_text: String,
+    pub translated_text: String,
+    pub target_language: String,
+    pub cfi: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CollectionRow {
+    pub name: String,
+    pub sort_order: i32,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub updated_by_device: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CollectionBookRow {
+    pub collection_id: String,
+    pub book_id: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub updated_by_device: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChatRow {
+    pub book_id: String,
+    pub title: String,
+    pub model: Option<String>,
+    pub pinned: bool,
+    pub metadata: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub updated_by_device: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChatMessageRow {
+    pub chat_id: String,
+    pub role: String,
+    pub content: String,
+    pub context: Option<String>,
+    pub metadata: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TombstoneRow {
+    pub id: String,
+    pub ts: i64,
+}
+
+/// Outcome reported back to the replay engine after a peer snapshot is
+/// processed. Mirrors the watermark advance written into `_replay_state`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplyOutcome {
+    /// Snapshot id matches `_replay_state.last_snapshot_id` — no-op.
+    AlreadyApplied,
+    /// Snapshot id `<=` `_replay_state.last_event_id`; we've already seen
+    /// every event this snapshot summarises individually. Watermarks are
+    /// advanced to `last_snapshot_id = snapshot.id` so we don't re-parse it.
+    HeaderOnly,
+    /// Snapshot rows applied; `last_snapshot_id` set, `last_event_id` bumped
+    /// to `MAX(prev, snapshot.id)`.
+    Applied,
+}
+
+impl Snapshot {
+    /// Build a snapshot from an event sequence. Used by compaction (own log
+    /// → own snapshot) and by tests. Folds events into an in-memory DB via
+    /// `merge::apply_event`, then dumps the materialized rows back out as
+    /// the snapshot state.
+    ///
+    /// `events` should already be in `(ts, device)` order — the same order
+    /// `ReplayEngine::tick()` uses. The snapshot's `id` and
+    /// `truncated_before` are set to the lexicographically largest event id
+    /// seen (callers that want a more conservative truncation point can
+    /// override `truncated_before` on the returned struct).
+    pub fn from_events(device: &str, events: &[Event]) -> AppResult<Self> {
+        let mut conn = Connection::open_in_memory()?;
+        // Match the FK posture of the replay engine — see merge.rs module
+        // doc for why FK is off during apply.
+        Db::run_migrations_on(&conn)?;
+        conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
+        {
+            let tx = conn.transaction()?;
+            for ev in events {
+                merge::apply_event(&tx, ev)?;
+            }
+            tx.commit()?;
+        }
+
+        let state = dump_state(&conn)?;
+        let max_id = events
+            .iter()
+            .map(|e| e.id.clone())
+            .max()
+            .unwrap_or_else(|| Ulid::nil().to_string());
+
+        Ok(Snapshot {
+            v: SNAPSHOT_SCHEMA_VERSION,
+            device: device.to_string(),
+            id: max_id.clone(),
+            generated_at: chrono::Utc::now().timestamp_millis(),
+            truncated_before: Some(max_id),
+            state,
+        })
+    }
+
+    /// Atomic write — temp file, fsync, rename. The destination directory is
+    /// created if missing. Crash-safe: a partial write never replaces the
+    /// existing snapshot.
+    pub fn write_atomic(&self, path: &Path) -> AppResult<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("snapshot.json.tmp");
+        let bytes = serde_json::to_vec(self)
+            .map_err(|e| AppError::Other(format!("snapshot serialize: {e}")))?;
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&tmp)?;
+        f.write_all(&bytes)?;
+        f.sync_all()?;
+        drop(f);
+        fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    pub fn read_from(path: &Path) -> AppResult<Self> {
+        let bytes = fs::read(path)?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| AppError::Other(format!("snapshot parse: {e}")))
+    }
+
+    /// Apply this snapshot into local SQLite. Idempotent under repeated
+    /// application; tombstones in `state.tombstones` are written first so
+    /// the entity rows that follow can short-circuit on the local-tombstone
+    /// check. Watermarks are advanced per Step 6 of the spec.
+    ///
+    /// `peer_device` is the keyed `_replay_state.peer_device` — usually
+    /// `self.device`, but the caller passes it explicitly so this works for
+    /// the migration apply-back case (where the snapshot's `device` is the
+    /// migrating device but `_replay_state` still treats it as a peer).
+    pub fn apply_peer(&self, tx: &Transaction, peer_device: &str) -> AppResult<ApplyOutcome> {
+        let prior: Option<(Option<String>, Option<String>)> = tx
+            .query_row(
+                "SELECT last_snapshot_id, last_event_id
+                 FROM _replay_state WHERE peer_device = ?1",
+                params![peer_device],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .map(Some)
+            .or_else(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                other => Err(other),
+            })?;
+
+        let prior_snap = prior.as_ref().and_then(|(s, _)| s.clone());
+        let prior_event = prior.as_ref().and_then(|(_, e)| e.clone());
+
+        if prior_snap.as_deref() == Some(self.id.as_str()) {
+            return Ok(ApplyOutcome::AlreadyApplied);
+        }
+
+        // Spec step 4b: snapshot summarises events we've already individually
+        // applied — skip rows but bump last_snapshot_id so we don't re-parse.
+        if prior_event.as_deref().is_some_and(|e| e >= self.id.as_str()) {
+            upsert_replay_state(tx, peer_device, Some(&self.id), prior_event.as_deref())?;
+            return Ok(ApplyOutcome::HeaderOnly);
+        }
+
+        // Spec step 5: tombstones first.
+        for (entity, list) in &self.state.tombstones {
+            for t in list {
+                if let Some(table) = entity_to_table(entity) {
+                    delete_by_id(tx, table, &t.id)?;
+                }
+                merge::insert_tombstone(tx, entity, &t.id, t.ts)?;
+            }
+        }
+
+        for (id, row) in &self.state.books {
+            if merge::is_tombstoned(tx, merge::entity::BOOK, id)? {
+                continue;
+            }
+            upsert_book(tx, id, row)?;
+        }
+        for (id, row) in &self.state.highlights {
+            if merge::is_tombstoned(tx, merge::entity::HIGHLIGHT, id)? {
+                continue;
+            }
+            upsert_highlight(tx, id, row)?;
+        }
+        for (id, row) in &self.state.bookmarks {
+            if merge::is_tombstoned(tx, merge::entity::BOOKMARK, id)? {
+                continue;
+            }
+            insert_bookmark(tx, id, row)?;
+        }
+        for (id, row) in &self.state.vocab_words {
+            if merge::is_tombstoned(tx, merge::entity::VOCAB, id)? {
+                continue;
+            }
+            upsert_vocab(tx, id, row)?;
+        }
+        for (id, row) in &self.state.translations {
+            if merge::is_tombstoned(tx, merge::entity::TRANSLATION, id)? {
+                continue;
+            }
+            insert_translation(tx, id, row)?;
+        }
+        for (id, row) in &self.state.collections {
+            if merge::is_tombstoned(tx, merge::entity::COLLECTION, id)? {
+                continue;
+            }
+            upsert_collection(tx, id, row)?;
+        }
+        for (key, row) in &self.state.collection_books {
+            if merge::is_tombstoned(tx, merge::entity::COLLECTION_BOOK, key)? {
+                continue;
+            }
+            upsert_collection_book(tx, row)?;
+        }
+        for (id, row) in &self.state.chats {
+            if merge::is_tombstoned(tx, merge::entity::CHAT, id)? {
+                continue;
+            }
+            upsert_chat(tx, id, row)?;
+        }
+        for (id, row) in &self.state.chat_messages {
+            if merge::is_tombstoned(tx, merge::entity::CHAT_MESSAGE, id)? {
+                continue;
+            }
+            insert_chat_message(tx, id, row)?;
+        }
+
+        // Watermarks: last_snapshot_id moves to this snapshot's id;
+        // last_event_id is monotonic — never decrease.
+        let new_event_id = match prior_event.as_deref() {
+            Some(prev) if prev > self.id.as_str() => prior_event.clone(),
+            _ => Some(self.id.clone()),
+        };
+        upsert_replay_state(tx, peer_device, Some(&self.id), new_event_id.as_deref())?;
+        Ok(ApplyOutcome::Applied)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-table upserts. INSERT … ON CONFLICT … DO UPDATE WHERE pattern: insert if
+// new, otherwise let LWW decide. Append-only tables use INSERT OR IGNORE
+// (their rows are immutable post-creation).
+// ---------------------------------------------------------------------------
+
+fn upsert_book(tx: &Transaction, id: &str, r: &BookRow) -> AppResult<()> {
+    tx.execute(
+        "INSERT INTO books
+         (id, title, author, description, cover_path, file_path, genre, pages,
+          format, status, progress, current_cfi, created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+         ON CONFLICT(id) DO UPDATE SET
+           title=excluded.title,
+           author=excluded.author,
+           description=excluded.description,
+           cover_path=excluded.cover_path,
+           file_path=excluded.file_path,
+           genre=excluded.genre,
+           pages=excluded.pages,
+           format=excluded.format,
+           status=excluded.status,
+           progress=excluded.progress,
+           current_cfi=excluded.current_cfi,
+           updated_at=excluded.updated_at,
+           updated_by_device=excluded.updated_by_device
+         WHERE (books.updated_at, books.updated_by_device)
+             < (excluded.updated_at, excluded.updated_by_device)",
+        params![
+            id, r.title, r.author, r.description, r.cover_path, r.file_path,
+            r.genre, r.pages, r.format, r.status, r.progress, r.current_cfi,
+            r.created_at, r.updated_at, r.updated_by_device,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_highlight(tx: &Transaction, id: &str, r: &HighlightRow) -> AppResult<()> {
+    tx.execute(
+        "INSERT INTO highlights
+         (id, book_id, cfi_range, color, note, text_content,
+          created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(id) DO UPDATE SET
+           color=excluded.color,
+           note=excluded.note,
+           text_content=excluded.text_content,
+           updated_at=excluded.updated_at,
+           updated_by_device=excluded.updated_by_device
+         WHERE (highlights.updated_at, highlights.updated_by_device)
+             < (excluded.updated_at, excluded.updated_by_device)",
+        params![
+            id, r.book_id, r.cfi_range, r.color, r.note, r.text_content,
+            r.created_at, r.updated_at, r.updated_by_device,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_bookmark(tx: &Transaction, id: &str, r: &BookmarkRow) -> AppResult<()> {
+    tx.execute(
+        "INSERT OR IGNORE INTO bookmarks
+         (id, book_id, cfi, label, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![id, r.book_id, r.cfi, r.label, r.created_at, r.updated_at],
+    )?;
+    Ok(())
+}
+
+fn upsert_vocab(tx: &Transaction, id: &str, r: &VocabRow) -> AppResult<()> {
+    tx.execute(
+        "INSERT INTO vocab_words
+         (id, book_id, word, definition, context_sentence, cfi,
+          mastery, review_count, next_review_at,
+          created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+         ON CONFLICT(id) DO UPDATE SET
+           mastery=excluded.mastery,
+           review_count=excluded.review_count,
+           next_review_at=excluded.next_review_at,
+           updated_at=excluded.updated_at,
+           updated_by_device=excluded.updated_by_device
+         WHERE (vocab_words.updated_at, vocab_words.updated_by_device)
+             < (excluded.updated_at, excluded.updated_by_device)",
+        params![
+            id, r.book_id, r.word, r.definition, r.context_sentence, r.cfi,
+            r.mastery, r.review_count, r.next_review_at,
+            r.created_at, r.updated_at, r.updated_by_device,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_translation(tx: &Transaction, id: &str, r: &TranslationRow) -> AppResult<()> {
+    tx.execute(
+        "INSERT OR IGNORE INTO translations
+         (id, book_id, source_text, translated_text, target_language, cfi,
+          created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            id, r.book_id, r.source_text, r.translated_text, r.target_language,
+            r.cfi, r.created_at, r.updated_at,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_collection(tx: &Transaction, id: &str, r: &CollectionRow) -> AppResult<()> {
+    tx.execute(
+        "INSERT INTO collections
+         (id, name, sort_order, created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(id) DO UPDATE SET
+           name=excluded.name,
+           sort_order=excluded.sort_order,
+           updated_at=excluded.updated_at,
+           updated_by_device=excluded.updated_by_device
+         WHERE (collections.updated_at, collections.updated_by_device)
+             < (excluded.updated_at, excluded.updated_by_device)",
+        params![id, r.name, r.sort_order, r.created_at, r.updated_at, r.updated_by_device],
+    )?;
+    Ok(())
+}
+
+fn upsert_collection_book(tx: &Transaction, r: &CollectionBookRow) -> AppResult<()> {
+    tx.execute(
+        "INSERT INTO collection_books
+         (collection_id, book_id, created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(collection_id, book_id) DO UPDATE SET
+           updated_at=excluded.updated_at,
+           updated_by_device=excluded.updated_by_device
+         WHERE (collection_books.updated_at, collection_books.updated_by_device)
+             < (excluded.updated_at, excluded.updated_by_device)",
+        params![r.collection_id, r.book_id, r.created_at, r.updated_at, r.updated_by_device],
+    )?;
+    Ok(())
+}
+
+fn upsert_chat(tx: &Transaction, id: &str, r: &ChatRow) -> AppResult<()> {
+    tx.execute(
+        "INSERT INTO chats
+         (id, book_id, title, model, pinned, metadata, created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(id) DO UPDATE SET
+           title=excluded.title,
+           model=excluded.model,
+           pinned=excluded.pinned,
+           metadata=excluded.metadata,
+           updated_at=excluded.updated_at,
+           updated_by_device=excluded.updated_by_device
+         WHERE (chats.updated_at, chats.updated_by_device)
+             < (excluded.updated_at, excluded.updated_by_device)",
+        params![
+            id, r.book_id, r.title, r.model, r.pinned as i64, r.metadata,
+            r.created_at, r.updated_at, r.updated_by_device,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_chat_message(tx: &Transaction, id: &str, r: &ChatMessageRow) -> AppResult<()> {
+    tx.execute(
+        "INSERT OR IGNORE INTO chat_messages
+         (id, chat_id, role, content, context, metadata, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![id, r.chat_id, r.role, r.content, r.context, r.metadata, r.created_at, r.updated_at],
+    )?;
+    Ok(())
+}
+
+fn delete_by_id(tx: &Transaction, table: &str, id: &str) -> AppResult<()> {
+    let sql = format!("DELETE FROM {table} WHERE id = ?1");
+    tx.execute(&sql, params![id])?;
+    Ok(())
+}
+
+fn entity_to_table(entity: &str) -> Option<&'static str> {
+    match entity {
+        merge::entity::BOOK => Some("books"),
+        merge::entity::HIGHLIGHT => Some("highlights"),
+        merge::entity::BOOKMARK => Some("bookmarks"),
+        merge::entity::VOCAB => Some("vocab_words"),
+        merge::entity::TRANSLATION => Some("translations"),
+        merge::entity::COLLECTION => Some("collections"),
+        merge::entity::CHAT => Some("chats"),
+        merge::entity::CHAT_MESSAGE => Some("chat_messages"),
+        // collection_books has a composite primary key; tombstones for it
+        // carry the synthetic `"<col>:<book>"` id which doesn't map cleanly
+        // to a single-column WHERE clause. We don't try to delete the row
+        // here — the merge::apply_collection_book_remove path handles row
+        // deletion before tombstoning, and `apply_peer`'s tombstone-first
+        // pass only needs to ensure the tombstone exists locally.
+        merge::entity::COLLECTION_BOOK => None,
+        _ => None,
+    }
+}
+
+fn upsert_replay_state(
+    tx: &Transaction,
+    peer: &str,
+    last_snapshot: Option<&str>,
+    last_event: Option<&str>,
+) -> AppResult<()> {
+    let now = chrono::Utc::now().timestamp_millis();
+    tx.execute(
+        "INSERT INTO _replay_state (peer_device, last_snapshot_id, last_event_id, updated_at)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(peer_device) DO UPDATE SET
+           last_snapshot_id = excluded.last_snapshot_id,
+           last_event_id = excluded.last_event_id,
+           updated_at = excluded.updated_at",
+        params![peer, last_snapshot, last_event, now],
+    )?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// State dump — read every synced table out of `conn` into a SnapshotState.
+// Used by `Snapshot::from_events`.
+// ---------------------------------------------------------------------------
+
+fn dump_state(conn: &Connection) -> AppResult<SnapshotState> {
+    let mut state = SnapshotState::default();
+
+    // books
+    let mut stmt = conn.prepare(
+        "SELECT id, title, author, description, cover_path, file_path, genre, pages,
+                format, status, progress, current_cfi,
+                created_at, updated_at, updated_by_device
+         FROM books",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            BookRow {
+                title: r.get(1)?,
+                author: r.get(2)?,
+                description: r.get(3)?,
+                cover_path: r.get(4)?,
+                file_path: r.get(5)?,
+                genre: r.get(6)?,
+                pages: r.get(7)?,
+                format: r.get(8)?,
+                status: r.get(9)?,
+                progress: r.get(10)?,
+                current_cfi: r.get(11)?,
+                created_at: r.get(12)?,
+                updated_at: r.get(13)?,
+                updated_by_device: r.get(14)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (id, b) = row?;
+        state.books.insert(id, b);
+    }
+    drop(stmt);
+
+    // highlights
+    let mut stmt = conn.prepare(
+        "SELECT id, book_id, cfi_range, color, note, text_content,
+                created_at, updated_at, updated_by_device FROM highlights",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            HighlightRow {
+                book_id: r.get(1)?,
+                cfi_range: r.get(2)?,
+                color: r.get(3)?,
+                note: r.get(4)?,
+                text_content: r.get(5)?,
+                created_at: r.get(6)?,
+                updated_at: r.get(7)?,
+                updated_by_device: r.get(8)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (id, h) = row?;
+        state.highlights.insert(id, h);
+    }
+    drop(stmt);
+
+    // bookmarks
+    let mut stmt = conn.prepare(
+        "SELECT id, book_id, cfi, label, created_at, updated_at FROM bookmarks",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            BookmarkRow {
+                book_id: r.get(1)?,
+                cfi: r.get(2)?,
+                label: r.get(3)?,
+                created_at: r.get(4)?,
+                updated_at: r.get(5)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (id, b) = row?;
+        state.bookmarks.insert(id, b);
+    }
+    drop(stmt);
+
+    // vocab_words
+    let mut stmt = conn.prepare(
+        "SELECT id, book_id, word, definition, context_sentence, cfi,
+                mastery, review_count, next_review_at,
+                created_at, updated_at, updated_by_device FROM vocab_words",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            VocabRow {
+                book_id: r.get(1)?,
+                word: r.get(2)?,
+                definition: r.get(3)?,
+                context_sentence: r.get(4)?,
+                cfi: r.get(5)?,
+                mastery: r.get(6)?,
+                review_count: r.get(7)?,
+                next_review_at: r.get(8)?,
+                created_at: r.get(9)?,
+                updated_at: r.get(10)?,
+                updated_by_device: r.get(11)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (id, v) = row?;
+        state.vocab_words.insert(id, v);
+    }
+    drop(stmt);
+
+    // translations
+    let mut stmt = conn.prepare(
+        "SELECT id, book_id, source_text, translated_text, target_language, cfi,
+                created_at, updated_at FROM translations",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            TranslationRow {
+                book_id: r.get(1)?,
+                source_text: r.get(2)?,
+                translated_text: r.get(3)?,
+                target_language: r.get(4)?,
+                cfi: r.get(5)?,
+                created_at: r.get(6)?,
+                updated_at: r.get(7)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (id, t) = row?;
+        state.translations.insert(id, t);
+    }
+    drop(stmt);
+
+    // collections
+    let mut stmt = conn.prepare(
+        "SELECT id, name, sort_order, created_at, updated_at, updated_by_device FROM collections",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            CollectionRow {
+                name: r.get(1)?,
+                sort_order: r.get(2)?,
+                created_at: r.get(3)?,
+                updated_at: r.get(4)?,
+                updated_by_device: r.get(5)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (id, c) = row?;
+        state.collections.insert(id, c);
+    }
+    drop(stmt);
+
+    // collection_books — composite key
+    let mut stmt = conn.prepare(
+        "SELECT collection_id, book_id, created_at, updated_at, updated_by_device
+         FROM collection_books",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        let col: String = r.get(0)?;
+        let book: String = r.get(1)?;
+        Ok((
+            format!("{col}:{book}"),
+            CollectionBookRow {
+                collection_id: col,
+                book_id: book,
+                created_at: r.get(2)?,
+                updated_at: r.get(3)?,
+                updated_by_device: r.get(4)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (key, cb) = row?;
+        state.collection_books.insert(key, cb);
+    }
+    drop(stmt);
+
+    // chats
+    let mut stmt = conn.prepare(
+        "SELECT id, book_id, title, model, pinned, metadata,
+                created_at, updated_at, updated_by_device FROM chats",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        let pinned: i64 = r.get(4)?;
+        Ok((
+            r.get::<_, String>(0)?,
+            ChatRow {
+                book_id: r.get(1)?,
+                title: r.get(2)?,
+                model: r.get(3)?,
+                pinned: pinned != 0,
+                metadata: r.get(5)?,
+                created_at: r.get(6)?,
+                updated_at: r.get(7)?,
+                updated_by_device: r.get(8)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (id, c) = row?;
+        state.chats.insert(id, c);
+    }
+    drop(stmt);
+
+    // chat_messages
+    let mut stmt = conn.prepare(
+        "SELECT id, chat_id, role, content, context, metadata, created_at, updated_at
+         FROM chat_messages",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            ChatMessageRow {
+                chat_id: r.get(1)?,
+                role: r.get(2)?,
+                content: r.get(3)?,
+                context: r.get(4)?,
+                metadata: r.get(5)?,
+                created_at: r.get(6)?,
+                updated_at: r.get(7)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (id, m) = row?;
+        state.chat_messages.insert(id, m);
+    }
+    drop(stmt);
+
+    // _tombstones
+    let mut stmt = conn.prepare("SELECT entity, id, ts FROM _tombstones")?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            TombstoneRow {
+                id: r.get(1)?,
+                ts: r.get(2)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (entity, t) = row?;
+        state.tombstones.entry(entity).or_default().push(t);
+    }
+
+    Ok(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::events::*;
+    use crate::sync::merge;
+    use rusqlite::Connection;
+    use tempfile::TempDir;
+
+    fn open_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        Db::run_migrations_on(&conn).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=OFF;").unwrap();
+        conn
+    }
+
+    fn ev(ts: i64, device: &str, body: EventBody) -> Event {
+        Event {
+            id: format!("01HYZX0000000000000000{:04X}", ts as u16),
+            ts,
+            device: device.to_string(),
+            v: EVENT_SCHEMA_VERSION,
+            body,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    fn import(id: &str) -> EventBody {
+        EventBody::BookImport(BookImportPayload {
+            id: id.into(),
+            title: format!("Book {id}"),
+            author: "Author".into(),
+            description: None,
+            cover_path: None,
+            file_path: format!("books/{id}.epub"),
+            format: "epub".into(),
+            genre: None,
+            pages: Some(100),
+        })
+    }
+
+    fn apply_to(conn: &mut Connection, events: &[Event]) {
+        let tx = conn.transaction().unwrap();
+        for e in events {
+            merge::apply_event(&tx, e).unwrap();
+        }
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn write_then_read_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let snap = Snapshot {
+            v: SNAPSHOT_SCHEMA_VERSION,
+            device: "dev-A".into(),
+            id: "01HYZX0000000000000000FFFF".into(),
+            generated_at: 1_714_770_000_000,
+            truncated_before: Some("01HYZX0000000000000000FFFF".into()),
+            state: SnapshotState::default(),
+        };
+        let path = tmp.path().join("logs/dev-A.snapshot.json");
+        snap.write_atomic(&path).unwrap();
+
+        let read = Snapshot::read_from(&path).unwrap();
+        assert_eq!(read, snap);
+    }
+
+    #[test]
+    fn from_events_captures_db_state() {
+        let events = vec![
+            ev(1000, "dev-A", import("b1")),
+            ev(
+                1100,
+                "dev-A",
+                EventBody::HighlightAdd(HighlightPayload {
+                    id: "h1".into(),
+                    book_id: "b1".into(),
+                    cfi_range: "epubcfi(/6/4!/2)".into(),
+                    color: "yellow".into(),
+                    note: None,
+                    text_content: None,
+                }),
+            ),
+            ev(
+                1200,
+                "dev-A",
+                EventBody::HighlightColorSet {
+                    id: "h1".into(),
+                    color: "pink".into(),
+                },
+            ),
+        ];
+        let snap = Snapshot::from_events("dev-A", &events).unwrap();
+        assert_eq!(snap.state.books.len(), 1);
+        assert_eq!(snap.state.highlights.len(), 1);
+        let h = snap.state.highlights.get("h1").unwrap();
+        assert_eq!(h.color, "pink");
+        assert_eq!(h.updated_at, 1200);
+    }
+
+    #[test]
+    fn apply_peer_bootstraps_empty_local_db() {
+        // Build a snapshot from peer-A's events; apply to a fresh peer-B DB;
+        // assert peer-B's SQL state matches.
+        let events = vec![
+            ev(1000, "dev-A", import("b1")),
+            ev(
+                1100,
+                "dev-A",
+                EventBody::HighlightAdd(HighlightPayload {
+                    id: "h1".into(),
+                    book_id: "b1".into(),
+                    cfi_range: "cfi".into(),
+                    color: "yellow".into(),
+                    note: None,
+                    text_content: None,
+                }),
+            ),
+        ];
+        let snap = Snapshot::from_events("dev-A", &events).unwrap();
+
+        let mut local = open_db();
+        let outcome = {
+            let tx = local.transaction().unwrap();
+            let outcome = snap.apply_peer(&tx, "dev-A").unwrap();
+            tx.commit().unwrap();
+            outcome
+        };
+        assert_eq!(outcome, ApplyOutcome::Applied);
+
+        let n_books: i64 = local
+            .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+            .unwrap();
+        let n_hl: i64 = local
+            .query_row("SELECT COUNT(*) FROM highlights", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_books, 1);
+        assert_eq!(n_hl, 1);
+
+        let (snap_id, ev_id): (Option<String>, Option<String>) = local
+            .query_row(
+                "SELECT last_snapshot_id, last_event_id FROM _replay_state WHERE peer_device = 'dev-A'",
+                [], |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(snap_id, Some(snap.id.clone()));
+        assert_eq!(ev_id, Some(snap.id.clone()));
+    }
+
+    #[test]
+    fn apply_peer_already_applied_is_short_circuit() {
+        let events = vec![ev(1000, "dev-A", import("b1"))];
+        let snap = Snapshot::from_events("dev-A", &events).unwrap();
+        let mut local = open_db();
+        {
+            let tx = local.transaction().unwrap();
+            snap.apply_peer(&tx, "dev-A").unwrap();
+            tx.commit().unwrap();
+        }
+        let outcome = {
+            let tx = local.transaction().unwrap();
+            let o = snap.apply_peer(&tx, "dev-A").unwrap();
+            tx.commit().unwrap();
+            o
+        };
+        assert_eq!(outcome, ApplyOutcome::AlreadyApplied);
+    }
+
+    #[test]
+    fn apply_peer_header_only_when_log_tail_already_ahead() {
+        // Peer event tail watermark is already past the snapshot's id —
+        // every event the snapshot summarises has been individually applied.
+        let events = vec![ev(1000, "dev-A", import("b1"))];
+        let snap = Snapshot::from_events("dev-A", &events).unwrap();
+        let later_event_id = "01HYZX9999999999999999FFFF"; // sorts after snap.id
+
+        let mut local = open_db();
+        // Pre-seed _replay_state as if A's log tail had already been read.
+        local
+            .execute(
+                "INSERT INTO _replay_state (peer_device, last_snapshot_id, last_event_id, updated_at)
+                 VALUES ('dev-A', NULL, ?1, ?2)",
+                params![later_event_id, chrono::Utc::now().timestamp_millis()],
+            )
+            .unwrap();
+
+        let outcome = {
+            let tx = local.transaction().unwrap();
+            let o = snap.apply_peer(&tx, "dev-A").unwrap();
+            tx.commit().unwrap();
+            o
+        };
+        assert_eq!(outcome, ApplyOutcome::HeaderOnly);
+
+        // No rows applied; tail watermark preserved (monotonic non-decrease).
+        let n_books: i64 = local
+            .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_books, 0);
+        let (snap_id, ev_id): (Option<String>, Option<String>) = local
+            .query_row(
+                "SELECT last_snapshot_id, last_event_id FROM _replay_state WHERE peer_device = 'dev-A'",
+                [], |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(snap_id, Some(snap.id.clone()));
+        assert_eq!(ev_id.as_deref(), Some(later_event_id));
+    }
+
+    #[test]
+    fn apply_peer_respects_local_tombstone() {
+        let events = vec![
+            ev(1000, "dev-A", import("b1")),
+            ev(
+                1100,
+                "dev-A",
+                EventBody::HighlightAdd(HighlightPayload {
+                    id: "h1".into(),
+                    book_id: "b1".into(),
+                    cfi_range: "cfi".into(),
+                    color: "yellow".into(),
+                    note: None,
+                    text_content: None,
+                }),
+            ),
+        ];
+        let snap = Snapshot::from_events("dev-A", &events).unwrap();
+
+        // Local user (peer-B) deleted the highlight before the snapshot arrived.
+        let mut local = open_db();
+        merge::insert_tombstone(
+            &local.transaction().unwrap(),
+            merge::entity::HIGHLIGHT,
+            "h1",
+            500,
+        )
+        .unwrap();
+        // Need to commit the tombstone before applying snapshot.
+        local
+            .execute(
+                "INSERT OR IGNORE INTO _tombstones (entity, id, ts) VALUES ('highlight', 'h1', 500)",
+                [],
+            )
+            .unwrap();
+
+        {
+            let tx = local.transaction().unwrap();
+            snap.apply_peer(&tx, "dev-A").unwrap();
+            tx.commit().unwrap();
+        }
+        let n: i64 = local
+            .query_row("SELECT COUNT(*) FROM highlights WHERE id = 'h1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "local tombstone should suppress snapshot insertion");
+    }
+
+    #[test]
+    fn apply_peer_lww_preserves_newer_local_value() {
+        // Local DB has progress=80 (newer), peer snapshot has progress=10
+        // (older). Apply must NOT overwrite the newer local value.
+        let mut local = open_db();
+        apply_to(
+            &mut local,
+            &[
+                ev(1000, "dev-B", import("b1")),
+                ev(
+                    5000,
+                    "dev-B",
+                    EventBody::BookProgressSet {
+                        book: "b1".into(),
+                        progress: 80,
+                        cfi: Some("c80".into()),
+                    },
+                ),
+            ],
+        );
+
+        let peer_events = vec![
+            ev(1000, "dev-A", import("b1")),
+            ev(
+                2000,
+                "dev-A",
+                EventBody::BookProgressSet {
+                    book: "b1".into(),
+                    progress: 10,
+                    cfi: Some("c10".into()),
+                },
+            ),
+        ];
+        let snap = Snapshot::from_events("dev-A", &peer_events).unwrap();
+        {
+            let tx = local.transaction().unwrap();
+            snap.apply_peer(&tx, "dev-A").unwrap();
+            tx.commit().unwrap();
+        }
+        let progress: i32 = local
+            .query_row("SELECT progress FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(progress, 80, "newer local value survives older snapshot");
+    }
+
+    #[test]
+    fn snapshot_equivalence_events_vs_snapshot_yields_same_state() {
+        // Apply event set X directly to DB1; build snapshot from X and apply
+        // to DB2; compare every row.
+        let events = vec![
+            ev(1000, "dev-A", import("b1")),
+            ev(1100, "dev-B", import("b2")),
+            ev(
+                1200,
+                "dev-A",
+                EventBody::HighlightAdd(HighlightPayload {
+                    id: "h1".into(),
+                    book_id: "b1".into(),
+                    cfi_range: "cfi".into(),
+                    color: "yellow".into(),
+                    note: Some("note".into()),
+                    text_content: None,
+                }),
+            ),
+            ev(
+                1300,
+                "dev-A",
+                EventBody::CollectionCreate {
+                    id: "c1".into(),
+                    name: "Top".into(),
+                    sort_order: 0,
+                },
+            ),
+            ev(
+                1400,
+                "dev-A",
+                EventBody::CollectionBookAdd {
+                    collection: "c1".into(),
+                    book: "b1".into(),
+                },
+            ),
+            ev(
+                1500,
+                "dev-B",
+                EventBody::HighlightDelete { id: "h1".into() },
+            ),
+        ];
+
+        let mut db1 = open_db();
+        apply_to(&mut db1, &events);
+
+        let snap = Snapshot::from_events("dev-A", &events).unwrap();
+        let mut db2 = open_db();
+        {
+            let tx = db2.transaction().unwrap();
+            snap.apply_peer(&tx, "dev-A").unwrap();
+            tx.commit().unwrap();
+        }
+
+        let dump = |db: &Connection, table: &str| -> Vec<String> {
+            let mut stmt = db
+                .prepare(&format!("SELECT * FROM {table} ORDER BY 1, 2"))
+                .unwrap();
+            let cols = stmt.column_count();
+            stmt.query_map([], |r| {
+                let mut s = String::new();
+                for i in 0..cols {
+                    let v: rusqlite::types::Value = r.get(i)?;
+                    s.push_str(&format!("{v:?}|"));
+                }
+                Ok(s)
+            })
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect()
+        };
+
+        for table in [
+            "books",
+            "highlights",
+            "bookmarks",
+            "vocab_words",
+            "translations",
+            "collections",
+            "collection_books",
+            "chats",
+            "chat_messages",
+            "_tombstones",
+        ] {
+            assert_eq!(
+                dump(&db1, table),
+                dump(&db2, table),
+                "{table} differs between event-direct and snapshot-applied"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Chunk 4 of issue #185 — pure data-flow code, no command wiring yet. Lands the converge step (`ReplayEngine::tick()`) plus the materialized-state plumbing it depends on (`merge::apply_event` and `Snapshot`). Write path still goes straight to SQL until Chunk 5 routes through `SyncWriter`.

Merging into the umbrella branch `feat/event-log-sync`, not `main`.

## What's in here

**`migrations/011_lww_tiebreak_and_outbox.sql`** — bundled because both pieces are Chunk 4/5 prerequisites:
- `updated_by_device TEXT NOT NULL DEFAULT 'migration'` on the six LWW-backed tables (resolves Problem 2 in the [known-problems doc](docs/impls/sync/31-sync-known-problems.md) — same-ms cross-device writes resolve deterministically by tuple compare).
- `_pending_publish (id, ts, body_json, created_at)` outbox (Problem 1's durable queue — `SyncWriter` writes here inside the SQL tx, `ReplayEngine` drains after commit).

**`sync/merge.rs`** — `apply_event(tx, event)` for all 26 `EventBody` variants. Tombstone-guarded `INSERT OR IGNORE` for adds; LWW updates use SQLite tuple compare in `WHERE` so the guard is one statement; deletes manually cascade to children (replay runs with FK off — see module doc for why). Composite-key tombstones for `collection_books` under entity `"collection_book"` keyed `"<col>:<book>"`.

**`sync/snapshot.rs`** — `Snapshot::{from_events, write_atomic, read_from, apply_peer}`. `from_events` folds events into in-memory SQLite via `merge::apply_event` then dumps state, so snapshot semantics are derived from merge semantics rather than re-implemented. `apply_peer` follows Step 6 exactly: short-circuit on `AlreadyApplied`/`HeaderOnly`; tombstones first; per-row LWW upserts via `INSERT … ON CONFLICT DO UPDATE WHERE`; monotonic `last_event_id`.

**`sync/replay.rs`** — `ReplayEngine::tick()` drains `_pending_publish` into own log, walks `<shared>/logs/*.{jsonl,snapshot.json}` (own files included as a peer), reads each peer's tail past `last_event_id`, applies snapshots + sorts events by `(ts, device)` globally, applies in one tx with FK toggled off, advances per-peer watermarks. Process-wide `TICK_MUTEX` serializes concurrent ticks.

**`sync/log.rs`** — extracts `read_log_file` / `read_log_file_after` as free functions so `ReplayEngine` can read peer logs without opening an `EventLog`.

## Test plan

- [x] `cargo test --lib` — 123 pass, 1 ignored (manual iCloud smoke test from Chunk 3)
- [x] `cargo clippy --lib --tests --no-deps` clean on the diff
- [x] Migration 011 integrity test: `updated_by_device = 'migration'` on every legacy row, NOT NULL enforced, `_pending_publish` empty + present
- [x] Merge determinism: shuffled apply yields byte-identical `SELECT *`
- [x] Same-ms LWW resolves deterministically by device UUID tuple
- [x] Tombstone blocks resurrection (delete then re-add at higher ts → row stays gone)
- [x] Manual cascade on `book.delete` removes children across all six FK-related tables
- [x] Snapshot equivalence: events vs `from_events` + `apply_peer` yield identical SQL state
- [x] Local tombstone wins over peer snapshot row
- [x] Newer local LWW value survives older peer snapshot
- [x] Replay watermark suppresses re-apply on second tick
- [x] Outbox drain → own log append → `_pending_publish` delete
- [x] FK pragma restored to `ON` after `tick()`

## What's deferred

- Chunk 5 wires `SyncWriter::with_tx` and routes the 26 mutation commands through it. That's where every LWW INSERT/UPDATE will start writing `updated_by_device = self_device_uuid` (the column lands here but isn't populated by the existing command code yet — every legacy row keeps the `'migration'` sentinel).
- `Snapshot::from_legacy_db` ships with the migration routine in Chunk 6.
- Compaction triggers (own log > 2MB / > 5000 events / monthly) ship in Chunk 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)