### PR TITLE
feat(ai): selection "Ask AI" always starts a new chat

### DIFF
--- a/src/components/AiPanel.tsx
+++ b/src/components/AiPanel.tsx
@@ -39,10 +39,14 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
 
   const currentChat = chats.find((c) => c.id === chatId);
 
-  // Initialize on mount / bookId change
+  // Initialize on mount / bookId change.
+  // Skip when an incoming context is pending — the context effect below will
+  // create a new chat for it, and we don't want a racing initialize() to load
+  // a stale chat and cancel the stream.
   useEffect(() => {
+    if (context) return;
     initialize();
-  }, [initialize]);
+  }, [initialize, context]);
 
   // Load specific chat when navigating from ChatsPage
   useEffect(() => {
@@ -56,13 +60,17 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  // Handle context from "Ask AI" context menu — auto-send
+  // Handle context from "Ask AI" context menu — always start a new chat.
+  // reset() clears chatId so send()'s lazy-create path fires; that path is
+  // also what marks the message as belonging to a new chat (drives title gen).
   useEffect(() => {
-    if (context && !streaming) {
+    if (!context || streaming || !bookId) return;
+    (async () => {
+      await reset();
       send(t("ai.explain"), context.text, context.cfi);
-      onContextConsumed?.();
-    }
-  }, [context, onContextConsumed, send, streaming]);
+    })();
+    onContextConsumed?.();
+  }, [context, bookId, onContextConsumed, reset, send, streaming, t]);
 
   // Focus title input when editing
   useEffect(() => {

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -203,6 +203,8 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
       setChatId(chat.id);
       chatIdRef.current = chat.id;
       updateMessages([]);
+      // Mark book as initialized so a later initialize() call won't reload a stale chat.
+      initializedBookRef.current = bid;
       await refreshChats(bid);
       return chat;
     } catch (err) {


### PR DESCRIPTION
## Summary
- Selecting a paragraph and choosing "Ask AI" now creates a new chat session by default, matching the iOS behavior. Previously it appended the selection to the most recently loaded chat.
- `AiPanel`'s initialize effect is skipped when an incoming `context` is pending, so a concurrent `loadChat()` cannot cancel the fresh stream.
- `useAiChat.createChat` now marks `initializedBookRef` so a later `initialize()` call won't reload a stale chat over an active session.

## Test plan
- [ ] Open a book with an existing chat history — selecting a paragraph and clicking "Ask AI" opens a brand-new session (not appended to the prior chat), and the chat picker reflects the new entry.
- [ ] Auto-title still generates on the new chat after the assistant finishes streaming.
- [ ] Open a book with no prior chats — "Ask AI" creates the first chat as before.
- [ ] The "+" new-chat button in the panel header still works and lazily creates on first send.
- [ ] Typing a message directly in the input (no selection) still appends to the currently loaded chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)