### PR TITLE
fix(reader): auto-hide back button 10s after last jump

### DIFF
--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -212,6 +212,7 @@ export default function Reader() {
   const currentCfiRef = useRef<string | null>(null);
   const [bookReady, setBookReady] = useState(false);
   const [canGoBack, setCanGoBack] = useState(false);
+  const backButtonTimerRef = useRef<number | null>(null);
   const [icloudDownloading, setIcloudDownloading] = useState(false);
   const [icloudTimeout, setIcloudTimeout] = useState(false);
   const [contextMenu, setContextMenu] = useState<{
@@ -440,9 +441,21 @@ export default function Reader() {
         }
       }) as EventListener);
 
-      // Track navigation history for back button
+      // Track navigation history for back button. Auto-hide 10s after the
+      // last jump so it doesn't linger once the reader has settled.
       view.history.addEventListener("index-change", () => {
-        setCanGoBack(view.history.canGoBack);
+        const canBack = view.history.canGoBack;
+        setCanGoBack(canBack);
+        if (backButtonTimerRef.current !== null) {
+          window.clearTimeout(backButtonTimerRef.current);
+          backButtonTimerRef.current = null;
+        }
+        if (canBack) {
+          backButtonTimerRef.current = window.setTimeout(() => {
+            setCanGoBack(false);
+            backButtonTimerRef.current = null;
+          }, 10000);
+        }
       });
 
       // Handle section loads — text selection, keyboard, highlights
@@ -639,6 +652,11 @@ export default function Reader() {
 
     return () => {
       cancelled = true;
+      if (backButtonTimerRef.current !== null) {
+        window.clearTimeout(backButtonTimerRef.current);
+        backButtonTimerRef.current = null;
+      }
+      setCanGoBack(false);
       if (viewRef.current) {
         viewRef.current.close();
         viewRef.current.remove();


### PR DESCRIPTION
## Summary
- Back button in the reader used to stay visible as long as there was any navigation history — it never went away on its own.
- Added a per-jump 10s timer that hides the button after the reader settles. Each new jump (footnote, TOC click) resets the timer.
- Timer is cleaned up on unmount and when the foliate view is torn down.

## Test plan
- [ ] Open a book, click a footnote/TOC link — back button appears.
- [ ] Wait ~10s without navigating — button vanishes.
- [ ] Click another link before 10s elapses — timer resets; button still hides 10s after that last jump.
- [ ] Click back button before timer fires — it disappears immediately when there's no more history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)