### PR TITLE
fix(vocab): persist in-context analysis as its own column (#214)

### DIFF
--- a/src-tauri/migrations/012_vocab_context_explanation.sql
+++ b/src-tauri/migrations/012_vocab_context_explanation.sql
@@ -1,0 +1,12 @@
+-- Migration 012 — split the AI's in-context analysis off `vocab_words.definition`.
+--
+-- The lookup popover used to persist `definition + "\n\n" + context_explanation`
+-- as a single TEXT blob and the detail modal split it back on `\n\n+`. Any
+-- paragraph break inside the definition stream (translation prefix, multi-
+-- paragraph definition, markdown list) corrupted the split — see #214.
+--
+-- New rows write the in-context analysis to its own column. Legacy rows keep
+-- NULL here; the modal renders their whole blob in the Definition region and
+-- hides the In Context sub-card. No backfill — regex-splitting the old blobs
+-- is the bug we're moving away from.
+ALTER TABLE vocab_words ADD COLUMN context_explanation TEXT;

--- a/src-tauri/src/commands/vocab.rs
+++ b/src-tauri/src/commands/vocab.rs
@@ -14,6 +14,7 @@ pub struct VocabWord {
     pub word: String,
     pub definition: String,
     pub context_sentence: Option<String>,
+    pub context_explanation: Option<String>,
     pub cfi: Option<String>,
     pub mastery: String,
     pub review_count: i64,
@@ -46,6 +47,7 @@ fn row_to_vocab(row: &rusqlite::Row) -> rusqlite::Result<VocabWord> {
         next_review_at: row.get(8)?,
         created_at: row.get(9)?,
         updated_at: row.get(10)?,
+        context_explanation: row.get(11)?,
         book_title: None,
     })
 }
@@ -63,18 +65,21 @@ fn row_to_vocab_with_book(row: &rusqlite::Row) -> rusqlite::Result<VocabWord> {
         next_review_at: row.get(8)?,
         created_at: row.get(9)?,
         updated_at: row.get(10)?,
-        book_title: row.get(11)?,
+        context_explanation: row.get(11)?,
+        book_title: row.get(12)?,
     })
 }
 
-const SELECT_COLS: &str = "id, book_id, word, definition, context_sentence, cfi, mastery, review_count, next_review_at, created_at, updated_at";
+const SELECT_COLS: &str = "id, book_id, word, definition, context_sentence, cfi, mastery, review_count, next_review_at, created_at, updated_at, context_explanation";
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub fn add_vocab_word(
     book_id: String,
     word: String,
     definition: String,
     context_sentence: Option<String>,
+    context_explanation: Option<String>,
     cfi: Option<String>,
     db: State<'_, Db>,
     sync: State<'_, SyncWriter>,
@@ -108,9 +113,9 @@ pub fn add_vocab_word(
         }
 
         tx.execute(
-            "INSERT INTO vocab_words (id, book_id, word, definition, context_sentence, cfi, mastery, review_count, next_review_at, created_at, updated_at, updated_by_device)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'new', 0, NULL, ?7, ?7, ?8)",
-            params![id, book_id, word, definition, context_sentence, cfi, now, device],
+            "INSERT INTO vocab_words (id, book_id, word, definition, context_sentence, context_explanation, cfi, mastery, review_count, next_review_at, created_at, updated_at, updated_by_device)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'new', 0, NULL, ?8, ?8, ?9)",
+            params![id, book_id, word, definition, context_sentence, context_explanation, cfi, now, device],
         )?;
         events.push(EventBody::VocabAdd(VocabPayload {
             id: id.clone(),
@@ -118,6 +123,7 @@ pub fn add_vocab_word(
             word: word.clone(),
             definition: definition.clone(),
             context_sentence: context_sentence.clone(),
+            context_explanation: context_explanation.clone(),
             cfi: cfi.clone(),
             mastery: "new".to_string(),
             review_count: 0,
@@ -129,6 +135,7 @@ pub fn add_vocab_word(
             word: word.clone(),
             definition: definition.clone(),
             context_sentence: context_sentence.clone(),
+            context_explanation: context_explanation.clone(),
             cfi: cfi.clone(),
             mastery: "new".to_string(),
             review_count: 0,
@@ -190,7 +197,7 @@ pub fn check_vocab_exists(
 pub fn list_all_vocab_words(db: State<'_, Db>) -> AppResult<Vec<VocabWord>> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     let mut stmt = conn.prepare(
-        "SELECT v.id, v.book_id, v.word, v.definition, v.context_sentence, v.cfi, v.mastery, v.review_count, v.next_review_at, v.created_at, v.updated_at, b.title FROM vocab_words v LEFT JOIN books b ON v.book_id = b.id ORDER BY v.created_at DESC"
+        "SELECT v.id, v.book_id, v.word, v.definition, v.context_sentence, v.cfi, v.mastery, v.review_count, v.next_review_at, v.created_at, v.updated_at, v.context_explanation, b.title FROM vocab_words v LEFT JOIN books b ON v.book_id = b.id ORDER BY v.created_at DESC"
     )?;
     let words = stmt
         .query_map([], row_to_vocab_with_book)?

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -17,6 +17,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (9, include_str!("../migrations/009_normalize_timestamps.sql")),
     (10, include_str!("../migrations/010_replay_state.sql")),
     (11, include_str!("../migrations/011_lww_tiebreak_and_outbox.sql")),
+    (12, include_str!("../migrations/012_vocab_context_explanation.sql")),
 ];
 
 /// SQLite handle for the local materialized view.
@@ -247,7 +248,7 @@ mod tests {
         let conn = db.conn.lock().unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 11);
+        assert_eq!(version, 12);
     }
 
     #[test]
@@ -283,7 +284,7 @@ mod tests {
         Db::run_migrations_on(&conn).unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 11);
+        assert_eq!(version, 12);
     }
 
     #[test]

--- a/src-tauri/src/sync/events.rs
+++ b/src-tauri/src/sync/events.rs
@@ -170,6 +170,12 @@ pub struct VocabPayload {
     pub mastery: String,
     pub review_count: i64,
     pub next_review_at: Option<i64>,
+    // Added in #214: AI's in-context analysis, persisted separately from the
+    // dictionary-style definition. `default` lets older-client payloads decode;
+    // `skip_serializing_if` keeps the wire form compact for senders that never
+    // populate it (legacy rows, iOS clients pre-update).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_explanation: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -288,6 +294,7 @@ mod tests {
             mastery: "new".into(),
             review_count: 0,
             next_review_at: Some(1_714_856_400_000),
+            context_explanation: Some("Used to mean an unexpectedly happy turn.".into()),
         })));
         roundtrip(&mk(EventBody::VocabMasterySet {
             id: "v1".into(),
@@ -296,6 +303,40 @@ mod tests {
             review_count: 3,
         }));
         roundtrip(&mk(EventBody::VocabDelete { id: "v1".into() }));
+    }
+
+    #[test]
+    fn vocab_payload_decodes_without_context_explanation() {
+        // Older clients (pre-#214) emit payloads without this field. Make sure
+        // they decode and re-serialize without injecting a null key.
+        let src = json!({
+            "id": "01HYZX0000000000000000EVT1",
+            "ts": 1_714_770_000_000_i64,
+            "device": "dev-a",
+            "v": 1,
+            "type": "vocab.add",
+            "payload": {
+                "id": "v1",
+                "book_id": "b1",
+                "word": "serendipity",
+                "definition": "a fortunate accident",
+                "context_sentence": null,
+                "cfi": null,
+                "mastery": "new",
+                "review_count": 0,
+                "next_review_at": null
+            }
+        });
+        let ev: Event = serde_json::from_value(src).unwrap();
+        let EventBody::VocabAdd(p) = &ev.body else {
+            panic!("expected VocabAdd");
+        };
+        assert_eq!(p.context_explanation, None);
+        let wire: Value = serde_json::to_value(&ev).unwrap();
+        assert!(
+            wire["payload"].get("context_explanation").is_none(),
+            "context_explanation should be omitted when None: {wire}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sync/merge.rs
+++ b/src-tauri/src/sync/merge.rs
@@ -497,16 +497,17 @@ fn apply_vocab_add(tx: &Transaction, event: &Event, p: &VocabPayload) -> AppResu
     }
     tx.execute(
         "INSERT OR IGNORE INTO vocab_words
-         (id, book_id, word, definition, context_sentence, cfi,
+         (id, book_id, word, definition, context_sentence, context_explanation, cfi,
           mastery, review_count, next_review_at,
           created_at, updated_at, updated_by_device)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10, ?11)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?11, ?12)",
         params![
             p.id,
             p.book_id,
             p.word,
             p.definition,
             p.context_sentence,
+            p.context_explanation,
             p.cfi,
             p.mastery,
             p.review_count,
@@ -1120,6 +1121,7 @@ mod tests {
                         word: "serendipity".into(),
                         definition: "fortunate".into(),
                         context_sentence: None,
+                        context_explanation: None,
                         cfi: None,
                         mastery: "new".into(),
                         review_count: 0,

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -136,6 +136,8 @@ pub struct VocabRow {
     pub word: String,
     pub definition: String,
     pub context_sentence: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_explanation: Option<String>,
     pub cfi: Option<String>,
     pub mastery: String,
     pub review_count: i64,
@@ -721,10 +723,10 @@ fn insert_bookmark(tx: &Transaction, id: &str, r: &BookmarkRow) -> AppResult<()>
 fn upsert_vocab(tx: &Transaction, id: &str, r: &VocabRow) -> AppResult<()> {
     tx.execute(
         "INSERT INTO vocab_words
-         (id, book_id, word, definition, context_sentence, cfi,
+         (id, book_id, word, definition, context_sentence, context_explanation, cfi,
           mastery, review_count, next_review_at,
           created_at, updated_at, updated_by_device)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
          ON CONFLICT(id) DO UPDATE SET
            mastery=excluded.mastery,
            review_count=excluded.review_count,
@@ -734,7 +736,7 @@ fn upsert_vocab(tx: &Transaction, id: &str, r: &VocabRow) -> AppResult<()> {
          WHERE (vocab_words.updated_at, vocab_words.updated_by_device)
              < (excluded.updated_at, excluded.updated_by_device)",
         params![
-            id, r.book_id, r.word, r.definition, r.context_sentence, r.cfi,
+            id, r.book_id, r.word, r.definition, r.context_sentence, r.context_explanation, r.cfi,
             r.mastery, r.review_count, r.next_review_at,
             r.created_at, r.updated_at, r.updated_by_device,
         ],
@@ -933,7 +935,7 @@ fn dump_state(conn: &Connection) -> AppResult<SnapshotState> {
     let mut stmt = conn.prepare(
         "SELECT id, book_id, word, definition, context_sentence, cfi,
                 mastery, review_count, next_review_at,
-                created_at, updated_at, updated_by_device FROM vocab_words",
+                created_at, updated_at, updated_by_device, context_explanation FROM vocab_words",
     )?;
     let rows = stmt.query_map([], |r| {
         Ok((
@@ -950,6 +952,7 @@ fn dump_state(conn: &Connection) -> AppResult<SnapshotState> {
                 created_at: r.get(9)?,
                 updated_at: r.get(10)?,
                 updated_by_device: r.get(11)?,
+                context_explanation: r.get(12)?,
             },
         ))
     })?;

--- a/src/components/DictionaryPanel.tsx
+++ b/src/components/DictionaryPanel.tsx
@@ -8,6 +8,7 @@ import VocabDetailModal from "./VocabDetailModal";
 
 interface DictionaryPanelProps {
   bookId: string;
+  bookTitle?: string;
   initialTab?: "dictionary" | "translations";
   onNavigate?: (cfi: string) => void;
   getPageFromCfi?: (cfi: string) => number | null;
@@ -15,7 +16,7 @@ interface DictionaryPanelProps {
 
 type Tab = "dictionary" | "translations";
 
-export default function DictionaryPanel({ bookId, initialTab = "dictionary", onNavigate, getPageFromCfi }: DictionaryPanelProps) {
+export default function DictionaryPanel({ bookId, bookTitle, initialTab = "dictionary", onNavigate, getPageFromCfi }: DictionaryPanelProps) {
   const { t } = useTranslation();
   const [tab, setTab] = useState<Tab>(initialTab);
   const [dictSearch, setDictSearch] = useState("");
@@ -261,6 +262,7 @@ export default function DictionaryPanel({ bookId, initialTab = "dictionary", onN
 
       <VocabDetailModal
         word={activeWord}
+        bookTitle={bookTitle}
         onClose={() => setActiveWord(null)}
         onDelete={async (id) => {
           await removeWord(id);

--- a/src/components/LookupPopover.tsx
+++ b/src/components/LookupPopover.tsx
@@ -5,11 +5,7 @@ import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { X, Loader2, Sparkles, BookmarkPlus, Check, Copy, Settings } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
-
-// Shared prose classes for lookup markdown rendering — tight spacing for the
-// 13px popover body so bullets/paragraphs don't blow out the card height.
-const LOOKUP_PROSE =
-  "prose prose-sm max-w-none leading-[1.55] [&_p]:my-0 [&_p+p]:mt-1.5 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0 [&_strong]:font-semibold [&_em]:italic [&_code]:bg-bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-[12px]";
+import { LOOKUP_PROSE } from "./lookup-prose";
 
 interface LookupPopoverProps {
   x: number;
@@ -166,14 +162,12 @@ export default function LookupPopover({
 
   const handleSave = async () => {
     try {
-      const fullDefinition = [definition.contentRef.current, context.contentRef.current]
-        .filter(Boolean)
-        .join("\n\n");
       await invoke("add_vocab_word", {
         bookId,
         word,
-        definition: fullDefinition,
+        definition: definition.contentRef.current ?? "",
         contextSentence: sentence || null,
+        contextExplanation: context.contentRef.current || null,
         cfi: cfi || null,
       });
       setSaved(true);

--- a/src/components/VocabDetailModal.tsx
+++ b/src/components/VocabDetailModal.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ArrowRight, BookOpen, Trash2, X } from "lucide-react";
+import Markdown from "react-markdown";
 import type { DictionaryWord } from "../hooks/useDictionary";
 import { openReaderWindow } from "../utils/openReaderWindow";
+import { LOOKUP_PROSE } from "./lookup-prose";
 
 interface VocabDetailModalProps {
   word: DictionaryWord | null;
@@ -16,33 +18,43 @@ interface VocabDetailModalProps {
    */
   navigateMode?: "window" | "inline";
   onNavigateInline?: (cfi: string) => void;
+  /**
+   * Authoritative book title for the Source row. `list_vocab_words` (the
+   * per-book query DictionaryPanel uses) doesn't JOIN the title, so callers
+   * that already have it in hand (the Reader) should pass it here. Falls
+   * back to `word.book_title` (populated by `list_all_vocab_words`) and
+   * then the unknown-book string.
+   */
+  bookTitle?: string;
 }
 
 interface ParsedDefinition {
   pronunciation: string | null;
   partOfSpeech: string | null;
   definition: string;
-  inContext: string | null;
 }
 
+// Pulls the leading /.../ phonetic + optional "noun."/"verb."/etc. off the
+// first paragraph so they can render in the subtitle. Everything else — the
+// rest of the first paragraph plus all following paragraphs — stays in the
+// Definition region verbatim. Legacy rows saved before #214 had the in-context
+// blurb concatenated into `definition` with a `\n\n` separator; we now keep
+// that blob whole here (the In Context sub-card reads from
+// `word.context_explanation` instead).
 function parseDefinition(raw: string): ParsedDefinition {
-  const [head, ...rest] = raw.split(/\n\n+/);
-  const inContext = rest.join("\n\n").trim() || null;
-  // Match leading /.../ phonetic + optional "noun."/"verb."/etc prefix
+  const breakIdx = raw.search(/\n\n+/);
+  const head = breakIdx === -1 ? raw : raw.slice(0, breakIdx);
+  const tail = breakIdx === -1 ? "" : raw.slice(breakIdx).replace(/^\n+/, "");
   const match = head.match(/^\s*(\/[^/]+\/)\s*(?:(\w+)\.)?\s*([\s\S]*)$/);
-  if (!match) {
-    return {
-      pronunciation: null,
-      partOfSpeech: null,
-      definition: head.trim(),
-      inContext,
-    };
-  }
+  const headRemainder = (match ? match[3] ?? "" : head).trim();
+  const definition =
+    headRemainder && tail
+      ? `${headRemainder}\n\n${tail}`
+      : headRemainder || tail;
   return {
-    pronunciation: match[1] ?? null,
-    partOfSpeech: match[2] ?? null,
-    definition: (match[3] ?? "").trim(),
-    inContext,
+    pronunciation: match?.[1] ?? null,
+    partOfSpeech: match?.[2] ?? null,
+    definition,
   };
 }
 
@@ -52,6 +64,7 @@ export default function VocabDetailModal({
   onDelete,
   navigateMode = "window",
   onNavigateInline,
+  bookTitle,
 }: VocabDetailModalProps) {
   const { t } = useTranslation();
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -91,6 +104,7 @@ export default function VocabDetailModal({
     .filter(Boolean)
     .join(" · ");
   const contextSentence = word.context_sentence?.trim() || null;
+  const contextExplanation = word.context_explanation?.trim() || null;
 
   const handleOpen = () => {
     if (navigateMode === "inline") {
@@ -160,7 +174,7 @@ export default function VocabDetailModal({
                 </div>
                 <div className="flex flex-col min-w-0">
                   <span className="text-[14px] font-semibold text-text-primary truncate">
-                    {word.book_title || t("vocab.detail.unknownBook")}
+                    {bookTitle ?? word.book_title ?? t("vocab.detail.unknownBook")}
                   </span>
                 </div>
               </div>
@@ -179,17 +193,17 @@ export default function VocabDetailModal({
             <h3 className="text-[11px] font-semibold uppercase tracking-[0.4px] text-text-muted">
               {t("vocab.detail.definition")}
             </h3>
-            <p className="text-[14px] leading-[1.55] text-text-primary whitespace-pre-wrap">
-              {parsed.definition}
-            </p>
-            {parsed.inContext && (
-              <div className="mt-1 p-3.5 bg-bg-muted border border-border-light rounded-[10px] flex flex-col gap-1.5">
+            <div className={`${LOOKUP_PROSE} text-[14px] text-text-primary`}>
+              <Markdown>{parsed.definition}</Markdown>
+            </div>
+            {contextExplanation && (
+              <div className="mt-1 p-3 rounded-lg bg-bg-muted border border-border/50 flex flex-col gap-1.5">
                 <span className="text-[12px] font-medium text-text-muted">
                   {t("vocab.detail.inContext")}
                 </span>
-                <p className="text-[13px] leading-[1.5] text-text-secondary whitespace-pre-wrap">
-                  {parsed.inContext}
-                </p>
+                <div className={`${LOOKUP_PROSE} text-[13px] text-text-secondary`}>
+                  <Markdown>{contextExplanation}</Markdown>
+                </div>
               </div>
             )}
           </section>

--- a/src/components/lookup-prose.ts
+++ b/src/components/lookup-prose.ts
@@ -1,0 +1,6 @@
+// Shared Tailwind prose classes for the lookup surfaces (popover + vocab
+// detail modal). Tight spacing tuned for the 13–14px body so bullets and
+// adjacent paragraphs don't blow out the card height. Compose with a
+// `text-[NNpx]` and a text color class at the call site.
+export const LOOKUP_PROSE =
+  "prose prose-sm max-w-none leading-[1.55] [&_p]:my-0 [&_p+p]:mt-1.5 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0 [&_strong]:font-semibold [&_em]:italic [&_code]:bg-bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-[12px]";

--- a/src/hooks/useDictionary.ts
+++ b/src/hooks/useDictionary.ts
@@ -7,6 +7,7 @@ export interface DictionaryWord {
   word: string;
   definition: string;
   context_sentence: string | null;
+  context_explanation: string | null;
   cfi: string | null;
   mastery: string;
   review_count: number;
@@ -37,13 +38,15 @@ export function useDictionary(bookId: string) {
       word: string,
       definition: string,
       contextSentence?: string,
-      cfi?: string
+      cfi?: string,
+      contextExplanation?: string
     ) => {
       const dictionaryWord = await invoke<DictionaryWord>("add_vocab_word", {
         bookId,
         word,
         definition,
         contextSentence: contextSentence || null,
+        contextExplanation: contextExplanation || null,
         cfi: cfi || null,
       });
       setWords((prev) => [dictionaryWord, ...prev]);

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -1364,6 +1364,7 @@ export default function Reader() {
           {sidePanel === "vocab" && bookId && (
             <DictionaryPanel
               bookId={bookId}
+              bookTitle={book.title}
               onNavigate={(cfi) => {
                 viewRef.current?.goTo(cfi).then(() => {
                   viewRef.current?.addAnnotation({ value: cfi, color: "#c27aff" });


### PR DESCRIPTION
## Summary
- Adds a `vocab_words.context_explanation` column (migration 012) and threads it through the vocab command, sync events/payload, snapshot, and merge engine. New rows write the AI's in-context analysis to its own field instead of joining it onto `definition` with `\n\n` and splitting back at read time — the lossy split was breaking definitions that contained any paragraph break.
- Modal styling parity with the lookup popover: extracted `LOOKUP_PROSE` to a shared module, switched Definition + In Context regions to `<Markdown>` rendering, matched the popover's card visuals (`rounded-lg`, `border-border/50`).
- Adds an optional `bookTitle` prop to `VocabDetailModal` so the reader's side-panel (which uses the per-book `list_vocab_words` query that doesn't JOIN the title) can override the Source row instead of showing "Unknown book".

Closes #214.

Legacy rows (NULL `context_explanation`) render the whole blob in the Definition region with no In Context sub-card — accepted regression since regex-splitting the old data is the bug we're moving away from.

## Test plan
- [x] `cargo check` clean
- [x] `cargo test --lib` 218/218 (incl. new `vocab_payload_decodes_without_context_explanation` backwards-compat test)
- [x] `pnpm tsc --noEmit` clean
- [ ] Save a new word in the reader, restart, open from Lookups tab — confirm Definition shows full dictionary entry and only the in-context analysis lands in the In Context card
- [ ] Open vocab side-panel inside the reader — Source row shows real book title

🤖 Generated with [Claude Code](https://claude.com/claude-code)