### PR TITLE
fix(epub): fall back to EPUB2 meta-cover hint on EPUB3 packages

### DIFF
--- a/src-tauri/src/epub.rs
+++ b/src-tauri/src/epub.rs
@@ -72,20 +72,28 @@ fn resolve_cover_resource(
     // The crate parses this into a metadata item with property
     // "cover" whose value is the manifest id.
     if let Some(id) = doc.mdata("cover").map(|m| m.value.clone()) {
-        if let Some(resource) = doc.get_resource(&id) {
+        if let Some(resource) = doc.get_resource(&id).filter(is_image_resource) {
             return Some(resource);
         }
     }
 
     // Conventional ids used by various publisher toolchains when
     // neither the EPUB3 property nor the EPUB2 meta hint is present.
+    // Filter on the resource's mime type — `id="cover"` in particular
+    // commonly points at `cover.xhtml` (the cover *page*) rather than
+    // the cover image, and writing XHTML bytes to `<book_id>.jpg`
+    // would render as a broken image in the library.
     for id in ["cover-image", "cover", "ci"] {
-        if let Some(resource) = doc.get_resource(id) {
+        if let Some(resource) = doc.get_resource(id).filter(is_image_resource) {
             return Some(resource);
         }
     }
 
     None
+}
+
+fn is_image_resource(resource: &(Vec<u8>, String)) -> bool {
+    resource.1.starts_with("image/")
 }
 
 pub fn count_chapters(epub_path: &Path) -> AppResult<usize> {

--- a/src-tauri/src/epub.rs
+++ b/src-tauri/src/epub.rs
@@ -37,7 +37,7 @@ pub fn extract_metadata(epub_path: &Path, covers_dir: &Path, book_id: &str) -> A
 }
 
 fn extract_cover(doc: &mut EpubDoc<std::io::BufReader<std::fs::File>>, covers_dir: &Path, book_id: &str) -> Option<String> {
-    let (data, mime) = doc.get_cover()?;
+    let (data, mime) = resolve_cover_resource(doc)?;
 
     let ext = match mime.as_str() {
         "image/png" => "png",
@@ -52,6 +52,40 @@ fn extract_cover(doc: &mut EpubDoc<std::io::BufReader<std::fs::File>>, covers_di
 
     // Return relative path for DB storage
     Some(format!("covers/{}", cover_filename))
+}
+
+/// Resolve the cover image bytes + mime, walking through fallback
+/// strategies. The `epub` crate's `get_cover()` only handles the
+/// EPUB3 `properties="cover-image"` form, so books that declare a
+/// `version="3.0"` package but use the legacy EPUB2 `<meta
+/// name="cover" content="<id>"/>` pointer (common in older trade
+/// publishing pipelines) fall through to `None`. We re-implement the
+/// EPUB2 fallback here, then try a couple of conventional ids.
+fn resolve_cover_resource(
+    doc: &mut EpubDoc<std::io::BufReader<std::fs::File>>,
+) -> Option<(Vec<u8>, String)> {
+    if let Some(found) = doc.get_cover() {
+        return Some(found);
+    }
+
+    // EPUB2-style: `<meta name="cover" content="<manifest-id>"/>`.
+    // The crate parses this into a metadata item with property
+    // "cover" whose value is the manifest id.
+    if let Some(id) = doc.mdata("cover").map(|m| m.value.clone()) {
+        if let Some(resource) = doc.get_resource(&id) {
+            return Some(resource);
+        }
+    }
+
+    // Conventional ids used by various publisher toolchains when
+    // neither the EPUB3 property nor the EPUB2 meta hint is present.
+    for id in ["cover-image", "cover", "ci"] {
+        if let Some(resource) = doc.get_resource(id) {
+            return Some(resource);
+        }
+    }
+
+    None
 }
 
 pub fn count_chapters(epub_path: &Path) -> AppResult<usize> {


### PR DESCRIPTION
## Summary
- Some EPUB 3 packages still declare their cover via the legacy `<meta name="cover" content="<id>"/>` hint instead of the modern `properties="cover-image"` manifest property. The `epub` crate's `get_cover_id()` branches on the declared version and returns `None` for these books, so the imported entry has no thumbnail. Reproduced on *The Gardener and the Carpenter* (Gopnik).
- `src-tauri/src/epub.rs` now wraps cover extraction in a fallback chain: EPUB3 `get_cover()` → EPUB2 `mdata("cover")` → manifest ids (`cover-image`, `cover`, `ci`).

## Test plan
- [x] `cargo clippy -- -D warnings` clean
- [x] Standalone repro on the failing EPUB: `get_cover()` returns `None`; the EPUB2 fallback resolves `mdata("cover") = "cover-image"` and `get_resource("cover-image")` returns 662 KB / `image/jpeg`
- [ ] Re-import *The Gardener and the Carpenter* and confirm the cover thumbnail renders in the library
- [ ] Spot-check a previously working book (any EPUB 3 with `properties="cover-image"`) still extracts via the EPUB3 path

## Recovery for already-imported books
Existing rows with `cover_path = NULL` won't backfill on their own — delete and re-add the affected book to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)