### PR TITLE
chore: release v1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quill",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "1.0.4"
+version = "1.0.5"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quill",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "identifier": "com.wycstudios.quill",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
v1.0.5 release.

## Highlights

- **PDF import no longer hangs 10s on macOS 14.x** (#222, #224) — root cause was pdf.js treating `tauri://localhost` as an opaque origin and wrapping the worker in a blob: that re-imports the URL, which stalls silently in 14.x WKWebView. Fixed by passing a self-constructed Worker via `GlobalWorkerOptions.workerPort`, bypassing the wrapper. Affected users now get full metadata + cover instead of filename-only fallback.
- Misleading "Imported with limited metadata" toast removed; fallback is console-only.
- Reader (foliate-js) gets the same workerPort fix so PDF reading also works on 14.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)