### PR TITLE
fix(sync): import spinner hangs on CJK titles + iCloud waits

### DIFF
--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -21,12 +21,31 @@ fn slugify(title: &str) -> String {
         .collect::<Vec<_>>()
         .join("-")
         .to_lowercase();
-    // Truncate to ~60 chars at a word boundary
+    // Truncate to ~60 bytes at a word boundary, but never slice into
+    // a multi-byte UTF-8 character. Naive `slug[..60]` panics on
+    // non-ASCII titles (e.g. CJK) where byte 60 lands mid-codepoint —
+    // which surfaces as `import_book` returning a command-runtime
+    // panic the UI sees as "spinner forever". `floor_char_boundary`
+    // walks back to the previous char start.
     if slug.len() <= 60 {
         slug
     } else {
-        slug[..60].rfind('-').map_or(&slug[..60], |i| &slug[..i]).to_string()
+        let cut = floor_char_boundary(&slug, 60);
+        let head = &slug[..cut];
+        head.rfind('-').map_or(head, |i| &head[..i]).to_string()
     }
+}
+
+/// Largest valid char-boundary `<= max_bytes`. Stable equivalent of
+/// `str::floor_char_boundary` (which is still nightly-only as of
+/// rustc 1.85). Walks at most 3 bytes back since UTF-8 codepoints are
+/// at most 4 bytes wide.
+fn floor_char_boundary(s: &str, max_bytes: usize) -> usize {
+    let mut i = max_bytes.min(s.len());
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
 }
 
 /// Build a human-readable filename: `{slug}_{short-id}.{ext}`
@@ -656,6 +675,36 @@ mod tests {
     use crate::db::Db;
     use rusqlite::params;
     use tempfile::TempDir;
+
+    /// Regression: slugify of a CJK title used to panic when the
+    /// 60-byte truncation point landed mid-codepoint. The user-facing
+    /// symptom was `import_book` hanging forever (Tauri's command
+    /// runtime swallows the panic so the spinner never resolves).
+    /// This particular title — "百年孤独 (root edition note)" — slugs
+    /// to exactly 62 bytes so the cut at byte 60 falls inside the
+    /// last `删` character.
+    #[test]
+    fn slugify_does_not_panic_on_cjk_title_at_byte_boundary() {
+        let title = "百年孤独(根据马尔克斯指定版本翻译,未做任何增删)";
+        let slug = slugify(title);
+        // Must be valid UTF-8 (the .to_string() in slugify would have
+        // panicked if the slice were invalid) and not empty.
+        assert!(!slug.is_empty());
+        assert!(slug.chars().count() > 0);
+        // Must round-trip into book_filename without panicking.
+        let _ = book_filename(title, "abcdef0123456789", "epub");
+    }
+
+    /// ASCII titles still get a meaningful slug after the truncation
+    /// fix (regression safety on the common path).
+    #[test]
+    fn slugify_truncates_long_ascii_at_word_boundary() {
+        let title = "the quick brown fox jumps over the lazy dog and then keeps on running";
+        let slug = slugify(title);
+        assert!(slug.len() <= 60);
+        assert!(slug.starts_with("the-quick-brown-fox"));
+        assert!(!slug.ends_with('-'));
+    }
 
     fn setup() -> (TempDir, Db) {
         let dir = TempDir::new().unwrap();

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -356,14 +356,8 @@ pub fn sync_enable(
     // is non-fatal — the watcher will retry on the next event, and a
     // fresh-enable session doesn't have leftover outbox rows or peer
     // tails that would get stuck pending.
-    {
-        let mut conn = db
-            .conn
-            .lock()
-            .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
-        if let Err(e) = engine.tick(&mut conn) {
-            eprintln!("sync_enable: initial tick failed: {e}");
-        }
+    if let Err(e) = engine.tick(&db) {
+        eprintln!("sync_enable: initial tick failed: {e}");
     }
 
     Ok(())
@@ -460,11 +454,7 @@ pub fn sync_now(
     let engine = sync_state
         .engine_snapshot()?
         .ok_or_else(|| AppError::Other("sync is not enabled on this device".into()))?;
-    let mut conn = db
-        .conn
-        .lock()
-        .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
-    let report = engine.tick(&mut conn)?;
+    let report = engine.tick(&db)?;
     Ok(report.into())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,14 +55,8 @@ fn boot_sync_engine(
     // Initial tick — drains any leftover outbox, applies peer snapshots
     // and log tails since last launch. Failure here is non-fatal; the
     // watcher's first event will retry.
-    {
-        let mut conn = db
-            .conn
-            .lock()
-            .map_err(|e| error::AppError::Other(format!("db conn mutex: {e}")))?;
-        if let Err(e) = engine.tick(&mut conn) {
-            eprintln!("sync: initial replay tick failed: {e}");
-        }
+    if let Err(e) = engine.tick(db) {
+        eprintln!("sync: initial replay tick failed: {e}");
     }
 
     // If watcher spawn fails, roll back the writer so new writes fall

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -30,6 +30,7 @@ use std::sync::{Arc, Mutex};
 
 use rusqlite::{params, Connection};
 
+use crate::db::Db;
 use crate::error::{AppError, AppResult};
 
 use super::events::{Event, EventBody};
@@ -69,51 +70,67 @@ impl ReplayEngine {
         }
     }
 
-    pub fn tick(&self, conn: &mut Connection) -> AppResult<ReplayReport> {
+    /// Run a single replay pass.
+    ///
+    /// Takes `&Db` rather than `&mut Connection` so the SQLite mutex
+    /// can be released around the slow iCloud I/O — `flush_outbox`,
+    /// `write_own_manifest`, and `compact_own_log` all hit
+    /// `NSFileCoordinator`, and holding `db.conn` across those waits
+    /// previously serialized every UI write (`import_book` etc.)
+    /// behind the watcher's tick.
+    pub fn tick(&self, db: &Db) -> AppResult<ReplayReport> {
         let _guard = TICK_MUTEX
             .lock()
             .map_err(|e| AppError::Other(format!("replay tick mutex poisoned: {e}")))?;
 
-        // Phase 0 — drain the outbox into the device log. Failures here
-        // surface to the caller; peers will see the local writes on the
-        // next successful tick.
-        let outbox_flushed = self.flush_outbox(conn)?;
+        // Phase 0 — drain the outbox into the device log. Manages its
+        // own per-row locking; the slow `log.append` runs without
+        // holding `db.conn`. Failures surface to the caller; peers
+        // will see the local writes on the next successful tick.
+        let outbox_flushed = flush_outbox(db, &self.own_log)?;
 
-        // Phase 1 — discover peers (including self).
+        // Phase 1 — discover peers (including self). Pure fs read.
         let peers = discover_peers(&self.shared_dir)?;
         let peers_seen = peers.len();
 
-        // Phase 2/3/4 — read peer files, apply in one tx, advance watermarks.
-        // FK off mirrors the merge engine's contract; orphan rows from
-        // out-of-order delivery are tolerated until parents arrive.
-        //
-        // The pragma must be restored even if the merge work errors mid-way,
-        // otherwise the shared connection silently loses FK enforcement for
-        // every subsequent command. We capture the inner result and run the
-        // restore unconditionally before returning.
-        conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
-        let inner = self.apply_in_tx(conn, &peers);
-        let restore = conn.execute_batch("PRAGMA foreign_keys = ON;");
+        // Phase 2/3/4 — read peer files, apply in one tx, advance
+        // watermarks. FK off mirrors the merge engine's contract;
+        // orphan rows from out-of-order delivery are tolerated until
+        // parents arrive. The pragma must be restored even if the
+        // merge work errors mid-way, otherwise the shared connection
+        // silently loses FK enforcement for every subsequent command.
+        let (snapshots_applied, events_applied) = {
+            let mut conn = db
+                .conn
+                .lock()
+                .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
+            conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
+            let inner = self.apply_in_tx(&mut conn, &peers);
+            let restore = conn.execute_batch("PRAGMA foreign_keys = ON;");
+            let counts = match (inner, restore) {
+                (Ok(counts), Ok(())) => counts,
+                (Err(e), _) => return Err(e),
+                (Ok(_), Err(e)) => return Err(AppError::Db(e)),
+            };
 
-        let (snapshots_applied, events_applied) = match (inner, restore) {
-            (Ok(counts), Ok(())) => counts,
-            (Err(e), _) => return Err(e),
-            (Ok(_), Err(e)) => return Err(AppError::Db(e)),
+            // Stamp self's `_replay_state.updated_at` so the settings
+            // UI's "Last sync" reflects every successful tick — not
+            // only the ones that happened to move a peer watermark.
+            // A no-op `sync_now` click (no peer changes, no outbox
+            // drain) still proves the engine is healthy, and the UI
+            // deserves to show that. Upserts a NULL-watermark self
+            // row on first call.
+            let now = chrono::Utc::now().timestamp_millis();
+            conn.execute(
+                "INSERT INTO _replay_state (peer_device, last_snapshot_id, last_event_id, updated_at)
+                 VALUES (?1, NULL, NULL, ?2)
+                 ON CONFLICT(peer_device) DO UPDATE SET updated_at = excluded.updated_at",
+                params![self.self_device, now],
+            )?;
+            counts
         };
-
-        // Stamp self's `_replay_state.updated_at` so the settings UI's
-        // "Last sync" reflects every successful tick — not only the
-        // ones that happened to move a peer watermark. A no-op
-        // `sync_now` click (no peer changes, no outbox drain) still
-        // proves the engine is healthy, and the UI deserves to show
-        // that. Upserts a NULL-watermark self row on first call.
-        let now = chrono::Utc::now().timestamp_millis();
-        conn.execute(
-            "INSERT INTO _replay_state (peer_device, last_snapshot_id, last_event_id, updated_at)
-             VALUES (?1, NULL, NULL, ?2)
-             ON CONFLICT(peer_device) DO UPDATE SET updated_at = excluded.updated_at",
-            params![self.self_device, now],
-        )?;
+        // db.conn released — heartbeat and compaction below run on
+        // iCloud without blocking concurrent UI writes.
 
         // Refresh own peer manifest's `last_seen` so other devices see
         // us as currently active. A failed heartbeat is non-fatal — peers
@@ -230,13 +247,6 @@ impl ReplayEngine {
         Ok((snapshots_applied, events_applied))
     }
 
-    /// Drain `_pending_publish` into the own device log. Thin wrapper over
-    /// the free function `flush_outbox` so `SyncWriter` (Chunk 5) can call
-    /// the same drain path right after a successful commit without going
-    /// through a `ReplayEngine`.
-    fn flush_outbox(&self, conn: &mut Connection) -> AppResult<usize> {
-        flush_outbox(conn, &self.own_log)
-    }
 }
 
 /// Drain `_pending_publish` into `log`. Each row is re-serialized into an
@@ -248,8 +258,22 @@ impl ReplayEngine {
 /// (post-commit step) so the publish-retry guarantee holds end-to-end:
 /// every committed-but-not-yet-published event lands in the device log on
 /// the next successful flush from either path.
-pub fn flush_outbox(conn: &mut Connection, log: &EventLog) -> AppResult<usize> {
-    let pending = read_outbox(conn)?;
+///
+/// **Locking discipline.** Takes `&Db` (not `&mut Connection`) so we can
+/// release the SQLite mutex around `log.append`. On macOS that append
+/// goes through `NSFileCoordinator` and synchronously waits for Apple's
+/// `bird` daemon — often several seconds. Holding `db.conn` across that
+/// wait would serialize every UI write behind the watcher's tick, which
+/// is exactly the "import spinner hangs" symptom users hit. Per-row
+/// lock/unlock is cheap relative to the iCloud I/O.
+pub fn flush_outbox(db: &Db, log: &EventLog) -> AppResult<usize> {
+    let pending = {
+        let conn = db
+            .conn
+            .lock()
+            .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
+        read_outbox(&conn)?
+    };
     if pending.is_empty() {
         return Ok(0);
     }
@@ -262,13 +286,20 @@ pub fn flush_outbox(conn: &mut Connection, log: &EventLog) -> AppResult<usize> {
                 row.id
             ))
         })?;
+        // Slow part — runs WITHOUT holding db.conn so concurrent UI
+        // writes (import_book, highlight.add, etc.) are not blocked.
         log.append(body, row.ts)?;
         // Per-row delete: if a later append in this batch fails, the
         // earlier rows are already published and can be removed cleanly.
+        let conn = db
+            .conn
+            .lock()
+            .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
         conn.execute(
             "DELETE FROM _pending_publish WHERE id = ?1",
             params![row.id],
         )?;
+        drop(conn);
         flushed += 1;
     }
     Ok(flushed)
@@ -385,12 +416,23 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
-    /// Test harness: shared dir + local SQLite + own EventLog.
+    /// Test harness: shared dir + local SQLite (wrapped in a Db so
+    /// `engine.tick(&db)` can re-acquire the conn lock the same way
+    /// production does) + own EventLog.
     struct Env {
         _dir: TempDir,
         shared: PathBuf,
-        conn: Connection,
+        db: Db,
         engine: ReplayEngine,
+    }
+
+    impl Env {
+        /// Convenience accessor for tests that want to do raw SQL
+        /// without going through `with_tx`. Holds the lock for the
+        /// returned guard's lifetime — keep the binding short-lived.
+        fn conn(&self) -> std::sync::MutexGuard<'_, Connection> {
+            self.db.conn.lock().unwrap()
+        }
     }
 
     fn setup(self_device: &str) -> Env {
@@ -401,6 +443,10 @@ mod tests {
 
         let conn = Connection::open_in_memory().unwrap();
         Db::run_migrations_on(&conn).unwrap();
+        let db = Db {
+            conn: Arc::new(Mutex::new(conn)),
+            data_dir: Arc::new(Mutex::new(dir.path().to_path_buf())),
+        };
 
         let own_log_path = logs.join(format!("{self_device}.jsonl"));
         let own_log = Arc::new(EventLog::open(&own_log_path, self_device, false).unwrap());
@@ -409,7 +455,7 @@ mod tests {
         Env {
             _dir: dir,
             shared,
-            conn,
+            db,
             engine,
         }
     }
@@ -461,7 +507,7 @@ mod tests {
         // whose log append failed.
         let body1 = import("b1");
         let body2 = import("b2");
-        env.conn
+        env.conn()
             .execute(
                 "INSERT INTO _pending_publish (id, ts, body_json, created_at) VALUES (?1, ?2, ?3, ?4)",
                 params![
@@ -472,7 +518,7 @@ mod tests {
                 ],
             )
             .unwrap();
-        env.conn
+        env.conn()
             .execute(
                 "INSERT INTO _pending_publish (id, ts, body_json, created_at) VALUES (?1, ?2, ?3, ?4)",
                 params![
@@ -484,12 +530,12 @@ mod tests {
             )
             .unwrap();
 
-        let report = env.engine.tick(&mut env.conn).unwrap();
+        let report = env.engine.tick(&env.db).unwrap();
         assert_eq!(report.outbox_flushed, 2);
 
         // Outbox is empty.
         let n: i64 = env
-            .conn
+            .conn()
             .query_row("SELECT COUNT(*) FROM _pending_publish", [], |r| r.get(0))
             .unwrap();
         assert_eq!(n, 0);
@@ -501,7 +547,7 @@ mod tests {
         assert_eq!(log_events.len(), 2);
 
         let n_books: i64 = env
-            .conn
+            .conn()
             .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
             .unwrap();
         assert_eq!(n_books, 2);
@@ -531,19 +577,19 @@ mod tests {
         ];
         write_peer_log(&env.shared, "peer-A", &peer_events);
 
-        let report = env.engine.tick(&mut env.conn).unwrap();
+        let report = env.engine.tick(&env.db).unwrap();
         assert_eq!(report.events_applied, 2);
         assert_eq!(report.peers_seen, 2, "peer-A + self");
 
         let n_books: i64 = env
-            .conn
+            .conn()
             .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
             .unwrap();
         assert_eq!(n_books, 1);
 
         // Watermark advanced to the max id from peer-A.
         let last: Option<String> = env
-            .conn
+            .conn()
             .query_row(
                 "SELECT last_event_id FROM _replay_state WHERE peer_device = 'peer-A'",
                 [], |r| r.get(0),
@@ -558,11 +604,11 @@ mod tests {
         let peer_events = vec![ev(1000, "peer-A", import("b1"))];
         write_peer_log(&env.shared, "peer-A", &peer_events);
 
-        let r1 = env.engine.tick(&mut env.conn).unwrap();
+        let r1 = env.engine.tick(&env.db).unwrap();
         assert_eq!(r1.events_applied, 1);
 
         // Second tick — same log, no new events.
-        let r2 = env.engine.tick(&mut env.conn).unwrap();
+        let r2 = env.engine.tick(&env.db).unwrap();
         assert_eq!(r2.events_applied, 0, "watermark should suppress re-apply");
 
         // Append a new event to peer-A's log; tick picks it up.
@@ -578,11 +624,11 @@ mod tests {
         ));
         write_peer_log(&env.shared, "peer-A", &more);
 
-        let r3 = env.engine.tick(&mut env.conn).unwrap();
+        let r3 = env.engine.tick(&env.db).unwrap();
         assert_eq!(r3.events_applied, 1);
 
         let progress: i32 = env
-            .conn
+            .conn()
             .query_row("SELECT progress FROM books WHERE id = 'b1'", [], |r| r.get(0))
             .unwrap();
         assert_eq!(progress, 50);
@@ -616,9 +662,9 @@ mod tests {
             ),
         ]);
 
-        env.engine.tick(&mut env.conn).unwrap();
+        env.engine.tick(&env.db).unwrap();
         let progress: i32 = env
-            .conn
+            .conn()
             .query_row("SELECT progress FROM books WHERE id = 'b1'", [], |r| r.get(0))
             .unwrap();
         assert_eq!(progress, 80, "later peer-B event wins");
@@ -652,16 +698,16 @@ mod tests {
         )];
         write_peer_log(&env.shared, "peer-A", &tail);
 
-        let report = env.engine.tick(&mut env.conn).unwrap();
+        let report = env.engine.tick(&env.db).unwrap();
         assert!(report.snapshots_applied >= 1);
         assert_eq!(report.events_applied, 1);
 
         let n_books: i64 = env
-            .conn
+            .conn()
             .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
             .unwrap();
         let n_hl: i64 = env
-            .conn
+            .conn()
             .query_row("SELECT COUNT(*) FROM highlights", [], |r| r.get(0))
             .unwrap();
         assert_eq!(n_books, 1);
@@ -675,7 +721,7 @@ mod tests {
     #[test]
     fn empty_shared_dir_is_a_noop() {
         let mut env = setup("self");
-        let report = env.engine.tick(&mut env.conn).unwrap();
+        let report = env.engine.tick(&env.db).unwrap();
         // Self log was created at setup → 1 peer (self).
         assert_eq!(report.peers_seen, 1);
         assert_eq!(report.events_applied, 0);
@@ -688,7 +734,7 @@ mod tests {
         let bad = env.shared.join("logs/peer-X.snapshot.json");
         fs::write(&bad, b"{not valid json").unwrap();
         // Tick must not error; bad file is logged + skipped.
-        let report = env.engine.tick(&mut env.conn).unwrap();
+        let report = env.engine.tick(&env.db).unwrap();
         assert_eq!(report.snapshots_applied, 0);
         assert_eq!(report.events_applied, 0);
     }
@@ -717,12 +763,12 @@ mod tests {
         write_peer_log(&env.shared, "peer-A", &bad);
 
         // Pre-set FK ON so the restore is observable.
-        env.conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
-        let result = env.engine.tick(&mut env.conn);
+        env.conn().execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        let result = env.engine.tick(&env.db);
         assert!(result.is_err(), "malformed metadata event should propagate");
 
         let fk: i64 = env
-            .conn
+            .conn()
             .query_row("PRAGMA foreign_keys", [], |r| r.get(0))
             .unwrap();
         assert_eq!(fk, 1, "FK must be restored to ON even after a tick error");
@@ -740,10 +786,10 @@ mod tests {
         // First tick — empty shared dir, nothing to apply. Self row
         // doesn't exist yet.
         let before = chrono::Utc::now().timestamp_millis();
-        env.engine.tick(&mut env.conn).unwrap();
+        env.engine.tick(&env.db).unwrap();
 
         let row1: Option<i64> = env
-            .conn
+            .conn()
             .query_row(
                 "SELECT updated_at FROM _replay_state WHERE peer_device = 'self'",
                 [],
@@ -756,10 +802,10 @@ mod tests {
         // Sleep a few millis so the second tick's timestamp is
         // visibly newer.
         std::thread::sleep(std::time::Duration::from_millis(5));
-        env.engine.tick(&mut env.conn).unwrap();
+        env.engine.tick(&env.db).unwrap();
 
         let row2: i64 = env
-            .conn
+            .conn()
             .query_row(
                 "SELECT updated_at FROM _replay_state WHERE peer_device = 'self'",
                 [],
@@ -777,7 +823,7 @@ mod tests {
     fn tick_refreshes_own_peer_manifest() {
         let mut env = setup("self");
         let before = chrono::Utc::now().timestamp_millis();
-        env.engine.tick(&mut env.conn).unwrap();
+        env.engine.tick(&env.db).unwrap();
 
         let manifest = peers::manifest_path(&env.shared, "self");
         assert!(manifest.exists(), "tick should publish own peer manifest");
@@ -794,10 +840,10 @@ mod tests {
     #[test]
     fn fk_pragma_restored_after_tick() {
         let mut env = setup("self");
-        env.conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
-        env.engine.tick(&mut env.conn).unwrap();
+        env.conn().execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        env.engine.tick(&env.db).unwrap();
         let fk: i64 = env
-            .conn
+            .conn()
             .query_row("PRAGMA foreign_keys", [], |r| r.get(0))
             .unwrap();
         assert_eq!(fk, 1, "FK should be restored to ON after tick");

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -44,6 +44,17 @@ use super::snapshot::{self, Snapshot};
 /// because every operation is idempotent — but they'd duplicate I/O work.
 static TICK_MUTEX: Mutex<()> = Mutex::new(());
 
+/// Process-wide lock that serializes `flush_outbox` callers so the
+/// outbox drain stays exactly-once. Without it, `SyncWriter::with_tx`'s
+/// background flush worker and a concurrent watcher tick could both
+/// read the same pending row before either deletes it, then each
+/// append the same event to the device log under a fresh ULID — the
+/// peer would apply the event twice. Most merges are idempotent (UUID
+/// dedup, LWW), but some payload shapes are not safe to publish twice,
+/// and even idempotent ones balloon the log. The mutex is entirely
+/// outside `db.conn`, so a flush in flight does not block UI writes.
+static FLUSH_OUTBOX_MUTEX: Mutex<()> = Mutex::new(());
+
 /// What `tick()` did, surfaced for the "Sync now" UI and for tests.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ReplayReport {
@@ -93,33 +104,25 @@ impl ReplayEngine {
         let peers = discover_peers(&self.shared_dir)?;
         let peers_seen = peers.len();
 
-        // Phase 2/3/4 — read peer files, apply in one tx, advance
-        // watermarks. FK off mirrors the merge engine's contract;
-        // orphan rows from out-of-order delivery are tolerated until
-        // parents arrive. The pragma must be restored even if the
-        // merge work errors mid-way, otherwise the shared connection
-        // silently loses FK enforcement for every subsequent command.
-        let (snapshots_applied, events_applied) = {
-            let mut conn = db
+        // Phase 2/3/4 — read peer files (no SQL lock), then apply in
+        // one tx. The disk I/O for snapshots and peer logs lives
+        // inside `apply_in_tx`'s "Phase A" so an iCloud-stalled or
+        // large peer file does not stall any concurrent UI writes
+        // behind the watcher tick. The PRAGMA wrap also lives inside
+        // `apply_in_tx` so any error path still restores FK = ON.
+        let (snapshots_applied, events_applied) = self.apply_in_tx(db, &peers)?;
+
+        // Stamp self's `_replay_state.updated_at` so the settings
+        // UI's "Last sync" reflects every successful tick — not only
+        // the ones that happened to move a peer watermark. A no-op
+        // `sync_now` click (no peer changes, no outbox drain) still
+        // proves the engine is healthy, and the UI deserves to show
+        // that. Upserts a NULL-watermark self row on first call.
+        {
+            let conn = db
                 .conn
                 .lock()
                 .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
-            conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
-            let inner = self.apply_in_tx(&mut conn, &peers);
-            let restore = conn.execute_batch("PRAGMA foreign_keys = ON;");
-            let counts = match (inner, restore) {
-                (Ok(counts), Ok(())) => counts,
-                (Err(e), _) => return Err(e),
-                (Ok(_), Err(e)) => return Err(AppError::Db(e)),
-            };
-
-            // Stamp self's `_replay_state.updated_at` so the settings
-            // UI's "Last sync" reflects every successful tick — not
-            // only the ones that happened to move a peer watermark.
-            // A no-op `sync_now` click (no peer changes, no outbox
-            // drain) still proves the engine is healthy, and the UI
-            // deserves to show that. Upserts a NULL-watermark self
-            // row on first call.
             let now = chrono::Utc::now().timestamp_millis();
             conn.execute(
                 "INSERT INTO _replay_state (peer_device, last_snapshot_id, last_event_id, updated_at)
@@ -127,8 +130,7 @@ impl ReplayEngine {
                  ON CONFLICT(peer_device) DO UPDATE SET updated_at = excluded.updated_at",
                 params![self.self_device, now],
             )?;
-            counts
-        };
+        }
         // db.conn released — heartbeat and compaction below run on
         // iCloud without blocking concurrent UI writes.
 
@@ -169,14 +171,79 @@ impl ReplayEngine {
         })
     }
 
-    /// Inner helper for `tick`: snapshot apply + log-tail merge inside a
-    /// single SQL transaction. Returns `(snapshots_applied, events_applied)`
-    /// counts. Caller is responsible for toggling `PRAGMA foreign_keys`
-    /// around the call so any error here doesn't leak FK = OFF.
+    /// Snapshot apply + log-tail merge.
+    ///
+    /// Split into two phases so the slow disk I/O on the iCloud
+    /// shared folder never runs while holding `db.conn`:
+    ///
+    /// - **Phase A — read** (no SQL lock): deserialize every peer
+    ///   snapshot file and slurp every peer log file from disk.
+    ///   iCloud-evicted or large peer files can stall here without
+    ///   blocking any concurrent UI write.
+    /// - **Phase B — apply** (one tx, conn lock held): apply the
+    ///   pre-loaded snapshots, then the log tails filtered against
+    ///   each peer's (possibly snapshot-bumped) `last_event_id`,
+    ///   then advance the watermarks.
+    ///
+    /// FK off mirrors the merge engine's contract; orphan rows from
+    /// out-of-order delivery are tolerated until parents arrive. The
+    /// PRAGMA wrap is inside this function so any error path still
+    /// restores `foreign_keys = ON` on the shared connection.
     fn apply_in_tx(
         &self,
-        conn: &mut Connection,
+        db: &Db,
         peers: &BTreeMap<String, PeerFiles>,
+    ) -> AppResult<(usize, usize)> {
+        // -- Phase A — read everything from disk. No SQL lock held. --
+        let mut snapshots: Vec<(String, Snapshot)> = Vec::new();
+        for (device, files) in peers {
+            let Some(snap_path) = &files.snap_path else {
+                continue;
+            };
+            match Snapshot::read_from(snap_path) {
+                Ok(s) => snapshots.push((device.clone(), s)),
+                Err(e) => {
+                    eprintln!(
+                        "sync: skipping malformed snapshot {}: {e}",
+                        snap_path.display()
+                    );
+                }
+            }
+        }
+        // Read full log tail; per-peer watermark filter happens in
+        // Phase B against the post-snapshot-apply watermark, so
+        // events the snapshot already covered get dropped there.
+        // Most merges are idempotent (UUID dedup, LWW), but filtering
+        // saves the apply cost.
+        let mut peer_logs: Vec<(String, Vec<Event>)> = Vec::new();
+        for (device, files) in peers {
+            let Some(log_path) = &files.log_path else {
+                continue;
+            };
+            let events = log::read_log_file_after(log_path, None)?;
+            peer_logs.push((device.clone(), events));
+        }
+
+        // -- Phase B — apply under one tx. Conn lock held throughout. --
+        let mut conn = db
+            .conn
+            .lock()
+            .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
+        conn.execute_batch("PRAGMA foreign_keys = OFF;")?;
+        let inner = self.apply_phase_b(&mut conn, &snapshots, &peer_logs);
+        let restore = conn.execute_batch("PRAGMA foreign_keys = ON;");
+        match (inner, restore) {
+            (Ok(counts), Ok(())) => Ok(counts),
+            (Err(e), _) => Err(e),
+            (Ok(_), Err(e)) => Err(AppError::Db(e)),
+        }
+    }
+
+    fn apply_phase_b(
+        &self,
+        conn: &mut Connection,
+        snapshots: &[(String, Snapshot)],
+        peer_logs: &[(String, Vec<Event>)],
     ) -> AppResult<(usize, usize)> {
         let mut snapshots_applied = 0usize;
         let mut events_applied = 0usize;
@@ -189,20 +256,7 @@ impl ReplayEngine {
         //     snapshot moves the watermark forward). Doing them before the
         //     log tails means the per-peer `last_event_id` we read in 3b
         //     reflects any snapshot bump.
-        for (device, files) in peers {
-            let Some(snap_path) = &files.snap_path else {
-                continue;
-            };
-            let snap = match Snapshot::read_from(snap_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!(
-                        "sync: skipping malformed snapshot {}: {e}",
-                        snap_path.display()
-                    );
-                    continue;
-                }
-            };
+        for (device, snap) in snapshots {
             let outcome = snap.apply_peer(&tx, device)?;
             if matches!(
                 outcome,
@@ -213,16 +267,18 @@ impl ReplayEngine {
             }
         }
 
-        // 3b. Read each peer's log tail past its (possibly just-bumped)
-        //     watermark. Collect, sort by `(ts, device)`, apply.
-        let mut all_events: Vec<Event> = Vec::new();
-        for (device, files) in peers {
-            let Some(log_path) = &files.log_path else {
-                continue;
-            };
+        // 3b. Filter each peer's pre-loaded log against its (possibly
+        //     just-bumped) watermark. Collect, sort by `(ts, device)`,
+        //     apply.
+        let mut all_events: Vec<&Event> = Vec::new();
+        for (device, events) in peer_logs {
             let last_id = read_last_event_id(&tx, device)?;
-            let events = log::read_log_file_after(log_path, last_id.as_deref())?;
             for ev in events {
+                if let Some(w) = last_id.as_deref() {
+                    if ev.id.as_str() <= w {
+                        continue;
+                    }
+                }
                 all_events.push(ev);
             }
         }
@@ -266,7 +322,16 @@ impl ReplayEngine {
 /// wait would serialize every UI write behind the watcher's tick, which
 /// is exactly the "import spinner hangs" symptom users hit. Per-row
 /// lock/unlock is cheap relative to the iCloud I/O.
+///
+/// **Single-flight via `FLUSH_OUTBOX_MUTEX`.** Concurrent callers (the
+/// `SyncWriter` background worker + a watcher-driven `tick`) would
+/// otherwise both read the same pending row, both append, and both
+/// delete — duplicating the event in the device log. The mutex sits
+/// outside `db.conn` so a flush in flight does not block UI writes.
 pub fn flush_outbox(db: &Db, log: &EventLog) -> AppResult<usize> {
+    let _guard = FLUSH_OUTBOX_MUTEX
+        .lock()
+        .map_err(|e| AppError::Other(format!("flush outbox mutex poisoned: {e}")))?;
     let pending = {
         let conn = db
             .conn
@@ -502,7 +567,7 @@ mod tests {
 
     #[test]
     fn outbox_drains_into_own_log_and_advances_to_caller() {
-        let mut env = setup("self");
+        let env = setup("self");
         // Seed two outbox rows representing previously-committed SQL writes
         // whose log append failed.
         let body1 = import("b1");
@@ -553,13 +618,57 @@ mod tests {
         assert_eq!(n_books, 2);
     }
 
+    /// Regression for the review finding on PR #209: two callers of
+    /// `flush_outbox` racing on the same outbox row would each read,
+    /// each append, and each delete — duplicating the device-log
+    /// event. With the `FLUSH_OUTBOX_MUTEX` single-flight guard, the
+    /// log must hold exactly one event after concurrent drains.
+    #[test]
+    fn concurrent_flush_outbox_does_not_double_publish() {
+        use std::thread;
+
+        let env = setup("self");
+        let body = import("b1");
+        env.conn()
+            .execute(
+                "INSERT INTO _pending_publish (id, ts, body_json, created_at) VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    uuid::Uuid::new_v4().to_string(),
+                    1000_i64,
+                    serde_json::to_string(&body).unwrap(),
+                    1000_i64,
+                ],
+            )
+            .unwrap();
+
+        let db = env.db.clone();
+        let log = Arc::clone(&env.engine.own_log);
+        let db2 = env.db.clone();
+        let log2 = Arc::clone(&env.engine.own_log);
+
+        // Two concurrent flush attempts. The mutex must serialize
+        // them; the loser sees an empty outbox and is a no-op.
+        let h1 = thread::spawn(move || flush_outbox(&db, &log).unwrap());
+        let h2 = thread::spawn(move || flush_outbox(&db2, &log2).unwrap());
+        let n1 = h1.join().unwrap();
+        let n2 = h2.join().unwrap();
+        assert_eq!(n1 + n2, 1, "exactly one flush wins; the other is a no-op");
+
+        let log_events = env.engine.own_log.read_all().unwrap();
+        assert_eq!(
+            log_events.len(),
+            1,
+            "single-flight guard must prevent duplicate device-log events",
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Peer log discovery + apply
     // -----------------------------------------------------------------------
 
     #[test]
     fn applies_events_from_a_single_peer_log() {
-        let mut env = setup("self");
+        let env = setup("self");
         let peer_events = vec![
             ev(1000, "peer-A", import("b1")),
             ev(
@@ -600,7 +709,7 @@ mod tests {
 
     #[test]
     fn watermark_skips_already_applied_events_on_second_tick() {
-        let mut env = setup("self");
+        let env = setup("self");
         let peer_events = vec![ev(1000, "peer-A", import("b1"))];
         write_peer_log(&env.shared, "peer-A", &peer_events);
 
@@ -636,7 +745,7 @@ mod tests {
 
     #[test]
     fn cross_peer_events_apply_in_global_ts_order() {
-        let mut env = setup("self");
+        let env = setup("self");
         // Two peers write the same book progress at different ts.
         write_peer_log(&env.shared, "peer-A", &[
             ev(1000, "peer-A", import("b1")),
@@ -676,7 +785,7 @@ mod tests {
 
     #[test]
     fn applies_peer_snapshot_then_log_tail() {
-        let mut env = setup("self");
+        let env = setup("self");
         // Build peer-A's snapshot + log split. Snapshot covers b1; the log
         // adds a highlight after the snapshot.
         let snap_events = vec![ev(1000, "peer-A", import("b1"))];
@@ -720,7 +829,7 @@ mod tests {
 
     #[test]
     fn empty_shared_dir_is_a_noop() {
-        let mut env = setup("self");
+        let env = setup("self");
         let report = env.engine.tick(&env.db).unwrap();
         // Self log was created at setup → 1 peer (self).
         assert_eq!(report.peers_seen, 1);
@@ -730,7 +839,7 @@ mod tests {
 
     #[test]
     fn malformed_snapshot_is_skipped_not_fatal() {
-        let mut env = setup("self");
+        let env = setup("self");
         let bad = env.shared.join("logs/peer-X.snapshot.json");
         fs::write(&bad, b"{not valid json").unwrap();
         // Tick must not error; bad file is logged + skipped.
@@ -747,7 +856,7 @@ mod tests {
         // book.metadata.set with a number where a string is expected) and
         // assert the connection's FK pragma is back to ON after tick
         // returns Err.
-        let mut env = setup("self");
+        let env = setup("self");
         let bad = vec![
             ev(1000, "peer-A", import("b1")),
             ev(
@@ -781,7 +890,7 @@ mod tests {
     /// tick is still a successful tick from the user's perspective.
     #[test]
     fn tick_bumps_self_updated_at_even_on_noop() {
-        let mut env = setup("self");
+        let env = setup("self");
 
         // First tick — empty shared dir, nothing to apply. Self row
         // doesn't exist yet.
@@ -821,7 +930,7 @@ mod tests {
 
     #[test]
     fn tick_refreshes_own_peer_manifest() {
-        let mut env = setup("self");
+        let env = setup("self");
         let before = chrono::Utc::now().timestamp_millis();
         env.engine.tick(&env.db).unwrap();
 
@@ -839,7 +948,7 @@ mod tests {
 
     #[test]
     fn fk_pragma_restored_after_tick() {
-        let mut env = setup("self");
+        let env = setup("self");
         env.conn().execute_batch("PRAGMA foreign_keys = ON;").unwrap();
         env.engine.tick(&env.db).unwrap();
         let fk: i64 = env

--- a/src-tauri/src/sync/watcher.rs
+++ b/src-tauri/src/sync/watcher.rs
@@ -169,16 +169,12 @@ fn run_loop(
             return;
         }
 
-        // Tick. We hold the conn lock for the duration; commands will
-        // wait, which is fine — replay batches are typically short.
-        let mut conn = match db.conn.lock() {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("sync watcher: db conn lock poisoned: {e}");
-                continue;
-            }
-        };
-        if let Err(e) = engine.tick(&mut conn) {
+        // Tick. `tick` manages its own `db.conn` locking — it only
+        // holds the mutex while running SQL, releasing it around the
+        // slow iCloud I/O (`flush_outbox`, `write_own_manifest`,
+        // `compact_own_log`). That keeps user-driven commands (e.g.
+        // `import_book`) responsive while a tick is in flight.
+        if let Err(e) = engine.tick(&db) {
             eprintln!("sync watcher: tick failed: {e}");
         }
     }

--- a/src-tauri/src/sync/writer.rs
+++ b/src-tauri/src/sync/writer.rs
@@ -97,6 +97,12 @@ pub struct SyncWriter {
     /// Per-book leading-edge throttle for `book.progress.set`. Key: book
     /// id. Value: unix millis of the most recent event we let through.
     progress_throttle: Mutex<HashMap<String, i64>>,
+    /// Test-only knob: when true, the Phase 2 outbox flush runs inline
+    /// on the caller's thread instead of being dispatched to a
+    /// background worker. Production always leaves this `false` so the
+    /// UI never blocks on `bird` / `NSFileCoordinator`. Tests flip it
+    /// on so they can assert post-commit log state without polling.
+    flush_inline_for_tests: AtomicBool,
 }
 
 impl SyncWriter {
@@ -106,7 +112,16 @@ impl SyncWriter {
             log: Mutex::new(None),
             should_queue: AtomicBool::new(false),
             progress_throttle: Mutex::new(HashMap::new()),
+            flush_inline_for_tests: AtomicBool::new(false),
         }
+    }
+
+    /// Test-only: force `with_tx`'s Phase 2 flush to run inline on the
+    /// caller's thread. Production code never calls this.
+    #[cfg(test)]
+    pub fn set_flush_inline_for_tests(&self, on: bool) {
+        self.flush_inline_for_tests
+            .store(on, Ordering::SeqCst);
     }
 
     pub fn self_device(&self) -> &str {
@@ -222,13 +237,33 @@ impl SyncWriter {
         // (i.e. the engine booted this session). Failures just leave
         // rows in the outbox for the next caller / replay tick to
         // retry.
+        //
+        // Runs on a background thread so the command thread never
+        // blocks on `EventLog::append`. On macOS, `append` wraps the
+        // write in `NSFileCoordinator.coordinateWritingItemAtURL`,
+        // which synchronously waits for Apple's `bird` daemon to
+        // settle on the log file. `bird` can hold the writing
+        // accessor for several seconds after any nearby iCloud
+        // activity (just-copied EPUB, a peer's snapshot landing,
+        // etc.), so a synchronous flush stalls every UI write —
+        // exactly the "import spinner hangs" symptom users reported
+        // on v1.0.x. The row is durable in `_pending_publish` after
+        // commit, and both the watcher tick and the next write's
+        // post-commit flush retry, so dropping this onto a worker
+        // thread loses nothing — only the optimistic "publish before
+        // returning to the UI" timing.
         if let Some(log) = log_snapshot {
-            let mut conn = db
-                .conn
-                .lock()
-                .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
-            if let Err(e) = replay::flush_outbox(&mut conn, &log) {
-                eprintln!("sync: post-commit outbox flush failed: {e}");
+            if self.flush_inline_for_tests.load(Ordering::SeqCst) {
+                if let Err(e) = replay::flush_outbox(db, &log) {
+                    eprintln!("sync: post-commit outbox flush failed: {e}");
+                }
+            } else {
+                let db = db.clone();
+                std::thread::spawn(move || {
+                    if let Err(e) = replay::flush_outbox(&db, &log) {
+                        eprintln!("sync: post-commit outbox flush failed: {e}");
+                    }
+                });
             }
         }
 
@@ -279,6 +314,11 @@ mod tests {
         let log = Arc::new(EventLog::open(&log_path, writer.self_device(), false).unwrap());
         writer.set_should_queue(true);
         writer.set_log(Some(log.clone()));
+        // Tests assert log + outbox state immediately after `with_tx`.
+        // Production runs Phase 2 on a worker thread to keep the UI
+        // off `bird` / `NSFileCoordinator`; force inline here so the
+        // asserts don't race the spawn.
+        writer.set_flush_inline_for_tests(true);
         log
     }
 


### PR DESCRIPTION
## Summary

Fixes \"Importing book…\" spinning forever. Two independent causes both surfacing as the same UI symptom:

1. **\`slugify\` panicked on CJK titles.** \`&slug[..60]\` truncated by *byte* offset, slicing into the middle of a multi-byte UTF-8 char on titles like \`百年孤独(根据马尔克斯指定版本翻译,未做任何增删)\`. Tauri's command runtime swallows the panic, so \`import_book\` never returns.
2. **\`db.conn\` held across iCloud waits.** Both \`SyncWriter::with_tx\` (post-commit) and \`ReplayEngine::tick\` (watcher-driven) held the SQLite mutex across \`EventLog::append\` → \`NSFileCoordinator\` waits on Apple's \`bird\` daemon, serializing every UI write behind the watcher.

Refactor:
- \`slugify\` walks back to the previous \`is_char_boundary\`.
- \`flush_outbox\` and \`ReplayEngine::tick\` take \`&Db\` and manage their own locking; conn lock released around iCloud I/O.
- \`SyncWriter::with_tx\` Phase 2 flush dispatched onto a background thread (test-only inline toggle keeps assertions deterministic).
- Watcher no longer pre-locks \`db.conn\`.

## Test plan

- [x] \`cargo test --lib\` — 216 passed (regression tests for both root causes added).
- [x] Local build of v1.0.1, imported the offending Chinese EPUB → spinner clears immediately.
- [ ] Smoke: import multiple books in quick succession with sync on; spinner doesn't stall behind a watcher tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)