### PR TITLE
fix: route pdf.js through workerPort to unblock PDF import on macOS 14.x

### DIFF
--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -53,10 +53,7 @@ async function pickFile(): Promise<string | null> {
   });
 }
 
-async function importFile(
-  filePath: string,
-  onMetadataWarning?: (warning: string) => void,
-): Promise<Book> {
+async function importFile(filePath: string): Promise<Book> {
   if (!filePath.toLowerCase().endsWith(".pdf")) {
     return invoke<Book>("import_book", { filePath });
   }
@@ -88,11 +85,10 @@ async function importFile(
     } catch (err) {
       // Metadata extraction failed (PDF.js error, missing CMaps, malformed
       // PDF, etc.). Don't block the import — fall back to filename-based
-      // metadata so the user still gets their book. Surface the diagnostic
-      // via onMetadataWarning so we can debug what actually broke.
-      const message = err instanceof Error ? err.message : String(err);
+      // metadata so the user still gets their book. Console-only; the user
+      // can't act on this and the import still succeeds, so surfacing a
+      // toast reads as an error (#222).
       console.warn("PDF metadata extraction failed, importing with filename only:", err);
-      onMetadataWarning?.(message);
       meta = {
         title: filenameToTitle(filePath),
         author: null,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -30,7 +30,6 @@
   "home.importing": "Importing book...",
   "home.importingSlow": "Still working—this file is taking longer than usual",
   "home.importError": "Couldn't import book",
-  "home.importWarning": "Imported with limited metadata",
 
   "reader.pageOf": "Page {{current}} of {{total}}",
   "reader.chapterOf": "Chapter {{current}} of {{total}}",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -30,7 +30,6 @@
   "home.importing": "正在导入书籍...",
   "home.importingSlow": "仍在处理，这个文件比平常慢一些",
   "home.importError": "无法导入书籍",
-  "home.importWarning": "已导入，但元数据不完整",
 
   "reader.pageOf": "第 {{current}} 页，共 {{total}} 页",
   "reader.chapterOf": "第 {{current}} 章，共 {{total}} 章",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Search, LayoutGrid, List, Plus, Upload, BookOpen, Loader, AlertCircle, AlertTriangle, X } from "lucide-react";
+import { Search, LayoutGrid, List, Plus, Upload, BookOpen, Loader, AlertCircle, X } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -35,7 +35,6 @@ export default function Home() {
   const [importing, setImporting] = useState(false);
   const [importSlow, setImportSlow] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
-  const [importWarning, setImportWarning] = useState<string | null>(null);
   const [icloudSyncing, setIcloudSyncing] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<"general" | "reading" | "ai" | "lookup" | "librarySync" | "about">("general");
@@ -166,7 +165,7 @@ export default function Home() {
           try {
             for (const filePath of books) {
               try {
-                await importBookDialog.importFile(filePath, setImportWarning);
+                await importBookDialog.importFile(filePath);
               } catch (err) {
                 console.error("Failed to import dropped book:", err);
                 setImportError(`${filePath.split("/").pop()}: ${formatError(err)}`);
@@ -223,7 +222,7 @@ export default function Home() {
       if (!selected) return;
       setImporting(true);
       try {
-        const book = await importBookDialog.importFile(selected, setImportWarning);
+        const book = await importBookDialog.importFile(selected);
         if (book) {
           refresh();
           allBooks.refresh();
@@ -385,26 +384,6 @@ export default function Home() {
           </div>
           <button
             onClick={() => setImportError(null)}
-            className="shrink-0 size-6 flex items-center justify-center rounded-lg hover:bg-bg-input cursor-pointer transition-colors"
-          >
-            <X size={14} className="text-text-muted" />
-          </button>
-        </div>
-      )}
-
-      {importWarning && (
-        <div className="fixed top-20 left-1/2 -translate-x-1/2 z-[60] max-w-[600px] bg-white dark:bg-bg-surface border border-border rounded-[14px] shadow-popover flex items-start gap-3 pl-4 pr-3 py-3">
-          <AlertTriangle size={16} className="shrink-0 mt-0.5 text-amber-500" />
-          <div className="flex-1 min-w-0">
-            <p className="text-[13px] font-medium text-text-primary tracking-[-0.08px]">
-              {t("home.importWarning")}
-            </p>
-            <p className="text-[12px] text-text-secondary mt-0.5 break-words">
-              {importWarning}
-            </p>
-          </div>
-          <button
-            onClick={() => setImportWarning(null)}
             className="shrink-0 size-6 flex items-center justify-center rounded-lg hover:bg-bg-input cursor-pointer transition-colors"
           >
             <X size={14} className="text-text-muted" />

--- a/src/utils/pdfMetadata.ts
+++ b/src/utils/pdfMetadata.ts
@@ -8,12 +8,14 @@ export interface PdfMetadata {
   coverData: Uint8Array | null;
 }
 
-// 10s is well above the 1–5s a normal PDF takes; past it we assume pdf.js
-// is stuck (specific PDFs and some WebKit versions silently hang inside
-// loadingTask.promise — macOS 14.8 reports confirm this isn't just <14.4).
-// Past ~10s the user has already concluded the app is broken; the
-// filename-only fallback gives them a working book faster than waiting longer.
-const PDF_METADATA_TIMEOUT_MS = 10_000;
+// 5s backstop. The primary stall mode (#222) is fixed by passing a
+// self-constructed Worker via `workerPort` below — pdf.js's own
+// `_isSameOrigin`/`_createCDNWrapper` path sees `tauri://localhost`'s
+// opaque origin as "null", wraps the worker in a blob that re-imports the
+// tauri:// URL, and that pattern stalls silently inside macOS 14.x
+// WKWebView. With `workerPort` we skip that whole path; the timeout is
+// only a safety net for genuinely slow PDFs / unrelated stalls.
+const PDF_METADATA_TIMEOUT_MS = 5_000;
 
 /**
  * Extract metadata from a PDF file by importing pdf.mjs directly.
@@ -37,6 +39,9 @@ export async function extractPdfMetadata(filePath: string): Promise<PdfMetadata>
   // untyped dynamic import.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let loadingTask: any = null;
+  // pdf.js doesn't terminate Workers it receives via `workerPort` (only ones
+  // it constructs itself), so we own this Worker's lifecycle end-to-end.
+  let worker: Worker | undefined;
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
@@ -70,8 +75,12 @@ export async function extractPdfMetadata(filePath: string): Promise<PdfMetadata>
       "/foliate-js/vendor/pdfjs/pdf.worker.mjs",
       window.location.origin,
     ).href;
+    // See PDF_METADATA_TIMEOUT_MS comment for why we bypass `workerSrc`.
+    // A self-constructed module Worker routes through pdf.js's
+    // `#initializeFromPort` and skips `_createCDNWrapper`'s blob shim.
+    worker = new Worker(workerUrl, { type: "module" });
     if (pdfjs.GlobalWorkerOptions) {
-      pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
+      pdfjs.GlobalWorkerOptions.workerPort = worker;
     }
 
     step = "getDocument lookup";
@@ -181,6 +190,11 @@ export async function extractPdfMetadata(filePath: string): Promise<PdfMetadata>
     throw new Error(`PDF metadata failed at "${step}": ${message}${stackSnippet}`);
   } finally {
     if (timeoutId !== null) clearTimeout(timeoutId);
+    // pdf.js skips terminating ports it didn't construct (pdf.mjs:15378-15386
+    // — `#webWorker` is only set in the self-construct path), so terminate
+    // here. Safe to call after a successful pdf.destroy() too — terminating
+    // an already-shut-down worker is a no-op.
+    worker?.terminate();
   }
 }
 


### PR DESCRIPTION
Closes #222.

## Root cause

pdf.js's `_isSameOrigin` (vendored `pdf.mjs:15228-15235`) returns `false` when `URL.parse(location).origin` is the string `"null"` — which is the URL-spec behavior for any non-special scheme. In production, Quill runs at `tauri://localhost`, so the origin check fails even when the worker URL is same-origin.

That sends pdf.js into `_createCDNWrapper` (`pdf.mjs:15236-15241`), which spawns a module Worker from a blob: URL containing `await import("tauri://...")`. **macOS 14.x WKWebView stalls silently on that pattern** — the Worker's `error` event sometimes never fires, so pdf.js's fake-worker fallback never engages, and `getDocument().promise` never settles. The 10s timeout from #217 catches it, but the UX is bad and metadata is lost.

This is not the `Promise.withResolvers` problem from #216 — that's a different 14.x WKWebView bug. macOS 15+ / Chromium handles the blob-worker pattern fine, which is why this hits some users and not others.

## Fix

Construct the Worker on the main thread and pass it via `GlobalWorkerOptions.workerPort`. pdf.js's `#initializeFromPort` (`pdf.mjs:15283-15288`) skips `_isSameOrigin` / `_createCDNWrapper` entirely — same-origin module Workers work fine under `tauri://` because the source is loaded directly, not via blob+import.

Applied in both code paths:
- `src/utils/pdfMetadata.ts` (metadata extraction at import time)
- `public/foliate-js/pdf.js` (reader at open time) — bumped to [yicheng47/foliate-js@a301e1e](https://github.com/yicheng47/foliate-js/commit/a301e1e)

Without the foliate-js bump, 14.x users would still hang when opening an imported PDF.

## Also in this PR

- **Drop the warning toast.** The filename-only fallback succeeds and the user can't act on it, so the toast just read as an error (per #222). Console-only now.
- **Drop timeout from 10s → 5s.** With the root cause fixed, the timeout is only a backstop for genuinely slow PDFs.
- **Worker lifecycle.** pdf.js's `PDFWorker.destroy` only terminates Workers it constructed itself, so both call sites now terminate the Worker explicitly on completion.

## Test plan

- [ ] Import a normal PDF on macOS 15+ — succeeds with metadata + cover (no regression).
- [ ] Import an EPUB — unchanged (skips this code path entirely).
- [ ] Import a PDF on macOS 14.x (or 14.8 field-report user) — succeeds with metadata + cover, no 10s wait, no warning toast.
- [ ] Open an imported PDF on macOS 14.x — reader loads (foliate-js fix).
- [ ] Verify the loading spinner clears in every case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)