### PR TITLE
chore: release v1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quill",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "1.0.3"
+version = "1.0.4"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quill",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "identifier": "com.wycstudios.quill",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to v1.0.4.

Includes the vocab definition/context split fix (#214 via #219) — the AI's in-context analysis is now persisted as its own column instead of being concatenated onto the definition blob, so the vocab detail modal no longer bleeds definition text into the In Context card. Also covers the PDF metadata-extraction timeout (#216) and CI cache improvements (#218) that landed on main since v1.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)