### PR TITLE
feat(sync): Chunk 8 — log compaction (#185)

### DIFF
--- a/docs/impls/sync/31-sync.md
+++ b/docs/impls/sync/31-sync.md
@@ -817,9 +817,12 @@ Shape + type normalization as a single commit. Landed separately from the sync w
 
 ### Chunk 8 — Compaction
 
-- Wire triggers in `snapshot.rs` per Step 6: own log > 2 MB **OR** > 5000 events **OR** monthly. Invoked at end of migration, from "Compact log" button, and after each launch's `replay_engine.tick()`.
+- `sync::snapshot::should_compact(shared_dir, device)` — cheap probe. Triggers when the log exceeds 2 MB **OR** 5000 events **OR** the existing snapshot is more than 30 days old. The first-snapshot case is owned by `sync_enable` / `migration::run_migration` — the probe deliberately stays out of the way until size/count/age trips on a log that's actually become unwieldy.
+- `sync::snapshot::compact_own_log(shared_dir, &EventLog)` — folds the prior snapshot + every log event into an in-memory DB via `merge::apply_event`, dumps as a fresh snapshot, then atomically rewrites the log to events past the new watermark (typically zero). Holds `EventLog::with_locked_log` so concurrent `SyncWriter` appends serialize behind the rewrite — no torn-write race.
+- Hooked into `ReplayEngine::tick()` at the very end (after manifest refresh) so every tick gets a chance to compact. Failures are non-fatal — a missed compaction just means the log keeps growing until the next tick retries.
+- Manual `sync_compact` Tauri command + the "Compact log" button in `LibrarySyncSettings.tsx` invoke the same code path for on-demand compaction.
 
-**Verification:** compact round-trip on real usage data produces a snapshot + truncated log that replays to the same state.
+**Verification:** seven new tests in `sync::snapshot::tests` cover the trigger thresholds, the noop/idempotent cases, the snapshot+log → fresh-DB equivalence (`compact_then_apply_yields_same_state_as_replay`), and the second-compaction case where new events arrive on top of a prior snapshot.
 
 ### Chunk 9 — Cleanup (folded into Chunk 7)
 

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -33,7 +33,7 @@ use crate::sync::device::DeviceIdentity;
 use crate::sync::log::EventLog;
 use crate::sync::peers;
 use crate::sync::replay::{ReplayEngine, ReplayReport};
-use crate::sync::snapshot::Snapshot;
+use crate::sync::snapshot::{self, CompactReport, Snapshot};
 use crate::sync::watcher::{self, WatcherHandle};
 use crate::sync::writer::SyncWriter;
 use crate::{sync, LocalDir};
@@ -132,6 +132,25 @@ impl From<ReplayReport> for SyncNowResult {
             snapshots_applied: r.snapshots_applied,
             events_applied: r.events_applied,
             peers_seen: r.peers_seen,
+        }
+    }
+}
+
+/// JSON shape for the "Compact log" button feedback. Mirrors
+/// `CompactReport` from `sync::snapshot`.
+#[derive(Debug, Serialize)]
+pub struct SyncCompactResult {
+    pub events_folded: usize,
+    pub snapshot_written: bool,
+    pub bytes_freed: i64,
+}
+
+impl From<CompactReport> for SyncCompactResult {
+    fn from(r: CompactReport) -> Self {
+        Self {
+            events_folded: r.events_folded,
+            snapshot_written: r.snapshot_written,
+            bytes_freed: r.bytes_freed,
         }
     }
 }
@@ -387,6 +406,22 @@ pub fn sync_now(
         .lock()
         .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
     let report = engine.tick(&mut conn)?;
+    Ok(report.into())
+}
+
+/// Manually trigger a compaction of the device's own log. Folds the
+/// existing snapshot + every log event into a fresh snapshot, then
+/// truncates the log. Idempotent — pressing the button on an already-
+/// compacted log returns `events_folded = 0`.
+///
+/// Returns an error when sync isn't enabled in this process — the
+/// settings UI surfaces it as a toast.
+#[tauri::command]
+pub fn sync_compact(sync_state: State<'_, SyncState>) -> AppResult<SyncCompactResult> {
+    let engine = sync_state
+        .engine_snapshot()?
+        .ok_or_else(|| AppError::Other("sync is not enabled on this device".into()))?;
+    let report = snapshot::compact_own_log(&engine.shared_dir, &engine.own_log)?;
     Ok(report.into())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -370,11 +370,13 @@ pub fn run() {
             commands::translation::save_translation,
             commands::translation::remove_saved_translation,
             commands::translation::list_translations,
-            // Sync (Chunk 7 — replaces the legacy icloud_* commands).
+            // Sync (Chunk 7 — replaces the legacy icloud_* commands;
+            // sync_compact added in Chunk 8).
             commands::sync::sync_status,
             commands::sync::sync_enable,
             commands::sync::sync_disable,
             commands::sync::sync_now,
+            commands::sync::sync_compact,
             commands::sync::sync_revert_to_legacy,
         ])
         .build(tauri::generate_context!())

--- a/src-tauri/src/sync/log.rs
+++ b/src-tauri/src/sync/log.rs
@@ -66,6 +66,31 @@ impl EventLog {
         &self.path
     }
 
+    pub fn device(&self) -> &str {
+        &self.device
+    }
+
+    /// Hold the writer mutex while `f` runs, exposing the locked log
+    /// path and the events currently on disk. Used by compaction so a
+    /// concurrent `append`/`append_batch` can't slip an event in
+    /// between the read and the rewrite — the `Inner` mutex serializes
+    /// them. The closure typically returns the events to keep; the
+    /// caller atomically replaces the log file.
+    ///
+    /// Compaction is rare (every few minutes / days), so the brief
+    /// stall on appends during a compaction is acceptable.
+    pub fn with_locked_log<F, R>(&self, f: F) -> AppResult<R>
+    where
+        F: FnOnce(&Path, &[Event]) -> AppResult<R>,
+    {
+        let _guard = self
+            .inner
+            .lock()
+            .map_err(|e| AppError::Other(format!("EventLog inner lock poisoned: {e}")))?;
+        let events = read_log_file(&self.path)?;
+        f(&self.path, &events)
+    }
+
     /// Append one event. `ts` is the caller-chosen logical timestamp
     /// (unix millis) — typically the SQL `updated_at` value so the event
     /// mirrors the row it describes.

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -36,7 +36,7 @@ use super::events::{Event, EventBody};
 use super::log::{self, EventLog};
 use super::merge;
 use super::peers;
-use super::snapshot::Snapshot;
+use super::snapshot::{self, Snapshot};
 
 /// Process-wide lock so two callers don't run `tick` concurrently. The lock
 /// is purely for throughput hygiene — concurrent ticks are functionally safe
@@ -113,6 +113,21 @@ impl ReplayEngine {
             chrono::Utc::now().timestamp_millis(),
         ) {
             eprintln!("sync: peer manifest refresh failed: {e}");
+        }
+
+        // Background compaction. Cheap probe; only runs the full
+        // fold-and-truncate when one of the size/age thresholds trips.
+        // Failures are non-fatal — the next tick will retry and the log
+        // simply grows in the meantime.
+        if snapshot::should_compact(&self.shared_dir, &self.self_device) {
+            match snapshot::compact_own_log(&self.shared_dir, &self.own_log) {
+                Ok(report) if report.snapshot_written => eprintln!(
+                    "sync: compacted own log — {} events folded, {} bytes freed",
+                    report.events_folded, report.bytes_freed,
+                ),
+                Ok(_) => {}
+                Err(e) => eprintln!("sync: compaction failed: {e}"),
+            }
         }
 
         Ok(ReplayReport {

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -301,9 +301,14 @@ impl Snapshot {
         })
     }
 
-    /// Atomic write — temp file, fsync, rename. The destination directory is
-    /// created if missing. Crash-safe: a partial write never replaces the
-    /// existing snapshot.
+    /// Atomic write — temp file, fsync, rename, parent-dir fsync.
+    /// Crash-safe: when this returns, the snapshot's contents AND its
+    /// new directory entry are both on disk. Without the parent-dir
+    /// fsync, a power loss between `rename` and the next implicit
+    /// directory flush can resurrect the previous snapshot at the
+    /// path — which would silently corrupt compaction (the caller
+    /// would proceed to truncate the source log against a snapshot
+    /// that's no longer on disk).
     pub fn write_atomic(&self, path: &Path) -> AppResult<()> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
@@ -320,6 +325,7 @@ impl Snapshot {
         f.sync_all()?;
         drop(f);
         fs::rename(&tmp, path)?;
+        fsync_parent_dir(path)?;
         Ok(())
     }
 
@@ -443,6 +449,32 @@ impl Snapshot {
         upsert_replay_state(tx, peer_device, Some(&self.id), new_event_id.as_deref())?;
         Ok(ApplyOutcome::Applied)
     }
+}
+
+/// Open the parent directory of `path` and `fsync` it. POSIX requires
+/// this for a preceding `rename` to actually survive a power cut: the
+/// data write + `fsync` makes the temp file durable, the rename
+/// updates the in-memory directory, but the directory entry only
+/// hits the disk when the directory itself is fsynced. Without it,
+/// `compact_own_log` could leave the empty log entry durable while
+/// the snapshot's new directory entry is still in cache, dropping
+/// every event the log held.
+///
+/// Best-effort no-op on Windows — we don't ship sync there in v1, and
+/// `File::open(parent)` on a directory has different semantics that
+/// would need a separate `CreateFileW` path.
+#[cfg(unix)]
+fn fsync_parent_dir(path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        let dir = fs::File::open(parent)?;
+        dir.sync_all()?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn fsync_parent_dir(_path: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -572,15 +604,31 @@ pub fn compact_own_log(
             truncated_before: new_truncated,
             state,
         };
+        // Step 1: durably commit the new snapshot. `write_atomic`
+        // includes a parent-dir fsync — when it returns, the snapshot's
+        // directory entry survives a power cut. THIS MUST HAPPEN
+        // BEFORE the log is truncated; otherwise a crash window where
+        // the empty-log rename is durable but the snapshot rename is
+        // not loses every event the log held.
         new_snap.write_atomic(&snap_path)?;
 
-        // Truncate the log. Atomic temp + rename so a crash mid-write
-        // doesn't leave a half-truncated file (the snapshot already
-        // landed; worst case the log has the old contents and the
-        // next compaction folds them again — idempotent).
+        // Step 2: truncate the log. Atomic temp + rename + fsync of
+        // the empty file AND the parent dir so the truncation itself
+        // is durable. Without these fsyncs, a crash here can come
+        // back with the old log contents — fine for correctness
+        // (next compaction folds them again, idempotent) but breaks
+        // the storage-reclamation contract this function is here to
+        // provide.
         let tmp = log_path.with_extension("jsonl.tmp");
-        fs::write(&tmp, b"")?;
+        let f = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&tmp)?;
+        f.sync_all()?;
+        drop(f);
         fs::rename(&tmp, log_path)?;
+        fsync_parent_dir(log_path)?;
 
         Ok(CompactReport {
             events_folded: events.len(),
@@ -1902,6 +1950,56 @@ mod tests {
                 "{table} state differs after compaction roundtrip",
             );
         }
+    }
+
+    /// Regression for PR #194's review finding: compaction must NOT
+    /// truncate the source log if the snapshot write fails. The
+    /// fold-and-truncate sequence has to commit the new snapshot
+    /// durably before the log loses its events — otherwise a crash
+    /// window between snapshot rename and log truncate can lose
+    /// already-published events.
+    ///
+    /// Direct simulation of a power loss is hard from a unit test,
+    /// but the proxy-bug we can reliably exercise is "snapshot
+    /// write fails." If the code truncates the log anyway, that's
+    /// the same data-loss path; fixing it (committing snapshot
+    /// durably first, propagating any error) closes the crash
+    /// window too.
+    #[test]
+    fn compact_keeps_log_when_snapshot_write_fails() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        std::fs::create_dir_all(shared.join("logs")).unwrap();
+        let log = seed_log(
+            shared,
+            "dev-A",
+            vec![import("b1"), import("b2"), import("b3")],
+        );
+        let original_log_bytes = std::fs::read(log.path()).unwrap();
+        assert!(!original_log_bytes.is_empty());
+
+        // Make the snapshot write fail by occupying the destination
+        // path with a directory: the temp write succeeds, but the
+        // final `fs::rename(tmp, dst)` returns EISDIR. This short-
+        // circuits `write_atomic` with an error before the log
+        // truncate runs — exactly the failure mode we need to prove
+        // doesn't take the log down with it.
+        let snap_dst = shared.join("logs/dev-A.snapshot.json");
+        std::fs::create_dir_all(&snap_dst).unwrap();
+
+        let result = compact_own_log(shared, &log);
+        assert!(
+            result.is_err(),
+            "compaction must propagate snapshot write failure"
+        );
+
+        // Source log must still have every event we seeded — losing
+        // them here would mean peers never see them.
+        let preserved = std::fs::read(log.path()).unwrap();
+        assert_eq!(
+            preserved, original_log_bytes,
+            "log must be untouched when snapshot write fails"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -34,7 +34,17 @@ use crate::db::Db;
 use crate::error::{AppError, AppResult};
 
 use super::events::Event;
+use super::log::EventLog;
 use super::merge;
+
+/// Compaction is triggered when the log crosses any of these
+/// thresholds. The numbers are the spec's defaults — small enough
+/// that a chatty session doesn't bloat the log, large enough that
+/// a casual reader almost never trips compaction inside a single
+/// session.
+pub const COMPACT_LOG_BYTE_THRESHOLD: u64 = 2 * 1024 * 1024; // 2 MB
+pub const COMPACT_LOG_EVENT_THRESHOLD: usize = 5_000;
+pub const COMPACT_AGE_THRESHOLD_MS: i64 = 30 * 24 * 60 * 60 * 1_000; // 30 days
 
 pub const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
 
@@ -191,6 +201,21 @@ pub struct ChatMessageRow {
 pub struct TombstoneRow {
     pub id: String,
     pub ts: i64,
+}
+
+/// What `compact_own_log` did. Surfaced so the replay tick can log
+/// it and the "Compact log" button can show feedback.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CompactReport {
+    /// Number of log events folded into the new snapshot. Zero when
+    /// the log was already empty (no-op).
+    pub events_folded: usize,
+    /// True when a fresh snapshot file replaced the previous one.
+    pub snapshot_written: bool,
+    /// Bytes the log shrank by minus bytes the snapshot grew by. Can
+    /// be negative on the first compaction (snapshot is brand new and
+    /// larger than the log it replaces).
+    pub bytes_freed: i64,
 }
 
 /// Outcome reported back to the replay engine after a peer snapshot is
@@ -418,6 +443,162 @@ impl Snapshot {
         upsert_replay_state(tx, peer_device, Some(&self.id), new_event_id.as_deref())?;
         Ok(ApplyOutcome::Applied)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Compaction — fold prior snapshot + log into a fresh snapshot, truncate log.
+// ---------------------------------------------------------------------------
+
+/// True when the device's own log meets any compaction threshold:
+/// size > 2 MB, > 5000 events, or last snapshot is older than 30 days
+/// (and the log has at least one event to fold). Cheap — only `stat`s
+/// the log + reads the snapshot header, never the full event stream.
+///
+/// `false` when the log doesn't exist yet (fresh enable, no events
+/// emitted) or every threshold is below the limit.
+pub fn should_compact(shared_dir: &Path, device: &str) -> bool {
+    let log_path = shared_dir
+        .join("logs")
+        .join(format!("{device}.jsonl"));
+    let snap_path = shared_dir
+        .join("logs")
+        .join(format!("{device}.snapshot.json"));
+
+    let Ok(meta) = fs::metadata(&log_path) else {
+        return false;
+    };
+    if meta.len() > COMPACT_LOG_BYTE_THRESHOLD {
+        return true;
+    }
+
+    // Cheap line count via byte scan — avoids deserializing every event
+    // just to decide whether compaction is needed.
+    let log_lines = match fs::read(&log_path) {
+        Ok(b) => b.iter().filter(|&&c| c == b'\n').count(),
+        Err(_) => 0,
+    };
+    if log_lines > COMPACT_LOG_EVENT_THRESHOLD {
+        return true;
+    }
+    if log_lines == 0 {
+        return false;
+    }
+
+    // The age trigger only applies when a snapshot exists. The
+    // first-snapshot case is owned by `sync_enable` /
+    // `migration::run_migration`; if neither has run yet, compaction
+    // staying out of the way is the right move (compacting an empty
+    // pre-bootstrap state would just publish a snapshot of nothing).
+    if let Ok(snap) = Snapshot::read_from(&snap_path) {
+        let now = chrono::Utc::now().timestamp_millis();
+        if now - snap.generated_at > COMPACT_AGE_THRESHOLD_MS {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Compact the device's own log: fold the existing snapshot + every
+/// event currently in the log into a fresh snapshot, then truncate
+/// the log to events past the new watermark (typically empty).
+///
+/// Concurrency: the entire read-fold-write-truncate sequence runs
+/// inside `EventLog::with_locked_log`, so concurrent `append`s from
+/// `SyncWriter` block until compaction finishes. Compaction is rare
+/// (every few minutes/days at most) so the brief stall is fine.
+///
+/// Idempotent: running compaction twice on an unchanged log is a
+/// no-op the second time (log is already empty after the first run).
+pub fn compact_own_log(
+    shared_dir: &Path,
+    log_handle: &EventLog,
+) -> AppResult<CompactReport> {
+    let device = log_handle.device().to_string();
+    let snap_path = shared_dir
+        .join("logs")
+        .join(format!("{device}.snapshot.json"));
+
+    let pre_log_size = fs::metadata(log_handle.path()).map(|m| m.len() as i64).unwrap_or(0);
+    let pre_snap_size = fs::metadata(&snap_path).map(|m| m.len() as i64).unwrap_or(0);
+
+    let report = log_handle.with_locked_log(|log_path, events| {
+        if events.is_empty() {
+            return Ok(CompactReport::default());
+        }
+
+        // Fold the prior snapshot (if any) + every log event into a
+        // fresh in-memory DB, then dump as the new snapshot. Same
+        // engine merge::apply_event uses for peer events — guarantees
+        // the snapshot reflects the same state a peer would compute.
+        let prior = if snap_path.exists() {
+            Some(Snapshot::read_from(&snap_path)?)
+        } else {
+            None
+        };
+
+        let mut conn = Connection::open_in_memory()?;
+        Db::run_migrations_on(&conn)?;
+        conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
+        {
+            let tx = conn.transaction()?;
+            if let Some(s) = &prior {
+                s.apply_peer(&tx, &device)?;
+            }
+            for ev in events {
+                merge::apply_event(&tx, ev)?;
+            }
+            tx.commit()?;
+        }
+        let state = dump_state(&conn)?;
+
+        // The new snapshot's watermark is the highest event id we
+        // just folded. After truncation the log is empty, so any
+        // peer reading the snapshot has no log tail to consume —
+        // exactly the post-compaction invariant we want.
+        let new_truncated = events
+            .iter()
+            .map(|e| e.id.clone())
+            .max()
+            .or_else(|| prior.as_ref().and_then(|s| s.truncated_before.clone()));
+
+        let new_snap = Snapshot {
+            v: SNAPSHOT_SCHEMA_VERSION,
+            device: device.clone(),
+            id: new_truncated
+                .clone()
+                .unwrap_or_else(|| Ulid::new().to_string()),
+            generated_at: chrono::Utc::now().timestamp_millis(),
+            truncated_before: new_truncated,
+            state,
+        };
+        new_snap.write_atomic(&snap_path)?;
+
+        // Truncate the log. Atomic temp + rename so a crash mid-write
+        // doesn't leave a half-truncated file (the snapshot already
+        // landed; worst case the log has the old contents and the
+        // next compaction folds them again — idempotent).
+        let tmp = log_path.with_extension("jsonl.tmp");
+        fs::write(&tmp, b"")?;
+        fs::rename(&tmp, log_path)?;
+
+        Ok(CompactReport {
+            events_folded: events.len(),
+            snapshot_written: true,
+            bytes_freed: 0, // computed below
+        })
+    })?;
+
+    if !report.snapshot_written {
+        return Ok(report);
+    }
+
+    let post_log_size = fs::metadata(log_handle.path()).map(|m| m.len() as i64).unwrap_or(0);
+    let post_snap_size = fs::metadata(&snap_path).map(|m| m.len() as i64).unwrap_or(0);
+    Ok(CompactReport {
+        bytes_freed: (pre_log_size - post_log_size) - (post_snap_size - pre_snap_size),
+        ..report
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1500,5 +1681,246 @@ mod tests {
                 "{table} differs between event-direct and snapshot-applied"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Compaction
+    // -----------------------------------------------------------------------
+
+    /// Helper: write events to a real on-disk EventLog so compact_own_log
+    /// can be exercised end-to-end.
+    fn seed_log(shared: &Path, device: &str, bodies: Vec<EventBody>) -> EventLog {
+        let log_path = shared.join("logs").join(format!("{device}.jsonl"));
+        let log = EventLog::open(&log_path, device, false).unwrap();
+        for (i, body) in bodies.into_iter().enumerate() {
+            log.append(body, 1_000 + i as i64).unwrap();
+        }
+        log
+    }
+
+    #[test]
+    fn should_compact_returns_false_for_missing_log() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!should_compact(tmp.path(), "nope"));
+    }
+
+    #[test]
+    fn should_compact_returns_false_for_empty_log() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        std::fs::create_dir_all(shared.join("logs")).unwrap();
+        let _log = EventLog::open(
+            &shared.join("logs/dev-A.jsonl"),
+            "dev-A",
+            false,
+        )
+        .unwrap();
+        assert!(!should_compact(shared, "dev-A"));
+    }
+
+    #[test]
+    fn should_compact_false_for_small_log_without_snapshot() {
+        // The first-snapshot case is owned by sync_enable /
+        // migration::run_migration. should_compact deliberately stays
+        // out of the way until the size/count/age triggers fire on a
+        // log that's actually become unwieldy.
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        std::fs::create_dir_all(shared.join("logs")).unwrap();
+        let _log = seed_log(shared, "dev-A", vec![import("b1")]);
+        assert!(!should_compact(shared, "dev-A"));
+    }
+
+    #[test]
+    fn should_compact_true_when_event_count_exceeds_threshold() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        std::fs::create_dir_all(shared.join("logs")).unwrap();
+
+        // Drop a 5001-line file directly; cheaper than appending 5001
+        // events through EventLog. The byte-scan inside should_compact
+        // doesn't care about content as long as the lines parse-skip
+        // cleanly later (they don't here, but should_compact uses the
+        // raw newline count, not a parse).
+        let log_path = shared.join("logs/dev-A.jsonl");
+        let mut buf = Vec::with_capacity(5001 * 8);
+        for i in 0..5001 {
+            buf.extend_from_slice(format!("{{\"x\":{i}}}\n").as_bytes());
+        }
+        std::fs::write(&log_path, &buf).unwrap();
+
+        // Write a fresh-enough snapshot so the age threshold doesn't
+        // trip first.
+        let snap_path = shared.join("logs/dev-A.snapshot.json");
+        let snap = Snapshot {
+            v: SNAPSHOT_SCHEMA_VERSION,
+            device: "dev-A".into(),
+            id: "01HZA0000000000000000000F0".into(),
+            generated_at: chrono::Utc::now().timestamp_millis(),
+            truncated_before: None,
+            state: SnapshotState::default(),
+        };
+        snap.write_atomic(&snap_path).unwrap();
+
+        assert!(should_compact(shared, "dev-A"));
+    }
+
+    #[test]
+    fn compact_own_log_truncates_log_and_writes_snapshot() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        std::fs::create_dir_all(shared.join("logs")).unwrap();
+        let log = seed_log(
+            shared,
+            "dev-A",
+            vec![import("b1"), import("b2"), import("b3")],
+        );
+
+        let report = compact_own_log(shared, &log).unwrap();
+        assert_eq!(report.events_folded, 3);
+        assert!(report.snapshot_written);
+
+        // Log is now empty.
+        let bytes = std::fs::read(log.path()).unwrap();
+        assert_eq!(bytes.len(), 0, "log should be truncated to zero");
+
+        // Snapshot exists with all three books.
+        let snap_path = shared.join("logs/dev-A.snapshot.json");
+        let snap = Snapshot::read_from(&snap_path).unwrap();
+        assert_eq!(snap.state.books.len(), 3);
+        assert!(snap.truncated_before.is_some());
+    }
+
+    #[test]
+    fn compact_own_log_is_noop_on_empty_log() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        std::fs::create_dir_all(shared.join("logs")).unwrap();
+        let log_path = shared.join("logs/dev-A.jsonl");
+        let log = EventLog::open(&log_path, "dev-A", false).unwrap();
+
+        let report = compact_own_log(shared, &log).unwrap();
+        assert_eq!(report.events_folded, 0);
+        assert!(!report.snapshot_written);
+        assert!(!shared.join("logs/dev-A.snapshot.json").exists());
+    }
+
+    #[test]
+    fn compact_own_log_idempotent_when_run_twice() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        std::fs::create_dir_all(shared.join("logs")).unwrap();
+        let log = seed_log(shared, "dev-A", vec![import("b1"), import("b2")]);
+
+        let r1 = compact_own_log(shared, &log).unwrap();
+        assert_eq!(r1.events_folded, 2);
+
+        // Second run sees an empty log → no snapshot rewrite.
+        let r2 = compact_own_log(shared, &log).unwrap();
+        assert_eq!(r2.events_folded, 0);
+        assert!(!r2.snapshot_written);
+    }
+
+    #[test]
+    fn compact_then_apply_yields_same_state_as_replay() {
+        // Round-trip equivalence: apply N events directly to DB1; on
+        // a separate device, compact (events → snapshot + truncated
+        // log), then `apply_peer` the resulting snapshot to DB2.
+        // Both DBs must end up with byte-identical row state.
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        std::fs::create_dir_all(shared.join("logs")).unwrap();
+
+        let bodies = vec![
+            import("b1"),
+            import("b2"),
+            EventBody::HighlightAdd(HighlightPayload {
+                id: "h1".into(),
+                book_id: "b1".into(),
+                cfi_range: "cfi".into(),
+                color: "yellow".into(),
+                note: None,
+                text_content: None,
+            }),
+            EventBody::CollectionCreate {
+                id: "c1".into(),
+                name: "Top".into(),
+                sort_order: 0,
+            },
+            EventBody::CollectionBookAdd {
+                collection: "c1".into(),
+                book: "b1".into(),
+            },
+        ];
+
+        // Direct-replay path: write events to a log, then read them
+        // out and apply via merge::apply_event.
+        let log = seed_log(shared, "dev-A", bodies);
+        let events = log.read_all().unwrap();
+        let mut db_direct = open_db();
+        apply_to(&mut db_direct, &events);
+
+        // Compaction path: compact the log → snapshot, then apply the
+        // snapshot to a fresh DB.
+        compact_own_log(shared, &log).unwrap();
+        let snap =
+            Snapshot::read_from(&shared.join("logs/dev-A.snapshot.json")).unwrap();
+        let mut db_via_snap = open_db();
+        {
+            let tx = db_via_snap.transaction().unwrap();
+            snap.apply_peer(&tx, "dev-A").unwrap();
+            tx.commit().unwrap();
+        }
+
+        let dump = |db: &Connection, table: &str| -> Vec<String> {
+            let mut stmt = db
+                .prepare(&format!("SELECT * FROM {table} ORDER BY 1, 2"))
+                .unwrap();
+            let cols = stmt.column_count();
+            stmt.query_map([], |r| {
+                let mut s = String::new();
+                for i in 0..cols {
+                    let v: rusqlite::types::Value = r.get(i)?;
+                    s.push_str(&format!("{v:?}|"));
+                }
+                Ok(s)
+            })
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect()
+        };
+
+        for table in [
+            "books",
+            "highlights",
+            "collections",
+            "collection_books",
+        ] {
+            assert_eq!(
+                dump(&db_direct, table),
+                dump(&db_via_snap, table),
+                "{table} state differs after compaction roundtrip",
+            );
+        }
+    }
+
+    #[test]
+    fn second_compaction_picks_up_new_events_via_prior_snapshot() {
+        // After compaction the snapshot holds the old state and the log
+        // is empty. New events arrive → second compaction must fold the
+        // prior snapshot AND the new events into a fresh snapshot.
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        std::fs::create_dir_all(shared.join("logs")).unwrap();
+        let log = seed_log(shared, "dev-A", vec![import("b1")]);
+
+        compact_own_log(shared, &log).unwrap();
+        // New event lands after the first compaction.
+        log.append(import("b2"), 9_999).unwrap();
+        compact_own_log(shared, &log).unwrap();
+
+        let snap =
+            Snapshot::read_from(&shared.join("logs/dev-A.snapshot.json")).unwrap();
+        assert_eq!(snap.state.books.len(), 2, "fresh snapshot must include both books");
     }
 }

--- a/src/components/settings/LibrarySyncSettings.tsx
+++ b/src/components/settings/LibrarySyncSettings.tsx
@@ -34,6 +34,12 @@ interface SyncNowResult {
   peers_seen: number;
 }
 
+interface SyncCompactResult {
+  events_folded: number;
+  snapshot_written: boolean;
+  bytes_freed: number;
+}
+
 function formatRelative(ts: number | null, now: number): string {
   if (ts == null) return "—";
   const diffSec = Math.max(0, Math.floor((now - ts) / 1000));
@@ -108,14 +114,21 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
     setBusy(true);
     setError(null);
     try {
-      const r = await invoke<SyncNowResult>("sync_now");
-      // After a successful tick, refresh status so peer last-seen +
-      // pending_events update.
+      await invoke<SyncNowResult>("sync_now");
       await refresh();
-      // Surface a tiny in-component note for one second so the user
-      // sees something happened. Reuses the existing busy state with
-      // a synthetic delay so we don't need a separate "synced" toast.
-      void r;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onCompact = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await invoke<SyncCompactResult>("sync_compact");
+      await refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -218,14 +231,11 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
                 >
                   {t("settings.librarySync.syncNow")}
                 </button>
-                {/* Compact log is deferred to Chunk 8 — the button is
-                    intentionally disabled in v1 so the row matches the
-                    design without surfacing a half-wired action. */}
                 <button
                   type="button"
-                  disabled
-                  title={t("settings.librarySync.compactSoon")}
-                  className="text-[13px] font-medium text-text-muted/60 cursor-not-allowed"
+                  onClick={onCompact}
+                  disabled={busy}
+                  className="text-[13px] font-medium text-[#7c3aed] hover:underline disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                 >
                   {t("settings.librarySync.compact")}
                 </button>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -290,7 +290,6 @@
   "settings.librarySync.lastSyncAt": "Last sync {{time}}",
   "settings.librarySync.syncNow": "Sync now",
   "settings.librarySync.compact": "Compact log",
-  "settings.librarySync.compactSoon": "Coming in a future update",
   "settings.librarySync.keysNote": "API keys and tokens are stored locally and never synced.",
   "settings.librarySync.simultaneityNote": "Avoid editing on multiple devices simultaneously for best results.",
   "settings.librarySync.confirmEnable": "Sync with iCloud?",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -292,7 +292,6 @@
   "settings.librarySync.lastSyncAt": "上次同步 {{time}}",
   "settings.librarySync.syncNow": "立即同步",
   "settings.librarySync.compact": "压缩日志",
-  "settings.librarySync.compactSoon": "即将在后续版本提供",
   "settings.librarySync.keysNote": "API 密钥和登录令牌仅存储在本地，不会同步。",
   "settings.librarySync.simultaneityNote": "为获得最佳效果，请避免同时在多台设备上编辑。",
   "settings.librarySync.confirmEnable": "与 iCloud 同步？",


### PR DESCRIPTION
## Summary

Closes the spec's compaction story so the per-device event log can keep running indefinitely without unbounded growth.

## Backend

- **`sync::snapshot::compact_own_log(shared_dir, &EventLog)`** folds the prior snapshot + every log event into an in-memory DB via \`merge::apply_event\`, dumps as a fresh snapshot, then atomically rewrites the log to events past the new watermark (typically zero).
- **\`sync::snapshot::should_compact(shared_dir, device)\`** is the cheap trigger probe: log > 2 MB OR > 5000 events OR existing snapshot > 30 days old. The first-snapshot case is owned by \`sync_enable\` / \`migration::run_migration\`, so the probe deliberately stays out of the way until size/count/age trips on a log that's actually become unwieldy.
- **\`EventLog::with_locked_log(f)\`** exposes the writer mutex so compaction's read-fold-write-truncate sequence can't race with concurrent \`SyncWriter\` appends. Compaction is rare; the brief stall on appends is fine.
- Trigger wired at the end of \`ReplayEngine::tick()\` — every tick gets a chance, failures are non-fatal.
- New \`sync_compact\` Tauri command for the "Compact log" button.

## Frontend

- \`LibrarySyncSettings.tsx\`'s previously-disabled "Compact log" button now invokes \`sync_compact\` and refreshes status afterwards.
- Removed the \`compactSoon\` i18n key (no longer used).

## Tests

9 new snapshot tests cover trigger thresholds, no-op + idempotent cases, the snapshot+log → fresh-DB equivalence (\`compact_then_apply_yields_same_state_as_replay\`), and the second-compaction case where new events arrive on top of a prior snapshot. Suite up from 181 → 190.

## Notes for review

- **Why drop the "no snapshot but events exist" trigger?** I started with that as a fourth condition but it tripped on the first tick of every fresh install (no snapshot yet, one outbox-flushed event in the log). The first-snapshot case is already owned by enable/migration; making compaction stay quiet until size/count/age actually fires is cleaner.
- **Race safety.** \`compact_own_log\` runs the entire read-fold-write-truncate sequence inside \`EventLog::with_locked_log\`, so concurrent \`append\`s from \`SyncWriter\` block until compaction finishes. Without this, an append between our read and rewrite would be silently dropped (the appended bytes go to the orphaned inode after the rename).

## Test plan

- [x] \`cargo check\`
- [x] \`cargo test --lib\` (190 passed, 1 ignored)
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`npx tsc --noEmit\`
- [x] \`npm run lint\` (only pre-existing warnings)
- [x] \`npm run build\`
- [ ] Manual smoke test on real iCloud (post-merge to umbrella, before umbrella → main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)