### PR TITLE
feat(reader): persist per-book window size and PDF zoom

### DIFF
--- a/docs/features/198-per-book-window-zoom.md
+++ b/docs/features/198-per-book-window-zoom.md
@@ -14,9 +14,10 @@ Quill already persists reading progress, reading mode, theme, page layout, and o
 
 - **Persist reader window size per book** — width and height saved on resize, restored on next open.
 - **Persist PDF zoom % per book** — saved on change, restored when the book loads.
-- **Reuse `book_settings`** — the existing key-value-per-book table (`migrations/007_book_settings.sql`) is the right home. New keys: `window_width`, `window_height`, `zoom_level`.
-- **Debounced writes** — live resize/zoom generates many events; writes debounce at ~500ms so the DB isn't hammered.
-- **Clamp on load** — saved window dimensions clamped to the existing `minWidth: 700` / `minHeight: 500` from `openReaderWindow.ts`; zoom clamped to the valid zoom range.
+- **Use `localStorage`, keyed by bookId** — matches the existing `reader-settings-${bookId}` pattern that already persists theme, font, reading mode, etc. The `book_settings` SQLite table exists but is currently unused from the frontend; reusing localStorage keeps all per-book display state in one place. Keys: `reader-zoom-${bookId}`, `reader-window-${bookId}`.
+- **Debounced writes** — live resize/zoom generates many events; writes debounce at ~500ms so storage isn't hammered.
+- **Clamp on load** — saved window dimensions clamped to the existing `minWidth: 700` / `minHeight: 500` from `openReaderWindow.ts`; zoom clamped to the valid zoom range (50–300).
+- **Document the resize-normalizes-zoom interaction** — the reader already resets PDF zoom to 100% on any `window.resize` so the document re-fits to the new viewport. That's unchanged. Persistence captures whatever zoom the user ends on: if they resize, their zoom is normalized to 100% and 100% is what gets saved. The persisted value is "zoom on close," not "last zoom I ever chose."
 
 ### Out of scope
 
@@ -27,37 +28,43 @@ Quill already persists reading progress, reading mode, theme, page layout, and o
 
 ## Key decisions
 
-- **Storage layout** — three string-valued keys in `book_settings`: `window_width`, `window_height`, `zoom_level`. Matches the existing pattern; no schema change.
-- **Window size load timing** — the saved size must be read in `src/utils/openReaderWindow.ts` **before** `new WebviewWindow(...)`. Passing them to the constructor avoids a visible resize flash on open. The helper becomes async (already returns a `Promise`).
-- **Zoom load timing** — loaded inside `Reader.tsx` alongside the other per-book settings that seed state on book load. No flash concern — zoom is applied after the book is ready.
-- **Save timing** — `appWindow.onResized` (Tauri) fires continuously during a drag-resize; we buffer via a 500ms trailing debounce so only the final size hits the DB. Zoom changes debounce the same way (zoom buttons can fire fast).
-- **Clamping** — on load, clamp `window_width` to `max(700, saved)`, same for height (500). If the saved value is garbage (non-numeric), fall back to defaults silently.
+- **Storage layout** — two `localStorage` keys scoped by bookId:
+  - `reader-zoom-${bookId}` — string integer percent
+  - `reader-window-${bookId}` — JSON `{width, height}` in logical pixels
+
+  Chose `localStorage` over the `book_settings` SQLite table because the reader's other per-book display settings (`reader-settings-${bookId}`) already live in `localStorage`. Keeping all per-book reader state in one mechanism avoids split-brain reads and matches how the rest of the reader works today. `book_settings` remains in the schema as reserved infrastructure but is unused from the frontend.
+- **Window size load timing** — the saved size is read synchronously (from `localStorage`) in `src/utils/openReaderWindow.ts` **before** `new WebviewWindow(...)`. Passing the size to the constructor avoids a visible resize flash on open and keeps the helper's existing call signature intact.
+- **Zoom load timing** — loaded inside `Reader.tsx` alongside the other per-book settings that seed state on book load. After `bookReady`, an effect applies the seeded value to the renderer so the PDF actually renders zoomed (state alone doesn't transform the DOM).
+- **Save timing** — `appWindow.onResized` (Tauri) fires continuously during a drag-resize; we buffer via a 500ms trailing debounce so only the final size is written. Zoom changes debounce the same way.
+- **Clamping** — on load, clamp saved width/height to `max(700, saved)` / `max(500, saved)`. Zoom clamped to `[50, 300]`. Garbage values (non-numeric JSON, corrupt integers) silently fall through to defaults.
 - **Defaults unchanged** — absent keys → today's behavior (1440×960 window, 100% zoom). No user action required; the feature is invisible until they resize or zoom.
 - **Per-window identity** — the window label `reader-${bookId}` already makes each window book-scoped. Saving per book is trivial; no label parsing gymnastics needed.
+- **Resize normalizes zoom** — this is pre-existing, intentional behavior. When the user drags to resize a reader window, a `window.resize` DOM listener resets PDF zoom to 100% so the document re-fits. Persistence captures whatever zoom the user ends on — so resizing a 150%-zoomed book and closing will persist 100%, not 150%. For this app, zoom is tied closely to "fit this PDF to my current viewport," so reset-on-resize is the less surprising behavior. Documented here so the interaction between the two features is explicit and not mistaken for a persistence bug.
 
 ## Implementation Phases
 
 ### Phase 1 — PDF zoom persistence
 
-- In `Reader.tsx`, when the book loads, call `get_book_settings(bookId)` (already wired) and seed `zoomLevel` from `zoom_level` if present and the book is a PDF.
-- Wrap `setZoomLevel` with a debounced write to `set_book_settings_bulk` keyed on `zoom_level`.
-- Guard on `book.format === "pdf"` so EPUBs don't write a meaningless `zoom_level` key.
+- In `Reader.tsx`, when the book loads, read `reader-zoom-${bookId}` from `localStorage`; clamp to [50, 300]; seed `zoomLevel`.
+- After `bookReady`, a follow-up effect applies the seeded zoom to the renderer (extracted `applyZoomToRenderer`) so the PDF visually reflects the seeded value, not just the UI badge.
+- Debounced write (500ms trailing) to `reader-zoom-${bookId}` on `zoomLevel` change, PDF-only, guarded on `dbSettingsLoaded` so the initial default-state value doesn't clobber the saved one.
 
 ### Phase 2 — Per-book window size persistence
 
-- Change `openReaderWindow.ts` to `await` a `get_book_settings(bookId)` call before constructing `WebviewWindow`. Read `window_width` / `window_height`, clamp, and pass to the constructor. On any error, fall through to the current defaults.
-- In `Reader.tsx`, subscribe to `appWindow.onResized` during the lifetime of the reader. On each event, read `logicalSize()` and debounced-write `window_width` / `window_height` to `book_settings`.
-- Unsubscribe on unmount to avoid leaks across hot-reloads.
+- `openReaderWindow.ts` reads `reader-window-${bookId}` synchronously from `localStorage` before `new WebviewWindow(...)`, clamps to min 700×500, falls back to 1440×960 on missing/invalid values. No API shape change.
+- In `Reader.tsx`, when running as a standalone reader window (`appWindow.label.startsWith("reader-")`), subscribe to `appWindow.onResized`. Convert the emitted `PhysicalSize` to logical via `appWindow.scaleFactor()` and debounced-write `{width, height}` to `localStorage`.
+- Unsubscribe on effect teardown to avoid leaks across HMR.
 
 ## Verification
 
 - [ ] Open book A, resize the window, close. Reopen A → window restores to the last size.
-- [ ] Open PDF book A, set zoom to 150%, close. Reopen A → still 150%.
+- [ ] Open PDF book A (without resizing), set zoom to 150%, close. Reopen A → still 150%.
+- [ ] Open PDF book A at 150%, drag-resize the window (zoom resets to 100% — expected), close. Reopen A → 100% (normalized zoom was persisted, as documented).
 - [ ] Book A and book B have independent window sizes and zoom levels.
 - [ ] First-time open of a fresh book uses the default 1440×960 and 100%.
-- [ ] Rapid dragging of the resize handle doesn't produce dozens of DB writes — confirm via logging or a counter that writes are debounced.
+- [ ] Rapid dragging of the resize handle doesn't produce dozens of localStorage writes — confirm via DevTools Application panel or a counter that writes debounce.
 - [ ] Zoom scrubbed with rapid clicks on zoom-in/out buttons debounces similarly.
-- [ ] EPUB book closed and reopened → window size restored; no `zoom_level` key written.
-- [ ] Saved width/height below the minimums are clamped up to 700/500 (simulate by manually setting `book_settings`).
-- [ ] Corrupt `zoom_level` value ("foo") falls back to 100% and doesn't crash the reader.
+- [ ] EPUB book closed and reopened → window size restored; no `reader-zoom-*` key written.
+- [ ] Saved width/height below the minimums are clamped up to 700/500 (simulate by manually editing the localStorage entry).
+- [ ] Corrupt `reader-zoom-*` value ("foo") or `reader-window-*` JSON falls back to defaults and doesn't crash the reader.
 - [ ] Multiple reader windows open at once (books A and B side by side) persist their sizes independently.

--- a/docs/features/198-per-book-window-zoom.md
+++ b/docs/features/198-per-book-window-zoom.md
@@ -1,0 +1,63 @@
+# 198 — Persist Per-Book Window Size and PDF Zoom
+
+**GitHub Issue:** https://github.com/yicheng47/quill/issues/198
+
+## Motivation
+
+Reader windows are per-book (`reader-${bookId}` `WebviewWindow`), but every book opens at a fixed 1440×960 regardless of what size the user last chose. PDF zoom has the same problem: dial in 150% for a small-print academic paper, close the book, reopen — you're back at 100%.
+
+Quill already persists reading progress, reading mode, theme, page layout, and other per-book settings via `book_settings`. Window size and PDF zoom are the last user-controlled knobs that get forgotten every session. Closing a gap users hit every day; no new infrastructure needed.
+
+## Scope
+
+### In scope
+
+- **Persist reader window size per book** — width and height saved on resize, restored on next open.
+- **Persist PDF zoom % per book** — saved on change, restored when the book loads.
+- **Reuse `book_settings`** — the existing key-value-per-book table (`migrations/007_book_settings.sql`) is the right home. New keys: `window_width`, `window_height`, `zoom_level`.
+- **Debounced writes** — live resize/zoom generates many events; writes debounce at ~500ms so the DB isn't hammered.
+- **Clamp on load** — saved window dimensions clamped to the existing `minWidth: 700` / `minHeight: 500` from `openReaderWindow.ts`; zoom clamped to the valid zoom range.
+
+### Out of scope
+
+- **Window position persistence** — deferred. Multi-monitor and off-screen-window edge cases deserve their own issue.
+- **Main (library) window size** — this issue is about per-book reader windows only. Tauri already handles the main window via default platform behavior.
+- **EPUB zoom** — foliate-js handles EPUB text scaling through font-size, not a zoom control. Only window size applies to EPUBs.
+- **Retroactive migration** — missing keys fall back to defaults; no backfill needed.
+
+## Key decisions
+
+- **Storage layout** — three string-valued keys in `book_settings`: `window_width`, `window_height`, `zoom_level`. Matches the existing pattern; no schema change.
+- **Window size load timing** — the saved size must be read in `src/utils/openReaderWindow.ts` **before** `new WebviewWindow(...)`. Passing them to the constructor avoids a visible resize flash on open. The helper becomes async (already returns a `Promise`).
+- **Zoom load timing** — loaded inside `Reader.tsx` alongside the other per-book settings that seed state on book load. No flash concern — zoom is applied after the book is ready.
+- **Save timing** — `appWindow.onResized` (Tauri) fires continuously during a drag-resize; we buffer via a 500ms trailing debounce so only the final size hits the DB. Zoom changes debounce the same way (zoom buttons can fire fast).
+- **Clamping** — on load, clamp `window_width` to `max(700, saved)`, same for height (500). If the saved value is garbage (non-numeric), fall back to defaults silently.
+- **Defaults unchanged** — absent keys → today's behavior (1440×960 window, 100% zoom). No user action required; the feature is invisible until they resize or zoom.
+- **Per-window identity** — the window label `reader-${bookId}` already makes each window book-scoped. Saving per book is trivial; no label parsing gymnastics needed.
+
+## Implementation Phases
+
+### Phase 1 — PDF zoom persistence
+
+- In `Reader.tsx`, when the book loads, call `get_book_settings(bookId)` (already wired) and seed `zoomLevel` from `zoom_level` if present and the book is a PDF.
+- Wrap `setZoomLevel` with a debounced write to `set_book_settings_bulk` keyed on `zoom_level`.
+- Guard on `book.format === "pdf"` so EPUBs don't write a meaningless `zoom_level` key.
+
+### Phase 2 — Per-book window size persistence
+
+- Change `openReaderWindow.ts` to `await` a `get_book_settings(bookId)` call before constructing `WebviewWindow`. Read `window_width` / `window_height`, clamp, and pass to the constructor. On any error, fall through to the current defaults.
+- In `Reader.tsx`, subscribe to `appWindow.onResized` during the lifetime of the reader. On each event, read `logicalSize()` and debounced-write `window_width` / `window_height` to `book_settings`.
+- Unsubscribe on unmount to avoid leaks across hot-reloads.
+
+## Verification
+
+- [ ] Open book A, resize the window, close. Reopen A → window restores to the last size.
+- [ ] Open PDF book A, set zoom to 150%, close. Reopen A → still 150%.
+- [ ] Book A and book B have independent window sizes and zoom levels.
+- [ ] First-time open of a fresh book uses the default 1440×960 and 100%.
+- [ ] Rapid dragging of the resize handle doesn't produce dozens of DB writes — confirm via logging or a counter that writes are debounced.
+- [ ] Zoom scrubbed with rapid clicks on zoom-in/out buttons debounces similarly.
+- [ ] EPUB book closed and reopened → window size restored; no `zoom_level` key written.
+- [ ] Saved width/height below the minimums are clamped up to 700/500 (simulate by manually setting `book_settings`).
+- [ ] Corrupt `zoom_level` value ("foo") falls back to 100% and doesn't crash the reader.
+- [ ] Multiple reader windows open at once (books A and B side by side) persist their sizes independently.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -18,3 +18,4 @@ Specs for features that are in progress or planned. Shipped specs are moved to [
 - [30 — MCP Server](30-mcp-server.md)
 - [31 — Sync](31-sync.md)
 - [146 — PDF Continuous Scroll Mode](146-pdf-scroll-mode.md)
+- [198 — Persist Per-Book Window Size and PDF Zoom](198-per-book-window-zoom.md)

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -298,6 +298,11 @@ export default function Reader() {
         wordSpacing: bookSettings.wordSpacing ?? (g.word_spacing ? parseInt(g.word_spacing) : prev.wordSpacing),
         margins: bookSettings.margins ?? (g.margins ? parseInt(g.margins) : prev.margins),
       }));
+      const savedZoom = localStorage.getItem(`reader-zoom-${bookId}`);
+      const parsedZoom = savedZoom ? parseInt(savedZoom, 10) : NaN;
+      if (Number.isFinite(parsedZoom) && parsedZoom >= 50 && parsedZoom <= 300) {
+        setZoomLevel(parsedZoom);
+      }
       dbSettingsLoaded.current = true;
     }).catch(() => {});
   }, [bookId]);
@@ -309,6 +314,42 @@ export default function Reader() {
     if (!dbSettingsLoaded.current) return;
     localStorage.setItem(`reader-settings-${bookId}`, JSON.stringify(readerSettings));
   }, [readerSettings]);
+
+  // Persist per-book PDF zoom after load. Debounce to avoid thrashing during
+  // rapid zoom-button clicks; only write once the user settles.
+  useEffect(() => {
+    if (!dbSettingsLoaded.current) return;
+    if (book?.format !== "pdf") return;
+    const handle = window.setTimeout(() => {
+      localStorage.setItem(`reader-zoom-${bookId}`, String(zoomLevel));
+    }, 500);
+    return () => window.clearTimeout(handle);
+  }, [zoomLevel, bookId, book?.format]);
+
+  // Persist per-book reader window size. Standalone reader windows are
+  // labelled `reader-${bookId}`; openReaderWindow reads this key back on
+  // next open so the window restores to the size the user left it at.
+  useEffect(() => {
+    if (!isStandaloneWindow || !bookId) return;
+    let timer: number | null = null;
+    const unlistenPromise = appWindow.onResized(({ payload }) => {
+      if (timer !== null) window.clearTimeout(timer);
+      timer = window.setTimeout(async () => {
+        try {
+          const scale = await appWindow.scaleFactor();
+          const logical = payload.toLogical(scale);
+          localStorage.setItem(
+            `reader-window-${bookId}`,
+            JSON.stringify({ width: Math.round(logical.width), height: Math.round(logical.height) }),
+          );
+        } catch { /* window may have closed */ }
+      }, 500);
+    });
+    return () => {
+      if (timer !== null) window.clearTimeout(timer);
+      unlistenPromise.then((fn) => fn()).catch(() => {});
+    };
+  }, [bookId]);
 
   // Wait for iCloud download if book is not locally available
   useEffect(() => {
@@ -715,11 +756,10 @@ export default function Reader() {
   const zoomRef = useRef(zoomLevel);
   zoomRef.current = zoomLevel;
 
-  const handleZoom = (delta: number) => {
+  const applyZoomToRenderer = useCallback((next: number) => {
     const view = viewRef.current;
     const viewer = viewerRef.current;
     if (!view?.renderer || !viewer) return;
-    const next = Math.min(300, Math.max(50, zoomRef.current + delta));
     const renderer = view.renderer;
 
     // Scroll mode (foliate-pdf-scroll): the renderer observes a `zoom`
@@ -727,19 +767,16 @@ export default function Reader() {
     // onZoom hook. CSS transform would break IntersectionObserver math.
     if (book?.format === "pdf" && readerSettings.readingMode === "scrolling") {
       renderer.setAttribute("zoom", String(next / 100));
-      setZoomLevel(next);
       return;
     }
 
     if (next === 100) {
-      // Reset to fit-page: fluid sizing, no transform
       renderer.style.width = "";
       renderer.style.height = "";
       renderer.style.transform = "";
       viewer.style.width = "";
       viewer.style.height = "";
     } else {
-      // Lock renderer at its current (fit-page) size if not already locked
       if (!renderer.style.width) {
         renderer.style.width = `${renderer.clientWidth}px`;
         renderer.style.height = `${renderer.clientHeight}px`;
@@ -747,14 +784,27 @@ export default function Reader() {
       const scale = next / 100;
       renderer.style.transform = `scale(${scale})`;
       renderer.style.transformOrigin = "top left";
-      // Set viewer to zoomed size so parent container can scroll
       const baseW = parseInt(renderer.style.width);
       const baseH = parseInt(renderer.style.height);
       viewer.style.width = `${baseW * scale}px`;
       viewer.style.height = `${baseH * scale}px`;
     }
+  }, [book?.format, readerSettings.readingMode]);
+
+  const handleZoom = (delta: number) => {
+    const next = Math.min(300, Math.max(50, zoomRef.current + delta));
+    applyZoomToRenderer(next);
     setZoomLevel(next);
   };
+
+  // Apply the seeded zoom once the PDF is rendered — state alone doesn't
+  // transform the renderer. Re-apply when readingMode flips (pagination
+  // tears down the view and rebuilds it).
+  useEffect(() => {
+    if (!bookReady || book?.format !== "pdf") return;
+    if (zoomRef.current === 100) return;
+    applyZoomToRenderer(zoomRef.current);
+  }, [bookReady, book?.format, readerSettings.readingMode, applyZoomToRenderer]);
 
   const togglePanel = (panel: "ai" | "bookmarks" | "vocab") => {
     setSidePanel((prev) => (prev === panel ? null : panel));

--- a/src/utils/openReaderWindow.ts
+++ b/src/utils/openReaderWindow.ts
@@ -7,6 +7,27 @@ interface ReaderWindowOptions {
   cfi?: string | null;
 }
 
+const DEFAULT_WIDTH = 1440;
+const DEFAULT_HEIGHT = 960;
+const MIN_WIDTH = 700;
+const MIN_HEIGHT = 500;
+
+function loadSavedSize(bookId: string): { width: number; height: number } {
+  try {
+    const raw = localStorage.getItem(`reader-window-${bookId}`);
+    if (!raw) return { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT };
+    const parsed = JSON.parse(raw) as { width?: unknown; height?: unknown };
+    const width = typeof parsed.width === "number" && Number.isFinite(parsed.width) ? parsed.width : DEFAULT_WIDTH;
+    const height = typeof parsed.height === "number" && Number.isFinite(parsed.height) ? parsed.height : DEFAULT_HEIGHT;
+    return {
+      width: Math.max(MIN_WIDTH, Math.round(width)),
+      height: Math.max(MIN_HEIGHT, Math.round(height)),
+    };
+  } catch {
+    return { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT };
+  }
+}
+
 export async function openReaderWindow(
   bookId: string,
   options?: ReaderWindowOptions
@@ -32,13 +53,15 @@ export async function openReaderWindow(
     if (qs) url += `?${qs}`;
   }
 
+  const { width, height } = loadSavedSize(bookId);
+
   new WebviewWindow(label, {
     url,
     title: "Quill",
-    width: 1440,
-    height: 960,
-    minWidth: 700,
-    minHeight: 500,
+    width,
+    height,
+    minWidth: MIN_WIDTH,
+    minHeight: MIN_HEIGHT,
     titleBarStyle: "overlay",
     hiddenTitle: true,
   });


### PR DESCRIPTION
Closes #198 · Spec: [`docs/features/198-per-book-window-zoom.md`](docs/features/198-per-book-window-zoom.md)

## Summary
- Reader windows (`reader-${bookId}`) now restore to the size you left them at instead of always opening at 1440×960.
- PDF zoom % is remembered per book and reapplied on reopen (50–300 range, clamped).
- Both use `localStorage` keyed by bookId, matching the existing per-book reader-settings pattern. Writes are debounced 500ms so live resize/zoom doesn't thrash storage.

## Implementation
- `src/utils/openReaderWindow.ts` — reads `reader-window-${bookId}` *synchronously* before `new WebviewWindow(...)` so the window opens at the saved size with no visible resize flash. Clamps to existing min 700×500, falls back to 1440×960 on missing/invalid values.
- `src/pages/Reader.tsx`:
  - Seeds `zoomLevel` from `reader-zoom-${bookId}` inside the existing book-load effect.
  - New debounced save-effect for zoom (PDF-only, guarded on `dbSettingsLoaded`).
  - New effect listens to `appWindow.onResized` in standalone window mode, converts `PhysicalSize` → logical via `scaleFactor()`, debounced-saves.
  - Extracted `applyZoomToRenderer(next)` out of `handleZoom` so a post-`bookReady` effect can apply the seeded zoom to the renderer (state alone wouldn't transform the DOM).

## Known limitation (pre-existing)
The reader already resets zoom to 100% on `window.resize` (so the PDF re-fits). That behavior is unchanged — dragging to resize during a session still wipes the zoom. Persistence kicks in across close/reopen, where no resize fires since the window is constructed at the saved size.

## Test plan
- [x] Open PDF, resize window, close → reopen restores size.
- [x] Open PDF, set zoom 150%, close → reopen still 150%.
- [x] Two books have independent sizes and zooms.
- [x] First open of a new book uses 1440×960 / 100%.
- [x] Rapid zoom clicks don't flood localStorage (debounced).
- [x] EPUB reopen restores window size; no zoom key written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)