### PR TITLE
feat(sync): remove peer devices from iCloud settings

### DIFF
--- a/docs/features/206-icloud-device-management.md
+++ b/docs/features/206-icloud-device-management.md
@@ -1,0 +1,88 @@
+# 206 — iCloud Device Management
+
+**GitHub Issue:** https://github.com/yicheng47/quill/issues/206
+
+## Motivation
+
+Desktop Quill's iCloud sync settings show every device that has ever registered in the shared iCloud container under "Other devices," but there's no way to remove one. Uninstalled apps, prior installs that re-registered after a reinstall, and wiped Macs all leave their manifest + log + snapshot behind indefinitely — the user has no UI path to clean them up.
+
+The iOS app already shipped this: a trash button per peer row with a confirmation alert, backed by `Sync.removePeer(deviceUUID:)` that deletes the peer's three files (`<uuid>.json` manifest, `<uuid>.jsonl` log, `<uuid>.snapshot.json`) from the shared folder. This spec brings the same affordance to desktop, matching the iOS copy and behavior.
+
+Also fits cleanly with the per-device event-log model (spec 31): peers are just files in the shared folder, so "remove device" is a bounded file-delete operation with no distributed coordination required.
+
+## Scope
+
+### In scope
+
+- **Backend `delete_peer`** in `src-tauri/src/sync/peers.rs` — deletes the manifest, `<uuid>.jsonl` log, and `<uuid>.snapshot.json` for a given device UUID. Idempotent (no error when files are already absent). Refuses to delete self (early return, not an error — matches iOS guard).
+- **Tauri command `sync_remove_peer(device_uuid)`** in `src-tauri/src/commands/sync.rs`, registered in `lib.rs`. Resolves shared dir via the same path the existing `sync_status` command uses. Returns `AppResult<()>`.
+- **Trash button per peer row** in `src/components/settings/LibrarySyncSettings.tsx`. Disabled while `busy`. Self does not appear in the peer list (backend filters), so no self-delete guard is needed in UI.
+- **Confirmation modal** — destructive action styling, matches the existing Modal primitive used elsewhere in settings. Copy mirrors iOS: names the device, explains what gets deleted (iCloud files for that device only), what's preserved (local books), and that the peer will reappear if it opens Quill again.
+- **i18n keys** added to `src/i18n/en.json` and `src/i18n/zh.json` under `settings.librarySync.*`.
+- **Status refresh** after successful removal so the row disappears immediately.
+
+### Out of scope
+
+- **Bulk "clear all stale peers" action.** Per-row is enough; stale peers are rare.
+- **Automatic pruning by `lastSeen` age.** Explicit user action only.
+- **iOS changes.** Already shipped.
+- **Removing the device's binary assets** (`books/<id>.epub`, `covers/<id>.jpg`). Those are shared across all devices in the folder — not per-peer — so peer removal must not touch them.
+- **Undo.** Once files are deleted from iCloud, they're gone. The peer can re-register by launching Quill on that device again; no undo needed.
+
+## Key decisions
+
+- **Three files, not two.** iOS's `Peers.deletePeer` covers manifest + log + snapshot. Desktop must match exactly — missing either the log or snapshot leaves orphan data that confuses replay on other peers. The names are:
+  - `devices/<uuid>.json` — manifest
+  - `logs/<uuid>.jsonl` — event log
+  - `logs/<uuid>.snapshot.json` — compacted snapshot (may or may not exist)
+- **Idempotent file delete.** Use `fs::remove_file` and swallow `ErrorKind::NotFound`. Any other I/O error propagates as `AppError`.
+- **Self-guard in backend, not UI.** UI already doesn't render the self row (backend `list_peers` filters it), but add a defensive early-return in `delete_peer` so a caller with a stale UUID can't accidentally nuke their own data. Matches iOS (`guard deviceUUID != selfDevice else { return }`).
+- **Confirmation is required.** Single-click destructive actions are a footgun; match iOS's alert dialog pattern with a separate Modal.
+- **Copy is translated literally from iOS.** Don't rewrite — consistency across platforms matters more than a cleverer line.
+- **No loading state on the trash button itself** — the operation is fast (three file deletes), and the modal is already the user's indication that something is happening. The whole settings panel's existing `busy` state disables the button during the call, which is enough.
+
+## Implementation Phases
+
+### Phase 1 — Backend
+
+1. Add `delete_peer(shared_dir: &Path, device_uuid: &str, own_uuid: &str) -> AppResult<()>` to `src-tauri/src/sync/peers.rs`. Early-return if `device_uuid == own_uuid`. Compute the three paths; for each, `fs::remove_file` and swallow `NotFound`.
+2. Add `#[tauri::command] pub fn sync_remove_peer(device_uuid: String, sync_state: State<'_, SyncState>) -> AppResult<()>` to `src-tauri/src/commands/sync.rs`. Resolve shared dir via the same helper used by `sync_status`; resolve own UUID from the device module. Call `peers::delete_peer`. Return `Ok(())`.
+3. Register `sync_remove_peer` in `src-tauri/src/lib.rs` tauri builder.
+4. Unit tests in `peers.rs`:
+   - Deletes all three files when present.
+   - Deletes when only some files exist (partial prior cleanup).
+   - No-op on self UUID.
+   - No error when files already absent (idempotent retry).
+   - Subsequent `list_peers` call does not include the removed UUID.
+
+### Phase 2 — Frontend
+
+1. Add trash-icon button to each peer row in `LibrarySyncSettings.tsx`. Use `lucide-react` `Trash2`.
+2. State: `pendingRemoval: PeerInfo | null`. Clicking trash sets it.
+3. Confirmation Modal rendered when `pendingRemoval !== null`. Two buttons: Cancel (clears state) and Remove (destructive). On Remove: `await invoke("sync_remove_peer", { deviceUuid: pendingRemoval.device_uuid })`, then re-fetch status, then clear `pendingRemoval`. Surface errors via the existing error-handling path for this settings panel.
+4. New i18n keys (add to both `en.json` and `zh.json`):
+   - `settings.librarySync.removeDevice` — "Remove device" (button aria-label / tooltip)
+   - `settings.librarySync.removeDeviceTitle` — "Remove {{name}} from sync?"
+   - `settings.librarySync.removeDeviceBody` — "This device's log, snapshot, and manifest in iCloud will be deleted. Any books already synced to this device are kept. The other device will reappear here if it opens Quill again and re-registers."
+   - `settings.librarySync.remove` — "Remove"
+   - `settings.librarySync.cancel` — "Cancel" (reuse an existing common cancel key if one exists)
+
+### Phase 3 — Polish
+
+- Verify button alignment matches the rest of the peer row on both light and dark themes.
+- Verify modal close on Escape and on backdrop click (whatever the Modal primitive already does).
+- Smoke test with a real multi-device iCloud shared folder: create a fake peer manifest/log, confirm removal wipes all three files.
+
+## Verification
+
+- [ ] Trash button appears on every peer row in "Other devices." Self is not listed (pre-existing backend behavior), so self-delete is not reachable from UI.
+- [ ] Clicking trash opens a confirmation modal showing the peer's name.
+- [ ] Confirming deletes the peer's manifest (`devices/<uuid>.json`), log (`logs/<uuid>.jsonl`), and snapshot (`logs/<uuid>.snapshot.json`) from the iCloud shared folder.
+- [ ] The peer row disappears after confirmation (status is refreshed).
+- [ ] Binary assets (`books/`, `covers/`) are untouched.
+- [ ] Calling `sync_remove_peer` again on an already-removed UUID returns Ok (idempotent).
+- [ ] If the removed device opens Quill again, it re-registers and reappears in the list.
+- [ ] The call refuses to touch self — if tested directly via invoke with the local device_uuid, it returns Ok without deleting anything.
+- [ ] Both English and Chinese translations render correctly (confirmation title, body, buttons, trash tooltip).
+- [ ] No new console errors or Rust warnings from `cargo check`.
+- [ ] Existing unit tests still pass (`cargo test -p quill`).

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -19,3 +19,4 @@ Specs for features that are in progress or planned. Shipped specs are moved to [
 - [31 — Sync](31-sync.md)
 - [146 — PDF Continuous Scroll Mode](146-pdf-scroll-mode.md)
 - [198 — Persist Per-Book Window Size and PDF Zoom](198-per-book-window-zoom.md)
+- [206 — iCloud Device Management](206-icloud-device-management.md)

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -484,6 +484,31 @@ pub fn sync_compact(sync_state: State<'_, SyncState>) -> AppResult<SyncCompactRe
     Ok(report.into())
 }
 
+/// Remove a peer device's footprint from the shared folder. Deletes
+/// the peer's manifest, event log, and snapshot. Used by the settings
+/// UI's per-device trash button to clean up orphaned entries (e.g. an
+/// uninstalled app whose UUID is still publishing a stale `last_seen`).
+///
+/// Idempotent — re-deleting an already-removed peer returns Ok. No-op
+/// when the device_uuid matches the local device (defense in depth;
+/// the UI doesn't render self in the peer list to begin with).
+///
+/// Resolves the shared dir the same way `sync_status` does so the
+/// command works whether or not the engine is currently booted in this
+/// process. Returns an error only when no shared dir can be resolved
+/// (iCloud unavailable AND no recorded marker).
+#[tauri::command]
+pub fn sync_remove_peer(
+    device_uuid: String,
+    local: State<'_, LocalDir>,
+    device: State<'_, DeviceIdentity>,
+) -> AppResult<()> {
+    let shared_dir = sync::migration::recorded_data_dir(&local.0)
+        .or_else(icloud::icloud_data_dir_deterministic)
+        .ok_or_else(|| AppError::Other("iCloud shared folder is not available".into()))?;
+    peers::delete_peer(&shared_dir, &device_uuid, &device.device_uuid)
+}
+
 /// Placeholder for the 30-day grace-window rollback to legacy file-sync.
 /// The legacy implementation has been removed in this chunk, so the
 /// rollback can't actually restore old behavior — return a clear

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -408,6 +408,7 @@ pub fn run() {
             commands::sync::sync_now,
             commands::sync::sync_compact,
             commands::sync::sync_revert_to_legacy,
+            commands::sync::sync_remove_peer,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/src-tauri/src/sync/peers.rs
+++ b/src-tauri/src/sync/peers.rs
@@ -25,6 +25,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 
@@ -126,32 +127,50 @@ pub fn delete_own_manifest(shared_dir: &Path, device_uuid: &str) -> AppResult<()
     }
 }
 
-/// Remove a peer device from the shared folder: deletes its manifest,
-/// event log, and snapshot. Used by the settings UI's per-device trash
-/// button to clean up orphaned entries (uninstalled apps, prior
-/// installs after a reinstall).
+/// Remove a peer device from the shared folder: deletes its log,
+/// snapshot, and finally its manifest. Used by the settings UI's
+/// per-device trash button to clean up orphaned entries (uninstalled
+/// apps, prior installs after a reinstall).
 ///
 /// Refuses to touch the caller's own UUID — early return, not an
 /// error. Mirrors iOS's `Peers.deletePeer` guard so a stale UUID can't
 /// accidentally wipe local state.
 ///
+/// **UUID validation.** `device_uuid` is rejected unless it parses as
+/// a real UUID. The shared folder is writable by every peer, so a
+/// malformed or hostile manifest could otherwise inject path
+/// components like `..` and steer this destructive command outside
+/// the `<shared>/devices/` and `<shared>/logs/` namespace. Strict
+/// parsing eliminates that whole class of input.
+///
+/// **Deletion order.** Log first, then snapshot, then manifest. Peer
+/// discovery (`list_peers`) keys off the manifest, so as long as the
+/// manifest still exists the user can retry from the UI after a
+/// partial failure on the log/snapshot writes. Deleting the manifest
+/// last means a mid-call I/O error never strands log/snapshot orphans
+/// that the UI can no longer surface.
+///
 /// Idempotent: missing files are not an error. Any other I/O failure
 /// stops at the first error and propagates — the UI surfaces it and
-/// the user can retry. Subsequent retries pick up wherever the previous
-/// attempt left off.
+/// the user can retry.
 pub fn delete_peer(shared_dir: &Path, device_uuid: &str, own_uuid: &str) -> AppResult<()> {
     if device_uuid == own_uuid {
         return Ok(());
     }
-    let manifest = manifest_path(shared_dir, device_uuid);
+    if Uuid::parse_str(device_uuid).is_err() {
+        return Err(AppError::Other(format!(
+            "refusing to delete peer: {device_uuid:?} is not a valid UUID"
+        )));
+    }
     let log = shared_dir
         .join("logs")
         .join(format!("{device_uuid}.jsonl"));
     let snapshot = shared_dir
         .join("logs")
         .join(format!("{device_uuid}.snapshot.json"));
+    let manifest = manifest_path(shared_dir, device_uuid);
 
-    for path in [&manifest, &log, &snapshot] {
+    for path in [&log, &snapshot, &manifest] {
         match fs::remove_file(path) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -285,18 +304,25 @@ mod tests {
         fs::write(logs.join(format!("{uuid}.snapshot.json")), b"{}").unwrap();
     }
 
+    // Real UUIDs for delete_peer tests — input is now validated as a
+    // genuine UUID, so the older string keys ("peer-A", "self") would
+    // be rejected by the path-traversal guard.
+    const PEER_A: &str = "11111111-1111-4111-8111-111111111111";
+    const PEER_B: &str = "22222222-2222-4222-8222-222222222222";
+    const SELF: &str = "00000000-0000-4000-8000-000000000000";
+
     #[test]
     fn delete_peer_removes_manifest_log_and_snapshot() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, "peer-A", "Mac A", "macos", "1.0.0", 1_000).unwrap();
-        seed_peer_log_and_snapshot(shared, "peer-A");
+        write_own_manifest(shared, PEER_A, "Mac A", "macos", "1.0.0", 1_000).unwrap();
+        seed_peer_log_and_snapshot(shared, PEER_A);
 
-        delete_peer(shared, "peer-A", "self").unwrap();
+        delete_peer(shared, PEER_A, SELF).unwrap();
 
-        assert!(!manifest_path(shared, "peer-A").exists());
-        assert!(!shared.join("logs/peer-A.jsonl").exists());
-        assert!(!shared.join("logs/peer-A.snapshot.json").exists());
+        assert!(!manifest_path(shared, PEER_A).exists());
+        assert!(!shared.join(format!("logs/{PEER_A}.jsonl")).exists());
+        assert!(!shared.join(format!("logs/{PEER_A}.snapshot.json")).exists());
     }
 
     #[test]
@@ -304,44 +330,108 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
         // No files exist yet — must not error.
-        delete_peer(shared, "ghost", "self").unwrap();
+        delete_peer(shared, PEER_A, SELF).unwrap();
 
         // Partial state: only a manifest exists.
-        write_own_manifest(shared, "ghost", "Ghost", "macos", "1.0.0", 1_000).unwrap();
-        delete_peer(shared, "ghost", "self").unwrap();
-        assert!(!manifest_path(shared, "ghost").exists());
+        write_own_manifest(shared, PEER_A, "Ghost", "macos", "1.0.0", 1_000).unwrap();
+        delete_peer(shared, PEER_A, SELF).unwrap();
+        assert!(!manifest_path(shared, PEER_A).exists());
 
         // Re-deleting after everything is gone is still a no-op.
-        delete_peer(shared, "ghost", "self").unwrap();
+        delete_peer(shared, PEER_A, SELF).unwrap();
     }
 
     #[test]
     fn delete_peer_refuses_self_uuid() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, "self", "Self", "macos", "1.0.0", 1_000).unwrap();
-        seed_peer_log_and_snapshot(shared, "self");
+        write_own_manifest(shared, SELF, "Self", "macos", "1.0.0", 1_000).unwrap();
+        seed_peer_log_and_snapshot(shared, SELF);
 
-        delete_peer(shared, "self", "self").unwrap();
+        delete_peer(shared, SELF, SELF).unwrap();
 
         // All three self artifacts must remain — guard refuses the call.
-        assert!(manifest_path(shared, "self").exists());
-        assert!(shared.join("logs/self.jsonl").exists());
-        assert!(shared.join("logs/self.snapshot.json").exists());
+        assert!(manifest_path(shared, SELF).exists());
+        assert!(shared.join(format!("logs/{SELF}.jsonl")).exists());
+        assert!(shared.join(format!("logs/{SELF}.snapshot.json")).exists());
     }
 
     #[test]
     fn list_peers_excludes_uuid_after_delete_peer() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, "peer-A", "Mac A", "macos", "1.0.0", 2_000).unwrap();
-        write_own_manifest(shared, "peer-B", "Mac B", "macos", "1.0.0", 3_000).unwrap();
+        write_own_manifest(shared, PEER_A, "Mac A", "macos", "1.0.0", 2_000).unwrap();
+        write_own_manifest(shared, PEER_B, "Mac B", "macos", "1.0.0", 3_000).unwrap();
 
-        delete_peer(shared, "peer-A", "self").unwrap();
+        delete_peer(shared, PEER_A, SELF).unwrap();
 
-        let peers = list_peers(shared, "self").unwrap();
+        let peers = list_peers(shared, SELF).unwrap();
         assert_eq!(peers.len(), 1);
-        assert_eq!(peers[0].device_uuid, "peer-B");
+        assert_eq!(peers[0].device_uuid, PEER_B);
+    }
+
+    /// Path-traversal guard: a manifest under attacker control could
+    /// claim `device_uuid = "../../etc/passwd"` (or similar). The
+    /// command must refuse before constructing any paths so a
+    /// malformed shared folder cannot steer file deletion outside
+    /// `<shared>/devices/` and `<shared>/logs/`.
+    #[test]
+    fn delete_peer_rejects_path_traversal_input() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path().join("shared");
+        let outside = tmp.path().join("victim.txt");
+        fs::create_dir_all(&shared).unwrap();
+        fs::write(&outside, b"keep me").unwrap();
+
+        // Whatever the attacker puts in `device_uuid`, the call must
+        // error and the outside file must remain. Try several shapes.
+        for evil in [
+            "../victim",
+            "../../etc/passwd",
+            "..\\windows",
+            "valid-looking-but-not-a-uuid",
+            "",
+        ] {
+            let result = delete_peer(&shared, evil, SELF);
+            assert!(
+                result.is_err(),
+                "delete_peer must reject non-UUID input {evil:?}",
+            );
+        }
+        assert!(outside.exists(), "outside file must be untouched");
+    }
+
+    /// Deletion order: log + snapshot first, manifest last. This means
+    /// a partial-failure mid-call leaves the manifest behind so the
+    /// peer still appears in `list_peers` and the user can retry the
+    /// trash button. The opposite order would orphan log/snapshot
+    /// files no UI surface can target.
+    ///
+    /// We simulate "mid-call failure" by manually deleting only the
+    /// log + snapshot, leaving the manifest, then verifying the peer
+    /// is still listed and a follow-up `delete_peer` finishes the job.
+    #[test]
+    fn delete_peer_order_lets_user_retry_after_partial_failure() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        write_own_manifest(shared, PEER_A, "Mac A", "macos", "1.0.0", 1_000).unwrap();
+        seed_peer_log_and_snapshot(shared, PEER_A);
+
+        // Simulate a successful first attempt that took out log +
+        // snapshot but somehow failed (or was interrupted) before the
+        // manifest delete: peer must still be discoverable.
+        fs::remove_file(shared.join(format!("logs/{PEER_A}.jsonl"))).unwrap();
+        fs::remove_file(shared.join(format!("logs/{PEER_A}.snapshot.json"))).unwrap();
+        let peers = list_peers(shared, SELF).unwrap();
+        assert_eq!(
+            peers.len(),
+            1,
+            "manifest must outlive the log/snapshot so the UI can retry",
+        );
+
+        // Retry from the UI completes cleanup.
+        delete_peer(shared, PEER_A, SELF).unwrap();
+        assert!(list_peers(shared, SELF).unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/sync/peers.rs
+++ b/src-tauri/src/sync/peers.rs
@@ -150,18 +150,38 @@ pub fn delete_own_manifest(shared_dir: &Path, device_uuid: &str) -> AppResult<()
 /// last means a mid-call I/O error never strands log/snapshot orphans
 /// that the UI can no longer surface.
 ///
+/// **Self-guard is value-based, not string-based.** Both UUIDs are
+/// parsed and compared as `Uuid` values, so casing differences (e.g.
+/// `ABCDEF…` vs `abcdef…`) cannot bypass the guard. iCloud's HFS+/APFS
+/// volumes are case-insensitive by default — without the value-based
+/// compare, a peer manifest at `<UPPER-OWN-UUID>.jsonl` would resolve
+/// to the same on-disk file as the lowercase own log and the call
+/// would happily wipe local state. The on-disk path stays in the
+/// caller-supplied case so cross-device sync onto a case-sensitive
+/// filesystem still finds the right file.
+///
 /// Idempotent: missing files are not an error. Any other I/O failure
 /// stops at the first error and propagates — the UI surfaces it and
 /// the user can retry.
 pub fn delete_peer(shared_dir: &Path, device_uuid: &str, own_uuid: &str) -> AppResult<()> {
-    if device_uuid == own_uuid {
+    let target = match Uuid::parse_str(device_uuid) {
+        Ok(u) => u,
+        Err(_) => {
+            return Err(AppError::Other(format!(
+                "refusing to delete peer: {device_uuid:?} is not a valid UUID"
+            )));
+        }
+    };
+    // Compare as parsed Uuid values so casing can't sneak past the
+    // self-guard on case-insensitive filesystems. own_uuid is owned
+    // by us and always parses; if it ever doesn't, we still refuse.
+    let own = Uuid::parse_str(own_uuid).map_err(|_| {
+        AppError::Other(format!("refusing to delete peer: own_uuid {own_uuid:?} is not a valid UUID"))
+    })?;
+    if target == own {
         return Ok(());
     }
-    if Uuid::parse_str(device_uuid).is_err() {
-        return Err(AppError::Other(format!(
-            "refusing to delete peer: {device_uuid:?} is not a valid UUID"
-        )));
-    }
+
     let log = shared_dir
         .join("logs")
         .join(format!("{device_uuid}.jsonl"));
@@ -195,6 +215,14 @@ pub fn delete_peer(shared_dir: &Path, device_uuid: &str, own_uuid: &str) -> AppR
 /// `device_uuid = "<victim>"` and trick the UI's trash button into
 /// deleting the victim's manifest/log/snapshot. Filenames must parse
 /// as a UUID; non-conforming entries are skipped.
+///
+/// **Self-filter is value-based.** Both the filename stem and
+/// `own_uuid` are parsed as `Uuid` values for the equality check, so
+/// casing differences (UPPERCASE vs lowercase) cannot make this
+/// device's own manifest show up in the peer list. iCloud's case-
+/// insensitive volumes resolve both to the same on-disk file, so a
+/// mis-cased self entry would otherwise let the UI delete its own
+/// state.
 pub fn list_peers(shared_dir: &Path, own_uuid: &str) -> AppResult<Vec<Peer>> {
     let dir = shared_dir.join(DEVICES_SUBDIR);
     let entries = match fs::read_dir(&dir) {
@@ -202,6 +230,12 @@ pub fn list_peers(shared_dir: &Path, own_uuid: &str) -> AppResult<Vec<Peer>> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => return Err(AppError::Io(e)),
     };
+
+    // Parse own_uuid once. If it doesn't parse (shouldn't happen —
+    // it's our own DeviceIdentity), fall through with `None` so the
+    // self-filter never matches and the UI sees every entry; that's
+    // strictly safer than crashing the status call.
+    let own_parsed = Uuid::parse_str(own_uuid).ok();
 
     let mut out = Vec::new();
     for entry in entries.flatten() {
@@ -216,11 +250,19 @@ pub fn list_peers(shared_dir: &Path, own_uuid: &str) -> AppResult<Vec<Peer>> {
             Some(s) => s,
             None => continue,
         };
-        if Uuid::parse_str(stem).is_err() {
-            eprintln!(
-                "sync: skipping non-UUID peer manifest filename {}",
-                path.display()
-            );
+        let stem_parsed = match Uuid::parse_str(stem) {
+            Ok(u) => u,
+            Err(_) => {
+                eprintln!(
+                    "sync: skipping non-UUID peer manifest filename {}",
+                    path.display()
+                );
+                continue;
+            }
+        };
+        // Value-based self filter — applied BEFORE reading the file,
+        // since we already know the identity from the filename.
+        if Some(stem_parsed) == own_parsed {
             continue;
         }
         let bytes = match fs::read(&path) {
@@ -254,9 +296,6 @@ pub fn list_peers(shared_dir: &Path, own_uuid: &str) -> AppResult<Vec<Peer>> {
             );
         }
         peer.device_uuid = stem.to_string();
-        if peer.device_uuid == own_uuid {
-            continue;
-        }
         out.push(peer);
     }
     // Stable ordering for the UI: most-recently-seen first.
@@ -467,6 +506,64 @@ mod tests {
         let peers = list_peers(shared, SELF_UUID).unwrap();
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].device_uuid, PEER_B_UUID);
+    }
+
+    /// Self-guard must be value-based, not string-based: an
+    /// uppercase-cased UUID matches the same on-disk file as the
+    /// lowercase form on iCloud's case-insensitive volumes. A
+    /// string-only compare would let a UPPER-cased self UUID slip
+    /// past as "another peer" and the resulting delete_peer call
+    /// would wipe local state. `Uuid::parse_str` normalises casing.
+    #[test]
+    fn delete_peer_self_guard_ignores_uuid_casing() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        // Seed a self log/snapshot/manifest under the canonical
+        // (lowercase) UUID — the actual on-disk state for this device.
+        write_own_manifest(shared, SELF_UUID, "Self", "macos", "1.0.0", 1_000).unwrap();
+        seed_peer_log_and_snapshot(shared, SELF_UUID);
+
+        // Caller hands in the uppercase form (e.g. read from a
+        // peer-impersonating manifest). delete_peer must treat it as
+        // self and refuse, regardless of casing.
+        let upper = SELF_UUID.to_uppercase();
+        delete_peer(shared, &upper, SELF_UUID).unwrap();
+
+        assert!(manifest_path(shared, SELF_UUID).exists());
+        assert!(shared.join(format!("logs/{SELF_UUID}.jsonl")).exists());
+        assert!(shared.join(format!("logs/{SELF_UUID}.snapshot.json")).exists());
+    }
+
+    /// Same hazard at the discovery layer: list_peers must filter
+    /// out a manifest whose filename is the casing-shifted form of
+    /// our own UUID, so the UI never even surfaces a "trash" target
+    /// that points at our own state.
+    #[test]
+    fn list_peers_filters_self_uuid_regardless_of_filename_casing() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        let dir = shared.join(DEVICES_SUBDIR);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Drop a manifest whose filename is the uppercase form of our
+        // own UUID. On a case-insensitive filesystem this is the same
+        // file as our own; on a case-sensitive one it's a distinct
+        // file — either way it must NOT appear in the peer list.
+        let upper_path = dir.join(format!("{}.json", SELF_UUID.to_uppercase()));
+        let manifest = Peer {
+            device_uuid: SELF_UUID.to_uppercase(),
+            name: "Maybe me, maybe not".into(),
+            platform: "macos".into(),
+            app_version: "1.0.0".into(),
+            last_seen: 1_000,
+        };
+        fs::write(&upper_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+        // Plus one real peer so we know discovery still works.
+        write_own_manifest(shared, PEER_A_UUID, "Real Peer", "macos", "1.0.0", 2_000).unwrap();
+
+        let peers = list_peers(shared, SELF_UUID).unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].device_uuid, PEER_A_UUID);
     }
 
     /// Path-traversal guard: a manifest under attacker control could

--- a/src-tauri/src/sync/peers.rs
+++ b/src-tauri/src/sync/peers.rs
@@ -126,6 +126,41 @@ pub fn delete_own_manifest(shared_dir: &Path, device_uuid: &str) -> AppResult<()
     }
 }
 
+/// Remove a peer device from the shared folder: deletes its manifest,
+/// event log, and snapshot. Used by the settings UI's per-device trash
+/// button to clean up orphaned entries (uninstalled apps, prior
+/// installs after a reinstall).
+///
+/// Refuses to touch the caller's own UUID — early return, not an
+/// error. Mirrors iOS's `Peers.deletePeer` guard so a stale UUID can't
+/// accidentally wipe local state.
+///
+/// Idempotent: missing files are not an error. Any other I/O failure
+/// stops at the first error and propagates — the UI surfaces it and
+/// the user can retry. Subsequent retries pick up wherever the previous
+/// attempt left off.
+pub fn delete_peer(shared_dir: &Path, device_uuid: &str, own_uuid: &str) -> AppResult<()> {
+    if device_uuid == own_uuid {
+        return Ok(());
+    }
+    let manifest = manifest_path(shared_dir, device_uuid);
+    let log = shared_dir
+        .join("logs")
+        .join(format!("{device_uuid}.jsonl"));
+    let snapshot = shared_dir
+        .join("logs")
+        .join(format!("{device_uuid}.snapshot.json"));
+
+    for path in [&manifest, &log, &snapshot] {
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(AppError::Io(e)),
+        }
+    }
+    Ok(())
+}
+
 /// List every peer manifest under `<shared>/devices/` excluding our own
 /// UUID. Parse failures are logged and skipped — discovery degrades
 /// gracefully rather than failing the whole status call.
@@ -239,6 +274,74 @@ mod tests {
         let peers = list_peers(shared, "other").unwrap();
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].last_seen, 5_000);
+    }
+
+    /// Helper: drop a fake event log + snapshot for a given peer so
+    /// `delete_peer` tests can assert cleanup of all three artifacts.
+    fn seed_peer_log_and_snapshot(shared: &Path, uuid: &str) {
+        let logs = shared.join("logs");
+        fs::create_dir_all(&logs).unwrap();
+        fs::write(logs.join(format!("{uuid}.jsonl")), b"{}\n").unwrap();
+        fs::write(logs.join(format!("{uuid}.snapshot.json")), b"{}").unwrap();
+    }
+
+    #[test]
+    fn delete_peer_removes_manifest_log_and_snapshot() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        write_own_manifest(shared, "peer-A", "Mac A", "macos", "1.0.0", 1_000).unwrap();
+        seed_peer_log_and_snapshot(shared, "peer-A");
+
+        delete_peer(shared, "peer-A", "self").unwrap();
+
+        assert!(!manifest_path(shared, "peer-A").exists());
+        assert!(!shared.join("logs/peer-A.jsonl").exists());
+        assert!(!shared.join("logs/peer-A.snapshot.json").exists());
+    }
+
+    #[test]
+    fn delete_peer_is_idempotent_on_missing_files() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        // No files exist yet — must not error.
+        delete_peer(shared, "ghost", "self").unwrap();
+
+        // Partial state: only a manifest exists.
+        write_own_manifest(shared, "ghost", "Ghost", "macos", "1.0.0", 1_000).unwrap();
+        delete_peer(shared, "ghost", "self").unwrap();
+        assert!(!manifest_path(shared, "ghost").exists());
+
+        // Re-deleting after everything is gone is still a no-op.
+        delete_peer(shared, "ghost", "self").unwrap();
+    }
+
+    #[test]
+    fn delete_peer_refuses_self_uuid() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        write_own_manifest(shared, "self", "Self", "macos", "1.0.0", 1_000).unwrap();
+        seed_peer_log_and_snapshot(shared, "self");
+
+        delete_peer(shared, "self", "self").unwrap();
+
+        // All three self artifacts must remain — guard refuses the call.
+        assert!(manifest_path(shared, "self").exists());
+        assert!(shared.join("logs/self.jsonl").exists());
+        assert!(shared.join("logs/self.snapshot.json").exists());
+    }
+
+    #[test]
+    fn list_peers_excludes_uuid_after_delete_peer() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        write_own_manifest(shared, "peer-A", "Mac A", "macos", "1.0.0", 2_000).unwrap();
+        write_own_manifest(shared, "peer-B", "Mac B", "macos", "1.0.0", 3_000).unwrap();
+
+        delete_peer(shared, "peer-A", "self").unwrap();
+
+        let peers = list_peers(shared, "self").unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].device_uuid, "peer-B");
     }
 
     #[test]

--- a/src-tauri/src/sync/peers.rs
+++ b/src-tauri/src/sync/peers.rs
@@ -186,6 +186,15 @@ pub fn delete_peer(shared_dir: &Path, device_uuid: &str, own_uuid: &str) -> AppR
 ///
 /// Missing `<shared>/devices/` directory returns an empty vec — happens
 /// on a fresh shared folder before any device has enabled sync.
+///
+/// **Filename is the source of truth for `device_uuid`.** The shared
+/// folder is writable by every peer, so the JSON payload's
+/// `device_uuid` is treated as untrusted: the field is overwritten
+/// with the filename stem before the `Peer` is returned. Without
+/// this, a hostile manifest at `devices/<attacker>.json` could declare
+/// `device_uuid = "<victim>"` and trick the UI's trash button into
+/// deleting the victim's manifest/log/snapshot. Filenames must parse
+/// as a UUID; non-conforming entries are skipped.
 pub fn list_peers(shared_dir: &Path, own_uuid: &str) -> AppResult<Vec<Peer>> {
     let dir = shared_dir.join(DEVICES_SUBDIR);
     let entries = match fs::read_dir(&dir) {
@@ -200,6 +209,20 @@ pub fn list_peers(shared_dir: &Path, own_uuid: &str) -> AppResult<Vec<Peer>> {
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
+        // Filename stem is the trusted identity. Skip anything whose
+        // basename doesn't parse as a UUID — random files in the
+        // shared folder shouldn't ever appear in the peer list.
+        let stem = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+        if Uuid::parse_str(stem).is_err() {
+            eprintln!(
+                "sync: skipping non-UUID peer manifest filename {}",
+                path.display()
+            );
+            continue;
+        }
         let bytes = match fs::read(&path) {
             Ok(b) => b,
             Err(e) => {
@@ -210,7 +233,7 @@ pub fn list_peers(shared_dir: &Path, own_uuid: &str) -> AppResult<Vec<Peer>> {
                 continue;
             }
         };
-        let peer: Peer = match serde_json::from_slice(&bytes) {
+        let mut peer: Peer = match serde_json::from_slice(&bytes) {
             Ok(p) => p,
             Err(e) => {
                 eprintln!(
@@ -220,6 +243,17 @@ pub fn list_peers(shared_dir: &Path, own_uuid: &str) -> AppResult<Vec<Peer>> {
                 continue;
             }
         };
+        // Discard whatever identity the payload claims; trust only
+        // the filename stem so impersonation isn't reachable from any
+        // downstream consumer.
+        if peer.device_uuid != stem {
+            eprintln!(
+                "sync: peer manifest {} declared device_uuid {:?} that doesn't match its filename; using filename",
+                path.display(),
+                peer.device_uuid,
+            );
+        }
+        peer.device_uuid = stem.to_string();
         if peer.device_uuid == own_uuid {
             continue;
         }
@@ -235,37 +269,45 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    // Real UUIDs for tests — `list_peers` now requires the manifest
+    // filename stem to parse as a UUID, so the older string keys
+    // ("self", "peer-A") would be silently skipped by discovery.
+    const SELF_UUID: &str = "00000000-0000-4000-8000-000000000000";
+    const PEER_A_UUID: &str = "11111111-1111-4111-8111-111111111111";
+    const PEER_B_UUID: &str = "22222222-2222-4222-8222-222222222222";
+    const PEER_C_UUID: &str = "33333333-3333-4333-8333-333333333333";
+
     #[test]
     fn write_then_list_skips_own_uuid() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, "self", "Self Mac", "macos", "0.10.0", 1_000).unwrap();
-        write_own_manifest(shared, "peer-A", "Mac A", "macos", "0.10.0", 2_000).unwrap();
-        write_own_manifest(shared, "peer-B", "Mac B", "macos", "0.10.0", 3_000).unwrap();
+        write_own_manifest(shared, SELF_UUID, "Self Mac", "macos", "0.10.0", 1_000).unwrap();
+        write_own_manifest(shared, PEER_A_UUID, "Mac A", "macos", "0.10.0", 2_000).unwrap();
+        write_own_manifest(shared, PEER_B_UUID, "Mac B", "macos", "0.10.0", 3_000).unwrap();
 
-        let peers = list_peers(shared, "self").unwrap();
+        let peers = list_peers(shared, SELF_UUID).unwrap();
         assert_eq!(peers.len(), 2);
-        assert!(peers.iter().all(|p| p.device_uuid != "self"));
+        assert!(peers.iter().all(|p| p.device_uuid != SELF_UUID));
     }
 
     #[test]
     fn list_orders_by_last_seen_descending() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, "old", "Old", "macos", "0.10.0", 1_000).unwrap();
-        write_own_manifest(shared, "new", "New", "macos", "0.10.0", 9_000).unwrap();
-        write_own_manifest(shared, "mid", "Mid", "macos", "0.10.0", 5_000).unwrap();
+        write_own_manifest(shared, PEER_A_UUID, "Old", "macos", "0.10.0", 1_000).unwrap();
+        write_own_manifest(shared, PEER_B_UUID, "New", "macos", "0.10.0", 9_000).unwrap();
+        write_own_manifest(shared, PEER_C_UUID, "Mid", "macos", "0.10.0", 5_000).unwrap();
 
-        let peers = list_peers(shared, "self").unwrap();
-        assert_eq!(peers[0].device_uuid, "new");
-        assert_eq!(peers[1].device_uuid, "mid");
-        assert_eq!(peers[2].device_uuid, "old");
+        let peers = list_peers(shared, SELF_UUID).unwrap();
+        assert_eq!(peers[0].device_uuid, PEER_B_UUID);
+        assert_eq!(peers[1].device_uuid, PEER_C_UUID);
+        assert_eq!(peers[2].device_uuid, PEER_A_UUID);
     }
 
     #[test]
     fn missing_devices_dir_returns_empty_list() {
         let tmp = TempDir::new().unwrap();
-        let peers = list_peers(tmp.path(), "self").unwrap();
+        let peers = list_peers(tmp.path(), SELF_UUID).unwrap();
         assert!(peers.is_empty());
     }
 
@@ -273,26 +315,90 @@ mod tests {
     fn malformed_manifest_is_skipped_not_fatal() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, "good", "Good", "macos", "0.10.0", 1_000).unwrap();
+        write_own_manifest(shared, PEER_A_UUID, "Good", "macos", "0.10.0", 1_000).unwrap();
 
-        let bad_path = shared.join(DEVICES_SUBDIR).join("bad.json");
+        let bad_path = shared
+            .join(DEVICES_SUBDIR)
+            .join(format!("{PEER_B_UUID}.json"));
         fs::write(&bad_path, b"{not valid json").unwrap();
 
-        let peers = list_peers(shared, "self").unwrap();
+        let peers = list_peers(shared, SELF_UUID).unwrap();
         assert_eq!(peers.len(), 1);
-        assert_eq!(peers[0].device_uuid, "good");
+        assert_eq!(peers[0].device_uuid, PEER_A_UUID);
     }
 
     #[test]
     fn rewrite_overwrites_in_place_with_new_last_seen() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, "me", "Me", "macos", "0.10.0", 1_000).unwrap();
-        write_own_manifest(shared, "me", "Me", "macos", "0.10.0", 5_000).unwrap();
+        write_own_manifest(shared, PEER_A_UUID, "Me", "macos", "0.10.0", 1_000).unwrap();
+        write_own_manifest(shared, PEER_A_UUID, "Me", "macos", "0.10.0", 5_000).unwrap();
 
-        let peers = list_peers(shared, "other").unwrap();
+        let peers = list_peers(shared, SELF_UUID).unwrap();
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].last_seen, 5_000);
+    }
+
+    /// Filename is the source of truth for `device_uuid`. A hostile
+    /// manifest at `devices/<attacker>.json` could declare
+    /// `device_uuid = "<victim>"` to trick downstream code into
+    /// targeting the victim's files. `list_peers` must overwrite the
+    /// payload field with the filename-derived UUID.
+    #[test]
+    fn list_peers_overrides_payload_uuid_with_filename() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        // Attacker's manifest filename is PEER_A but it claims to be PEER_B.
+        let attacker = Peer {
+            device_uuid: PEER_B_UUID.to_string(),
+            name: "Impersonator".into(),
+            platform: "macos".into(),
+            app_version: "0.10.0".into(),
+            last_seen: 1_000,
+        };
+        let dir = shared.join(DEVICES_SUBDIR);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join(format!("{PEER_A_UUID}.json")),
+            serde_json::to_vec(&attacker).unwrap(),
+        )
+        .unwrap();
+
+        let peers = list_peers(shared, SELF_UUID).unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(
+            peers[0].device_uuid, PEER_A_UUID,
+            "device_uuid must come from the filename, not the JSON payload",
+        );
+    }
+
+    /// A manifest with a non-UUID filename (random file dropped into
+    /// the shared folder by some other tool) must not appear in the
+    /// peer list — the UI's trash button would otherwise be unable to
+    /// target it correctly anyway.
+    #[test]
+    fn list_peers_skips_non_uuid_filenames() {
+        let tmp = TempDir::new().unwrap();
+        let shared = tmp.path();
+        let dir = shared.join(DEVICES_SUBDIR);
+        fs::create_dir_all(&dir).unwrap();
+        let bogus = Peer {
+            device_uuid: PEER_A_UUID.to_string(),
+            name: "Looks legit".into(),
+            platform: "macos".into(),
+            app_version: "0.10.0".into(),
+            last_seen: 1_000,
+        };
+        fs::write(
+            dir.join("not-a-uuid.json"),
+            serde_json::to_vec(&bogus).unwrap(),
+        )
+        .unwrap();
+        write_own_manifest(shared, PEER_B_UUID, "Real Peer", "macos", "0.10.0", 2_000).unwrap();
+
+        let peers = list_peers(shared, SELF_UUID).unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].device_uuid, PEER_B_UUID);
     }
 
     /// Helper: drop a fake event log + snapshot for a given peer so
@@ -304,25 +410,18 @@ mod tests {
         fs::write(logs.join(format!("{uuid}.snapshot.json")), b"{}").unwrap();
     }
 
-    // Real UUIDs for delete_peer tests — input is now validated as a
-    // genuine UUID, so the older string keys ("peer-A", "self") would
-    // be rejected by the path-traversal guard.
-    const PEER_A: &str = "11111111-1111-4111-8111-111111111111";
-    const PEER_B: &str = "22222222-2222-4222-8222-222222222222";
-    const SELF: &str = "00000000-0000-4000-8000-000000000000";
-
     #[test]
     fn delete_peer_removes_manifest_log_and_snapshot() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, PEER_A, "Mac A", "macos", "1.0.0", 1_000).unwrap();
-        seed_peer_log_and_snapshot(shared, PEER_A);
+        write_own_manifest(shared, PEER_A_UUID, "Mac A", "macos", "1.0.0", 1_000).unwrap();
+        seed_peer_log_and_snapshot(shared, PEER_A_UUID);
 
-        delete_peer(shared, PEER_A, SELF).unwrap();
+        delete_peer(shared, PEER_A_UUID, SELF_UUID).unwrap();
 
-        assert!(!manifest_path(shared, PEER_A).exists());
-        assert!(!shared.join(format!("logs/{PEER_A}.jsonl")).exists());
-        assert!(!shared.join(format!("logs/{PEER_A}.snapshot.json")).exists());
+        assert!(!manifest_path(shared, PEER_A_UUID).exists());
+        assert!(!shared.join(format!("logs/{PEER_A_UUID}.jsonl")).exists());
+        assert!(!shared.join(format!("logs/{PEER_A_UUID}.snapshot.json")).exists());
     }
 
     #[test]
@@ -330,44 +429,44 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
         // No files exist yet — must not error.
-        delete_peer(shared, PEER_A, SELF).unwrap();
+        delete_peer(shared, PEER_A_UUID, SELF_UUID).unwrap();
 
         // Partial state: only a manifest exists.
-        write_own_manifest(shared, PEER_A, "Ghost", "macos", "1.0.0", 1_000).unwrap();
-        delete_peer(shared, PEER_A, SELF).unwrap();
-        assert!(!manifest_path(shared, PEER_A).exists());
+        write_own_manifest(shared, PEER_A_UUID, "Ghost", "macos", "1.0.0", 1_000).unwrap();
+        delete_peer(shared, PEER_A_UUID, SELF_UUID).unwrap();
+        assert!(!manifest_path(shared, PEER_A_UUID).exists());
 
         // Re-deleting after everything is gone is still a no-op.
-        delete_peer(shared, PEER_A, SELF).unwrap();
+        delete_peer(shared, PEER_A_UUID, SELF_UUID).unwrap();
     }
 
     #[test]
     fn delete_peer_refuses_self_uuid() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, SELF, "Self", "macos", "1.0.0", 1_000).unwrap();
-        seed_peer_log_and_snapshot(shared, SELF);
+        write_own_manifest(shared, SELF_UUID, "Self", "macos", "1.0.0", 1_000).unwrap();
+        seed_peer_log_and_snapshot(shared, SELF_UUID);
 
-        delete_peer(shared, SELF, SELF).unwrap();
+        delete_peer(shared, SELF_UUID, SELF_UUID).unwrap();
 
         // All three self artifacts must remain — guard refuses the call.
-        assert!(manifest_path(shared, SELF).exists());
-        assert!(shared.join(format!("logs/{SELF}.jsonl")).exists());
-        assert!(shared.join(format!("logs/{SELF}.snapshot.json")).exists());
+        assert!(manifest_path(shared, SELF_UUID).exists());
+        assert!(shared.join(format!("logs/{SELF_UUID}.jsonl")).exists());
+        assert!(shared.join(format!("logs/{SELF_UUID}.snapshot.json")).exists());
     }
 
     #[test]
     fn list_peers_excludes_uuid_after_delete_peer() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, PEER_A, "Mac A", "macos", "1.0.0", 2_000).unwrap();
-        write_own_manifest(shared, PEER_B, "Mac B", "macos", "1.0.0", 3_000).unwrap();
+        write_own_manifest(shared, PEER_A_UUID, "Mac A", "macos", "1.0.0", 2_000).unwrap();
+        write_own_manifest(shared, PEER_B_UUID, "Mac B", "macos", "1.0.0", 3_000).unwrap();
 
-        delete_peer(shared, PEER_A, SELF).unwrap();
+        delete_peer(shared, PEER_A_UUID, SELF_UUID).unwrap();
 
-        let peers = list_peers(shared, SELF).unwrap();
+        let peers = list_peers(shared, SELF_UUID).unwrap();
         assert_eq!(peers.len(), 1);
-        assert_eq!(peers[0].device_uuid, PEER_B);
+        assert_eq!(peers[0].device_uuid, PEER_B_UUID);
     }
 
     /// Path-traversal guard: a manifest under attacker control could
@@ -392,7 +491,7 @@ mod tests {
             "valid-looking-but-not-a-uuid",
             "",
         ] {
-            let result = delete_peer(&shared, evil, SELF);
+            let result = delete_peer(&shared, evil, SELF_UUID);
             assert!(
                 result.is_err(),
                 "delete_peer must reject non-UUID input {evil:?}",
@@ -414,15 +513,15 @@ mod tests {
     fn delete_peer_order_lets_user_retry_after_partial_failure() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, PEER_A, "Mac A", "macos", "1.0.0", 1_000).unwrap();
-        seed_peer_log_and_snapshot(shared, PEER_A);
+        write_own_manifest(shared, PEER_A_UUID, "Mac A", "macos", "1.0.0", 1_000).unwrap();
+        seed_peer_log_and_snapshot(shared, PEER_A_UUID);
 
         // Simulate a successful first attempt that took out log +
         // snapshot but somehow failed (or was interrupted) before the
         // manifest delete: peer must still be discoverable.
-        fs::remove_file(shared.join(format!("logs/{PEER_A}.jsonl"))).unwrap();
-        fs::remove_file(shared.join(format!("logs/{PEER_A}.snapshot.json"))).unwrap();
-        let peers = list_peers(shared, SELF).unwrap();
+        fs::remove_file(shared.join(format!("logs/{PEER_A_UUID}.jsonl"))).unwrap();
+        fs::remove_file(shared.join(format!("logs/{PEER_A_UUID}.snapshot.json"))).unwrap();
+        let peers = list_peers(shared, SELF_UUID).unwrap();
         assert_eq!(
             peers.len(),
             1,
@@ -430,22 +529,22 @@ mod tests {
         );
 
         // Retry from the UI completes cleanup.
-        delete_peer(shared, PEER_A, SELF).unwrap();
-        assert!(list_peers(shared, SELF).unwrap().is_empty());
+        delete_peer(shared, PEER_A_UUID, SELF_UUID).unwrap();
+        assert!(list_peers(shared, SELF_UUID).unwrap().is_empty());
     }
 
     #[test]
     fn delete_own_manifest_removes_file_and_is_idempotent() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, "me", "Me", "macos", "0.10.0", 1_000).unwrap();
-        assert!(manifest_path(shared, "me").exists());
+        write_own_manifest(shared, PEER_A_UUID, "Me", "macos", "0.10.0", 1_000).unwrap();
+        assert!(manifest_path(shared, PEER_A_UUID).exists());
 
-        delete_own_manifest(shared, "me").unwrap();
-        assert!(!manifest_path(shared, "me").exists());
+        delete_own_manifest(shared, PEER_A_UUID).unwrap();
+        assert!(!manifest_path(shared, PEER_A_UUID).exists());
 
         // Re-deleting is a no-op.
-        delete_own_manifest(shared, "me").unwrap();
+        delete_own_manifest(shared, PEER_A_UUID).unwrap();
     }
 
     #[test]
@@ -474,13 +573,13 @@ mod tests {
     fn non_json_files_in_devices_dir_are_ignored() {
         let tmp = TempDir::new().unwrap();
         let shared = tmp.path();
-        write_own_manifest(shared, "me", "Me", "macos", "0.10.0", 1_000).unwrap();
+        write_own_manifest(shared, PEER_A_UUID, "Me", "macos", "0.10.0", 1_000).unwrap();
 
         // A `.DS_Store` or stray temp file shouldn't break listing.
         fs::write(shared.join(DEVICES_SUBDIR).join(".DS_Store"), b"").unwrap();
         fs::write(shared.join(DEVICES_SUBDIR).join("scratch.txt"), b"hi").unwrap();
 
-        let peers = list_peers(shared, "other").unwrap();
+        let peers = list_peers(shared, SELF_UUID).unwrap();
         assert_eq!(peers.len(), 1);
     }
 }

--- a/src/components/settings/LibrarySyncSettings.tsx
+++ b/src/components/settings/LibrarySyncSettings.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { Loader2, Monitor, Smartphone, Laptop } from "lucide-react";
+import { Loader2, Monitor, Smartphone, Laptop, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import Button from "../ui/Button";
 import Toggle from "../ui/Toggle";
@@ -71,6 +71,9 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
   // Disable flow (because `migration_complete` is now true), leaving
   // the user with no UI path to finish the half-completed enable.
   const [lastFailedAction, setLastFailedAction] = useState<"enable" | "disable" | null>(null);
+  // Peer the user clicked the trash icon on; opens a confirmation
+  // modal until cleared (cancel) or acted on (remove).
+  const [pendingRemoval, setPendingRemoval] = useState<PeerInfo | null>(null);
   // Tick once a minute so "Last seen 2m ago" stays fresh while the modal
   // is open. Cheap; the component re-renders are bounded.
   const [now, setNow] = useState(Date.now());
@@ -153,6 +156,22 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
     setError(null);
     try {
       await invoke<SyncNowResult>("sync_now");
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onConfirmRemovePeer = async () => {
+    const peer = pendingRemoval;
+    setPendingRemoval(null);
+    if (!peer) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await invoke("sync_remove_peer", { deviceUuid: peer.device_uuid });
       await refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -269,6 +288,16 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
                             {p.pending_events}
                           </span>
                         )}
+                        <button
+                          type="button"
+                          onClick={() => setPendingRemoval(p)}
+                          disabled={busy}
+                          aria-label={t("settings.librarySync.removeDevice")}
+                          title={t("settings.librarySync.removeDevice")}
+                          className="text-text-muted hover:text-[#e7000b] dark:hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer p-1 -m-1"
+                        >
+                          <Trash2 size={14} />
+                        </button>
                       </div>
                     );
                   })}
@@ -338,6 +367,33 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
           </div>
         )}
       </div>
+
+      {/* Remove-device confirmation. Mirrors iOS's destructive alert
+          copy so the cross-platform UX matches. */}
+      {pendingRemoval && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40">
+          <div className="bg-bg-surface rounded-xl shadow-lg w-[400px] p-6">
+            <h3 className="text-[18px] font-semibold text-text-primary mb-2">
+              {t("settings.librarySync.removeDeviceTitle", { name: pendingRemoval.name })}
+            </h3>
+            <p className="text-[14px] text-text-secondary leading-5 mb-6">
+              {t("settings.librarySync.removeDeviceBody")}
+            </p>
+            <div className="flex justify-end gap-3">
+              <Button variant="ghost" size="md" onClick={() => setPendingRemoval(null)}>
+                {t("common.cancel")}
+              </Button>
+              <button
+                type="button"
+                onClick={onConfirmRemovePeer}
+                className="bg-[#e7000b] hover:bg-[#c00009] text-white text-[14px] font-medium rounded-md px-4 py-2 cursor-pointer"
+              >
+                {t("settings.librarySync.remove")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Confirmation dialog — same shape as the legacy iCloud one so
           the UX is identical at the point of decision. */}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -301,6 +301,10 @@
   "settings.librarySync.confirmDisable": "Stop syncing with iCloud?",
   "settings.librarySync.confirmDisableMsg": "Your library will be copied back to local storage. Other devices keep their own copy until you delete it.",
   "settings.librarySync.confirmDisableCta": "Stop syncing",
+  "settings.librarySync.removeDevice": "Remove device",
+  "settings.librarySync.removeDeviceTitle": "Remove {{name}} from sync?",
+  "settings.librarySync.removeDeviceBody": "This device's log, snapshot, and manifest in iCloud will be deleted. Any books already synced to this device are kept. The other device will reappear here if it opens Quill again and re-registers.",
+  "settings.librarySync.remove": "Remove",
 
   "settings.appearance.title": "Appearance",
   "settings.appearance.subtitle": "Customize the look and feel of the app",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -303,6 +303,10 @@
   "settings.librarySync.confirmDisable": "停止与 iCloud 同步？",
   "settings.librarySync.confirmDisableMsg": "你的书库将被复制回本地存储。其他设备的副本将保留，直到你手动删除。",
   "settings.librarySync.confirmDisableCta": "停止同步",
+  "settings.librarySync.removeDevice": "移除设备",
+  "settings.librarySync.removeDeviceTitle": "将 {{name}} 从同步中移除？",
+  "settings.librarySync.removeDeviceBody": "iCloud 中该设备的日志、快照和清单文件将被删除。已同步到此设备的书籍会被保留。如果该设备再次打开 Quill 并重新注册，它会再次出现在这里。",
+  "settings.librarySync.remove": "移除",
 
   "settings.appearance.title": "外观",
   "settings.appearance.subtitle": "自定义应用的外观和风格",


### PR DESCRIPTION
## Summary

- Adds a per-peer trash button + destructive confirmation modal to the iCloud sync settings, matching the affordance already shipped in quill-ios.
- New backend: `delete_peer` (manifest + log + snapshot, idempotent, refuses self) exposed as the `sync_remove_peer` Tauri command.
- New i18n keys (en + zh) for the trash tooltip, confirmation title/body, and Remove button.

Closes #206. Spec: \`docs/features/206-icloud-device-management.md\`.

## Test plan

- [x] \`cargo test --lib\` — 208 passed (4 new \`delete_peer\` tests)
- [x] \`tsc --noEmit\` clean
- [ ] Manual: sync on, fake peer manifest in shared folder, click trash → confirm → row disappears, files gone from iCloud
- [ ] Manual: removed device launches Quill again → reappears in list
- [ ] Manual: zh locale renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)