### PR TITLE
ci: cache apt packages for backend job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,28 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      # Tauri 2 on Linux needs webkit2gtk and friends even for `cargo check`
+      # because tauri-runtime-wry links against them. cache-apt-pkgs-action
+      # caches the *installed filesystem* (not just the .debs), so a cache
+      # hit untars in ~3s.
+      #
+      # Raw `apt-get install` takes 5+ min on a cold runner because Azure's
+      # Ubuntu mirror serves the 100+ transitive deps slowly with occasional
+      # 60s `Ign:` retries — that was the previous behavior here, and it
+      # consistently hit the 5-min wall on backend CI.
+      #
+      # `timeout-minutes` bounds the cold path so a stalled install fails
+      # fast instead of hanging the job; rerun to retry. Bump `version`
+      # when the package list changes to invalidate the cache.
+      - name: Install system dependencies (cached)
+        # Pinned to v1.6.0 (2025-10-15) — `@v1` moves to v1.5.3 which has
+        # had cache-restore flakes; v1.6.0 picks up the "ls error when no
+        # tar files exist in cache restore" fix plus a few other patches.
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        timeout-minutes: 5
+        with:
+          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          version: 1.0
       - run: cargo clippy -- -D warnings
       - run: cargo check
       - run: cargo test --lib


### PR DESCRIPTION
## Summary
- Switch backend job's apt install from raw `sudo apt-get install` to `awalsh128/cache-apt-pkgs-action@v1.6.0` (caches the installed filesystem; cache hit untars in ~3s instead of 5+ min).
- Add `timeout-minutes: 5` so a stalled cold install fails fast instead of pinning the job.
- Same approach the runner repo already uses for the same Tauri-on-Linux deps.

## Why
The `Install system dependencies` step has been the dominant cost on backend CI — most recent runs sit on it 5+ min because Azure's Ubuntu mirror serves the 100+ transitive deps of `libwebkit2gtk-4.1-dev` slowly with intermittent retries. PR #217's backend job got stuck here for almost the entire duration before passing/failing. This change makes the warm path effectively free.

## Test plan
- [ ] First run after merge: cold cache, expect ~5 min on "Install system dependencies (cached)" (same as before, but bounded).
- [ ] Second run: cache hit, expect ~3s on that step.
- [ ] If the package list changes later: bump `version: 1.0` to invalidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)