### PR TITLE
chore: move desktop design source into design/

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,11 @@
+# Design
+
+Pencil (`.pen`) source files for the Quill desktop UI. Open these in the Pencil app; they are encrypted on disk and not meant to be read as plain text.
+
+Conventions:
+- `quill-desktop.pen` is the canonical design source for the Tauri desktop app. Split into per-surface files (e.g. `reader.pen`, `library.pen`) only if `quill-desktop.pen` gets unwieldy.
+- iOS designs live in their own repo at [`quill-design`](https://github.com/yicheng47/quill-design) (alongside the `quill-ios` repo).
+- Exports land under `/public/` (icons, app images) or are referenced directly from React components via Pencil's MCP export flow.
+
+Follow-ups parked in design (no issue yet):
+- _none yet_

--- a/design/quill-desktop.pen
+++ b/design/quill-desktop.pen
@@ -1,0 +1,16068 @@
+{
+  "version": "2.11",
+  "children": [
+    {
+      "type": "frame",
+      "id": "IBjLW",
+      "x": 0,
+      "y": 953,
+      "name": "Library / Home",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "children": [
+        {
+          "type": "frame",
+          "id": "K4OsT",
+          "name": "Sidebar",
+          "clip": true,
+          "width": 224,
+          "height": "fill_container",
+          "fill": "$bg-muted",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "$border"
+          },
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            0,
+            16,
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "2CiZ7",
+              "name": "Logo row",
+              "gap": 10,
+              "padding": [
+                44,
+                0,
+                8,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Pt3SW",
+                  "name": "Logo",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "$accent",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "xnPx0",
+                      "name": "logoIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "feather",
+                      "iconFontFamily": "lucide",
+                      "fill": "$white"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "oBbGz",
+                  "name": "logoText",
+                  "fill": "$text-primary",
+                  "content": "Quill",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.5
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "piFyP",
+              "name": "Library section",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "IYliW",
+                  "name": "libHeader",
+                  "fill": "$text-muted",
+                  "content": "LIBRARY",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.3
+                },
+                {
+                  "type": "frame",
+                  "id": "LlfUm",
+                  "name": "Library items",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "T94Q9",
+                      "name": "All Books (active)",
+                      "width": "fill_container",
+                      "height": 36,
+                      "fill": "$accent-bg",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "HkHyx",
+                          "name": "allBooksLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Y9ZR7",
+                              "name": "allBooksIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "library",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            },
+                            {
+                              "type": "text",
+                              "id": "QuujM",
+                              "name": "allBooksLabel",
+                              "fill": "$accent",
+                              "content": "All Books",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "PhFFt",
+                          "name": "allBooksCount",
+                          "fill": "$text-muted",
+                          "content": "40",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HHs0a",
+                      "name": "Currently Reading",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "PpdEW",
+                          "name": "readingLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "MxuDu",
+                              "name": "readingIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "book-open",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "bVsi1",
+                              "name": "readingLabel",
+                              "fill": "$text-secondary",
+                              "content": "Currently Reading",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "h1jBE",
+                          "name": "readingCount",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dLFyA",
+                      "name": "Finished",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "YzF47",
+                          "name": "finishedLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "18hMt",
+                              "name": "finishedIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "circle-check",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "jooNC",
+                              "name": "finishedLabel",
+                              "fill": "$text-secondary",
+                              "content": "Finished",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "nzUjd",
+                          "name": "finishedCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Nxwcg",
+              "name": "Tools section",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "P0bAi",
+                  "name": "toolsHeader",
+                  "fill": "$text-muted",
+                  "content": "TOOLS",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.3
+                },
+                {
+                  "type": "frame",
+                  "id": "ztWCc",
+                  "name": "toolsList",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ECvkZ",
+                      "name": "Dictionary",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "r3q8V",
+                          "name": "dictIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "book-a",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "2bVG4",
+                          "name": "dictLabel",
+                          "fill": "$text-secondary",
+                          "content": "Dictionary",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Is3wQ",
+                      "name": "Chats",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "rne2U",
+                          "name": "chatsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "message-square",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "DtjxP",
+                          "name": "chatsLabel",
+                          "fill": "$text-secondary",
+                          "content": "Chats",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DGU19",
+                      "name": "Translations",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "AtyYr",
+                          "name": "transIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "globe",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "I0SK3",
+                          "name": "transLabel",
+                          "fill": "$text-secondary",
+                          "content": "Translations",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UJIt6",
+              "name": "Collections section",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "k4uoW",
+                  "name": "Collections header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "I4VjQ",
+                      "name": "colsHeader",
+                      "fill": "$text-muted",
+                      "content": "COLLECTIONS",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.3
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "aVpUk",
+                      "name": "colsPlus",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ggvqY",
+                  "name": "Collections list",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "TjUII",
+                      "name": "Fiction",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fcyBF",
+                          "name": "fictionLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "oYmuk",
+                              "name": "fictionGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "ISNrO",
+                              "name": "fictionIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "s1vfL",
+                              "name": "fictionLabel",
+                              "fill": "$text-secondary",
+                              "content": "Fiction",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "36d72",
+                          "name": "fictionCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZIn9U",
+                      "name": "Scifi",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "2g7DO",
+                          "name": "scifiLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "tsfNL",
+                              "name": "scifiGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "CDXog",
+                              "name": "scifiIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "50HbX",
+                              "name": "scifiLabel",
+                              "fill": "$text-secondary",
+                              "content": "Scifi",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "s5YPh",
+                          "name": "scifiCount",
+                          "fill": "$text-muted",
+                          "content": "5",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "y6Jym",
+                      "name": "History",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "tdgxw",
+                          "name": "historyLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "enunc",
+                              "name": "historyGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "8armr",
+                              "name": "historyIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "cz9zK",
+                              "name": "historyLabel",
+                              "fill": "$text-secondary",
+                              "content": "History",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "BahfB",
+                          "name": "historyCount",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gMWlp",
+                      "name": "Chinese",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "TaqAM",
+                          "name": "chineseLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "R84M0",
+                              "name": "chineseGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "V5m9l",
+                              "name": "chineseIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "aQU2E",
+                              "name": "chineseLabel",
+                              "fill": "$text-secondary",
+                              "content": "Chinese",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "2mliH",
+                          "name": "chineseCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6SfK3",
+                      "name": "Russian",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "uZkYA",
+                          "name": "russianLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "yvPdG",
+                              "name": "russianGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "FLPcs",
+                              "name": "russianIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "zgdBi",
+                              "name": "russianLabel",
+                              "fill": "$text-secondary",
+                              "content": "Russian",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "sHbBc",
+                          "name": "russianCount",
+                          "fill": "$text-muted",
+                          "content": "2",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cBgwu",
+                      "name": "Japanese",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "6IOLl",
+                          "name": "japaneseLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "aanQG",
+                              "name": "japaneseGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "ofVRh",
+                              "name": "japaneseIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "KT31Y",
+                              "name": "japaneseLabel",
+                              "fill": "$text-secondary",
+                              "content": "Japanese",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "04Slk",
+                          "name": "japaneseCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "4VQPA",
+                      "name": "Fashion",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "pPQyS",
+                          "name": "fashionLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "HUOg7",
+                              "name": "fashionGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "SzHst",
+                              "name": "fashionIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "rK2Hh",
+                              "name": "fashionLabel",
+                              "fill": "$text-secondary",
+                              "content": "Fashion",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "lvIwt",
+                          "name": "fashionCount",
+                          "fill": "$text-muted",
+                          "content": "5",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qzDwO",
+                      "name": "Music",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "xp4lP",
+                          "name": "musicLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "FJH41",
+                              "name": "musicGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "b6R3M",
+                              "name": "musicIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "g7BKU",
+                              "name": "musicLabel",
+                              "fill": "$text-secondary",
+                              "content": "Music",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "A10MR",
+                          "name": "musicCount",
+                          "fill": "$text-muted",
+                          "content": "2",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gw25J",
+                      "name": "Computer Science",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ol02I",
+                          "name": "csLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "gWLe9",
+                              "name": "csGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "0N00b",
+                              "name": "csIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "rvY1w",
+                              "name": "csLabel",
+                              "fill": "$text-secondary",
+                              "content": "Computer Science",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "zbSyA",
+                          "name": "csCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "6VxhY",
+              "name": "User profile",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "padding": [
+                12,
+                0,
+                0,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "BqaH9",
+                  "name": "User button",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "wCbxf",
+                      "name": "Avatar",
+                      "width": 28,
+                      "height": 28,
+                      "fill": "$accent",
+                      "cornerRadius": 9999,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "2b7Y8",
+                          "name": "userAvatarText",
+                          "fill": "$white",
+                          "content": "J",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ppYi0",
+                      "name": "userInfo",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "HbUq9",
+                          "name": "userName",
+                          "fill": "$text-primary",
+                          "content": "Jason",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "u8eMh",
+                          "name": "userSub",
+                          "fill": "$text-muted",
+                          "content": "Settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "1Kahu",
+          "name": "Main content",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg-surface",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "0kQ7c",
+              "name": "Header",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "gap": 16,
+              "padding": [
+                44,
+                24,
+                24,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "As56i",
+                  "name": "Title row",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "37vYV",
+                      "name": "title",
+                      "fill": "$text-primary",
+                      "content": "All Books",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.07
+                    },
+                    {
+                      "type": "frame",
+                      "id": "PY1vg",
+                      "name": "View toggle",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "oYrcT",
+                          "name": "Grid view (active)",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "NcTfZ",
+                              "name": "gridIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "layout-grid",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "8UP83",
+                          "name": "List view",
+                          "width": 36,
+                          "height": 36,
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "WOl5k",
+                              "name": "listIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "list",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "iN081",
+                  "name": "Search",
+                  "width": 448,
+                  "height": 36,
+                  "fill": "$bg-input",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "LKuRx",
+                      "name": "searchIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "8jdZn",
+                      "name": "searchPlaceholder",
+                      "fill": "$text-placeholder",
+                      "content": "Search books...",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "0D8Tp",
+              "name": "Book grid scroll",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 24,
+              "padding": 24,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "tIAc2",
+                  "name": "Row 1",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "5cul6",
+                      "name": "Invisible Cities",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ufnIO",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775988320372.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "gp2WV",
+                          "name": "book1Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Invisible Cities (transl. William...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "1EkLj",
+                          "name": "book1Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Italo Calvino",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "s28oJ",
+                      "name": "Fight Club",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "xfyCX",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775452511015.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "siMT0",
+                          "name": "book2Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Fight Club",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "0EAve",
+                          "name": "book2Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Chuck Palahniuk",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZzWCv",
+                      "name": "Lightening 2024.11",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "JqisV",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775988346070.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "fTcDD",
+                          "name": "book3Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Lightening 2024.11",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "fC8y1",
+                          "name": "book3Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Heritage",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "EuWPJ",
+                      "name": "Theory of Poker",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "0WNPX",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775988365458.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "9tiXX",
+                          "name": "book4Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "The Theory of Poker",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "V1ke1",
+                          "name": "book4Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "David Sklansky",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "G97YU",
+                      "name": "Count Zero",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "5ATv6",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775988544992.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "XHTUK",
+                          "name": "book5Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Count Zero",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "4zHtZ",
+                          "name": "book5Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "William Gibson",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "y3qR5",
+                  "name": "Row 2",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "PXZ4z",
+                      "name": "Wo Yu Ditan",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "FCtYB",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775988568293.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Uaqwz",
+                          "name": "book6Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "我与地坛",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "9WCtR",
+                          "name": "book6Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "史铁生",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XV6Ao",
+                      "name": "Understanding Movies",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "2R3y4",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775988594959.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "h2l5i",
+                          "name": "book7Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Understanding Movies",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "K2GkG",
+                          "name": "book7Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Louis Giannetti",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "unTg4",
+                      "name": "Wei Cheng",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "990gC",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775988612700.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "SAKXV",
+                          "name": "book8Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "围城",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "GRd5d",
+                          "name": "book8Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "钱钟书",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "2IEBo",
+                      "name": "Lightening 2025.7",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "T7bHr",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775988637338.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "vpMYr",
+                          "name": "book9Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Lightening 2025.7",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "m4Pas",
+                          "name": "book9Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Heritage",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XFlcA",
+                      "name": "Lightening 2024.6",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "zZGZY",
+                          "name": "Cover",
+                          "clip": true,
+                          "width": "fill_container",
+                          "height": 286,
+                          "fill": {
+                            "type": "image",
+                            "enabled": true,
+                            "url": "./images/generated-1775988663579.png",
+                            "mode": "fill"
+                          },
+                          "cornerRadius": 8,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001A",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 6,
+                            "spread": -1
+                          },
+                          "layout": "none"
+                        },
+                        {
+                          "type": "text",
+                          "id": "KhCT8",
+                          "name": "book10Title",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Lightening 2024.6",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.15
+                        },
+                        {
+                          "type": "text",
+                          "id": "fOsB5",
+                          "name": "book10Author",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Heritage",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "IdJmD",
+              "name": "Drop hint",
+              "width": "fill_container",
+              "gap": 8,
+              "padding": [
+                16,
+                24,
+                24,
+                24
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RiPJC",
+                  "name": "Drop box",
+                  "width": "fill_container",
+                  "height": 56,
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#71717b66"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    16
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "YOuDi",
+                      "name": "dropIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "upload",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-secondary"
+                    },
+                    {
+                      "type": "text",
+                      "id": "5GDBF",
+                      "name": "dropText",
+                      "fill": "$text-secondary",
+                      "content": "Drop files or click to import more books",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "YwSOa",
+      "x": 3287,
+      "y": 953,
+      "name": "Reader with AI Panel",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "qa8Zs",
+          "name": "Top bar",
+          "width": "fill_container",
+          "fill": "$bg-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$border"
+          },
+          "padding": [
+            32,
+            24,
+            8,
+            24
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "2RF0Q",
+              "name": "Top left",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "GCiZM",
+                  "name": "Back icon",
+                  "width": 40,
+                  "height": 40,
+                  "fill": "$accent",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "cAOMz",
+                      "name": "backIcon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "$white"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "yj4eF",
+                  "name": "TOC",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "lzGSh",
+                      "name": "tocIcon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "list",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "8hUdq",
+              "name": "Title center",
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "PrsNr",
+                  "name": "titleText",
+                  "fill": "$text-primary",
+                  "content": "Fight Club",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "uS3GQ",
+                  "name": "chapterText",
+                  "fill": "$text-muted",
+                  "content": "Chapter 22 of 38",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "AVUsf",
+              "name": "Top right",
+              "gap": 2,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Ors4Z",
+                  "name": "Font",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "gap": 1,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "C00S4",
+                      "name": "fontBig",
+                      "fill": "$text-primary",
+                      "content": "A",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "zS9NS",
+                      "name": "fontSmall",
+                      "fill": "$text-primary",
+                      "content": "A",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "f1poR",
+                  "name": "Bookmark",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Q5hXR",
+                      "name": "bookmarkIcon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "bookmark",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "6tegU",
+                  "name": "Translate",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "FfNnc",
+                      "name": "translateIcon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "languages",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "oIqCs",
+                  "name": "dividerWrap",
+                  "padding": [
+                    0,
+                    4
+                  ],
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "sQLjS",
+                      "name": "divider",
+                      "fill": "$border",
+                      "width": 1,
+                      "height": 24
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JSAxv",
+                  "name": "AI Assistant",
+                  "height": 32,
+                  "fill": "$accent-bg",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "0nxt9",
+                      "name": "aiIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "sparkles",
+                      "iconFontFamily": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ToYwy",
+                      "name": "aiLabel",
+                      "fill": "$accent",
+                      "content": "AI Assistant",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.15
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "I0eKI",
+          "name": "Body",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg-surface",
+          "children": [
+            {
+              "type": "frame",
+              "id": "fMxMx",
+              "name": "Reader column",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$bg-surface",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "tvAOf",
+                  "name": "Reading area",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": [
+                    32,
+                    120,
+                    16,
+                    120
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "RK51q",
+                      "name": "p1",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "And one night in an uptown square park, another group of men poured gasoline around every tree and from tree to tree and set a perfect little forest fire. It was in the newspaper, how townhouse windows across the street from the fire melted, and parked cars farted and settled on melted flat tires.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "2ewUP",
+                      "name": "p2",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    Tyler's rented house on Paper Street is a living thing wet on the inside from so many people sweating and breathing. So many people are moving inside, the house moves.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "G4pxw",
+                      "name": "p4",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    And Tyler was a few of the space monkeys had Tyler drilling holes in their hand. Then those space monkeys are on the front porch to replace them.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "8bTnP",
+                      "name": "p3",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    Another night that Tyler didn't come home, someone was drilling bank machines and lube fittings into the drilled holes... bank machines and pay telephones.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "PxXO1",
+                      "name": "p5",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    And every day in different cars. You never saw the same car twice. One evening, I hear Marla on the front",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ouT5Z",
+                  "name": "Bottom progress",
+                  "width": "fill_container",
+                  "fill": "$bg-surface",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    24,
+                    8,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "OfUj4",
+                      "name": "Progress track",
+                      "width": "fill_container",
+                      "height": 2,
+                      "fill": "$border",
+                      "cornerRadius": 9999,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "UZjSa",
+                          "name": "Progress fill",
+                          "width": 760,
+                          "height": 2,
+                          "fill": "$accent",
+                          "cornerRadius": 9999
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xh0Xq",
+                      "name": "Progress row",
+                      "width": "fill_container",
+                      "height": 32,
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZWjTv",
+                          "name": "pageText",
+                          "fill": "$text-muted",
+                          "content": "Page 162 of 267",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "6h713",
+                          "name": "Nav arrows",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "hwpvc",
+                              "name": "leftArrow",
+                              "width": 24,
+                              "height": 24,
+                              "cornerRadius": 4,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "GevdY",
+                                  "name": "leftIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "chevron-left",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$text-muted"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "bC6cd",
+                              "name": "pctText",
+                              "fill": "$text-muted",
+                              "content": "61%",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "M2zoX",
+                              "name": "rightArrow",
+                              "width": 24,
+                              "height": 24,
+                              "cornerRadius": 4,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "RhShl",
+                                  "name": "rightIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "chevron-right",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$text-muted"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "Dy0Gg",
+                          "name": "leftText",
+                          "fill": "$text-muted",
+                          "content": "105 pages left",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UfIQp",
+              "name": "AI Panel",
+              "clip": true,
+              "width": 440,
+              "height": "fill_container",
+              "fill": "$bg-muted",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "left": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KNU8R",
+                  "name": "AI header",
+                  "width": "fill_container",
+                  "height": 63,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$border"
+                  },
+                  "padding": [
+                    0,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Li0Pa",
+                      "name": "aiHeaderLeft",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "a07b9",
+                          "name": "aiHeaderIcon",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "sparkles",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "407Uo",
+                          "name": "aiHeaderTitle",
+                          "fill": "$text-primary",
+                          "content": "Tyler Explains Harsh Initiation Test",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.23
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "galkk",
+                          "name": "aiHeaderChevron",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "1iI9V",
+                      "name": "aiHeaderPlus",
+                      "width": 28,
+                      "height": 28,
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "YeVb3",
+                          "name": "aiHeaderPlusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jrDjA",
+                  "name": "Messages",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "aht6K",
+                      "name": "User context msg",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "JhrLQ",
+                          "name": "Context quote",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "left": 2
+                            },
+                            "fill": "$lavender"
+                          },
+                          "padding": [
+                            2,
+                            0,
+                            2,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gF8mZ",
+                              "name": "userCtxText",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": 340,
+                              "content": "This is how Buddhist temples have tested applicants going back for bah-zillion years, Tyler says. You tell the applicant to go away, and if...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TqOph",
+                          "name": "Explain bubble",
+                          "fill": "$user-bubble",
+                          "cornerRadius": 8,
+                          "padding": 13,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "y3oTd",
+                              "name": "userExplainText",
+                              "fill": "$text-primary",
+                              "content": "Explain",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Vlz28",
+                      "name": "Assistant msg",
+                      "fill": "$bg-surface",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border"
+                      },
+                      "layout": "vertical",
+                      "gap": 10,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "RxfBX",
+                          "name": "assistIntro",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "In this passage, Tyler is justifying the harsh \"test\" he gives new recruits by comparing it to an old spiritual tradition.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "1VVUD",
+                          "name": "assistH1",
+                          "fill": "$text-primary",
+                          "content": "What he's saying",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Ve35u",
+                          "name": "assistP1",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "He claims Buddhist temples used to test people by rejecting them at first. Only if someone waited outside for days—hungry, uncomfortable, ignored—would they be accepted for training.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "BO3DO",
+                          "name": "assistH2",
+                          "fill": "$text-primary",
+                          "content": "Why this matters in Fight Club",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "nYkEL",
+                          "name": "assistP2",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Tyler is using this idea to support his philosophy:",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ttcPt",
+                          "name": "assistBullets",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Commitment must be proven through suffering\nOnly the truly devoted deserve entry\nEgo gets stripped away by humiliation and endurance",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "atkBH",
+                          "name": "assistP3",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "It turns Project Mayhem into something like a cult initiation: people must show total obedience before belonging.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "r1oNR",
+                          "name": "assistH3",
+                          "fill": "$text-primary",
+                          "content": "Tone / characterization",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "eorKT",
+                          "name": "assistP4",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "The \"bah-zillion years\" phrasing is sarcastic and exaggerated. It shows Tyler's charismatic, performative style — he mixes half-history, myth, and confidence to make extreme behavior sound meaningful and inevitable.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "3xOuZ",
+                      "name": "User msg 2",
+                      "width": "fill_container",
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "wiYWM",
+                          "name": "userMsg2",
+                          "fill": "$user-bubble",
+                          "cornerRadius": 8,
+                          "padding": 13,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "s1UQK",
+                              "name": "userMsg2Text",
+                              "fill": "$text-primary",
+                              "content": "Interesting a lot of current society",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "avhcp",
+                      "name": "Assistant msg 2",
+                      "fill": "$bg-surface",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border"
+                      },
+                      "layout": "vertical",
+                      "gap": 6,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Li5aE",
+                          "name": "assist2P1",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Absolutely — you're picking up on one of the novel's biggest points.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "r1TU3",
+                          "name": "assist2P2",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "I think you're starting to say: a lot of current society still works like this—people are made to \"prove\" themselves through stress, rejection, and grind before they're accepted.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "0mgZK",
+                  "name": "AI input",
+                  "width": "fill_container",
+                  "fill": "$bg-muted",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "$border"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    17,
+                    16,
+                    16,
+                    16
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "vgIJa",
+                      "name": "aiInputRow",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "oFWJx",
+                          "name": "aiInputBox",
+                          "width": "fill_container",
+                          "height": 60,
+                          "fill": "$bg-input",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "chmJ4",
+                              "name": "aiInputPlaceholder",
+                              "fill": "$text-placeholder",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask me anything about what you're reading...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ohU9j",
+                          "name": "Send",
+                          "width": 60,
+                          "height": 60,
+                          "fill": "$accent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "TkgxO",
+                              "name": "aiSendIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "send",
+                              "iconFontFamily": "lucide",
+                              "fill": "$white"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "my5uS",
+                      "name": "aiHint",
+                      "fill": "$text-muted",
+                      "content": "Press Enter to send, Shift+Enter for new line",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "h0Ib8",
+          "layoutPosition": "absolute",
+          "x": 284,
+          "y": 340,
+          "name": "Look Up popover",
+          "width": 440,
+          "fill": "#ffffff",
+          "cornerRadius": 14,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000026",
+            "offset": {
+              "x": 0,
+              "y": 20
+            },
+            "blur": 25
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "B5GK7",
+              "name": "Header",
+              "width": "fill_container",
+              "fill": "$accent-bg",
+              "padding": [
+                12,
+                16,
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "S5Kbo",
+                  "name": "popHdrLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "6edd5",
+                      "name": "popHdrIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sparkles",
+                      "iconFontFamily": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "OLYb0",
+                      "name": "popHdrTitle",
+                      "fill": "$accent",
+                      "content": "Look Up",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.15
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lf9XO",
+                  "name": "popHdrClose",
+                  "width": 24,
+                  "height": 24,
+                  "cornerRadius": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ryyNq",
+                      "name": "popHdrCloseIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "aMVxH",
+              "name": "Body",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "padding": [
+                12,
+                16,
+                8,
+                16
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "OJZCA",
+                  "name": "popWord",
+                  "fill": "$text-primary",
+                  "content": "Another nigh",
+                  "fontFamily": "Inter",
+                  "fontSize": 20,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "0Lad2",
+                  "name": "popTrans",
+                  "fill": "$accent",
+                  "content": "又一个夜晚",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Oz9BM",
+                  "name": "popDef",
+                  "fill": "$text-primary",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "/əˈnʌðər naɪ/ phrase. Means \"one more night\" or \"an additional night\"; in this context, it introduces yet another night when Tyler did not come home.",
+                  "lineHeight": 1.55,
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "wqgFC",
+                  "name": "In this context card",
+                  "width": "fill_container",
+                  "fill": "$bg-muted",
+                  "cornerRadius": 8,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "iCIkJ",
+                      "name": "popCtxLabel",
+                      "fill": "$text-muted",
+                      "content": "In this context",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "cv5uN",
+                      "name": "popCtxBody",
+                      "fill": "$text-secondary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "\"Another nigh[t]\" signals repetition and escalation: this isn't a one-off event, but part of a continuing pattern of Tyler's absence and chaos. The clipped, slightly off phrasing also matches the narrator's frantic, exhausted voice, as if thoughts are tumbling out faster than they can be neatly framed. It sets a tone of inevitability before launching into the absurd sabotage details.",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sBHBq",
+              "name": "Footer",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "$border"
+              },
+              "padding": [
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NDC3p",
+                  "name": "popSave",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "AUfLJ",
+                      "name": "popSaveIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "bookmark-plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "f4g2H",
+                      "name": "popSaveLabel",
+                      "fill": "$accent",
+                      "content": "Save to Dict",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "pSX9z",
+                  "name": "popCopy",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "EdftX",
+                      "name": "popCopyIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "copy",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "29PzN",
+                      "name": "popCopyLabel",
+                      "fill": "$text-muted",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "VYMxj",
+      "x": 0,
+      "y": 2504,
+      "name": "Dictionary",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "children": [
+        {
+          "type": "frame",
+          "id": "qqvZQ",
+          "name": "Sidebar",
+          "clip": true,
+          "width": 224,
+          "height": "fill_container",
+          "fill": "$bg-muted",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "$border"
+          },
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            0,
+            16,
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "kai2t",
+              "name": "Logo row",
+              "gap": 10,
+              "padding": [
+                44,
+                0,
+                8,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "2nEcw",
+                  "name": "Logo",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "$accent",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ajIwc",
+                      "name": "logoIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "feather",
+                      "iconFontFamily": "lucide",
+                      "fill": "$white"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "1CB9E",
+                  "name": "logoText",
+                  "fill": "$text-primary",
+                  "content": "Quill",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.5
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "0sOsf",
+              "name": "Library section",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "3diiU",
+                  "name": "libHeader",
+                  "fill": "$text-muted",
+                  "content": "LIBRARY",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.3
+                },
+                {
+                  "type": "frame",
+                  "id": "w1nvL",
+                  "name": "Library items",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "D2nha",
+                      "name": "All Books (active)",
+                      "width": "fill_container",
+                      "height": 36,
+                      "fill": {
+                        "type": "color",
+                        "color": "#ffffff",
+                        "enabled": false
+                      },
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "HKPic",
+                          "name": "allBooksLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "tU8eX",
+                              "name": "allBooksIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "library",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "C4eQN",
+                              "name": "allBooksLabel",
+                              "fill": "$text-secondary",
+                              "content": "All Books",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "cW1MD",
+                          "name": "allBooksCount",
+                          "fill": "$text-muted",
+                          "content": "40",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "R1UUm",
+                      "name": "Currently Reading",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "eLEmY",
+                          "name": "readingLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "f59VT",
+                              "name": "readingIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "book-open",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "8pjbB",
+                              "name": "readingLabel",
+                              "fill": "$text-secondary",
+                              "content": "Currently Reading",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "u6Hmw",
+                          "name": "readingCount",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QSY7r",
+                      "name": "Finished",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "axnD7",
+                          "name": "finishedLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "mz1Yy",
+                              "name": "finishedIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "circle-check",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "3zULj",
+                              "name": "finishedLabel",
+                              "fill": "$text-secondary",
+                              "content": "Finished",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "rrIV2",
+                          "name": "finishedCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JnkBs",
+              "name": "Tools section",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Mc9Gb",
+                  "name": "toolsHeader",
+                  "fill": "$text-muted",
+                  "content": "TOOLS",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.3
+                },
+                {
+                  "type": "frame",
+                  "id": "NQyzv",
+                  "name": "toolsList",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "EDcHD",
+                      "name": "Dictionary",
+                      "width": "fill_container",
+                      "height": 36,
+                      "fill": "$accent-bg",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Ezl6R",
+                          "name": "dictIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "book-a",
+                          "iconFontFamily": "lucide",
+                          "fill": "$accent"
+                        },
+                        {
+                          "type": "text",
+                          "id": "mIyvB",
+                          "name": "dictLabel",
+                          "fill": "$accent",
+                          "content": "Dictionary",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "37tzB",
+                      "name": "Chats",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "eiYmh",
+                          "name": "chatsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "message-square",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "JqHmU",
+                          "name": "chatsLabel",
+                          "fill": "$text-secondary",
+                          "content": "Chats",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "2cVZH",
+                      "name": "Translations",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "gp0t5",
+                          "name": "transIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "globe",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ai7fJ",
+                          "name": "transLabel",
+                          "fill": "$text-secondary",
+                          "content": "Translations",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Gg3Bl",
+              "name": "Collections section",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vV0Gm",
+                  "name": "Collections header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rj68z",
+                      "name": "colsHeader",
+                      "fill": "$text-muted",
+                      "content": "COLLECTIONS",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.3
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "9IesA",
+                      "name": "colsPlus",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "90KK9",
+                  "name": "Collections list",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "XLiAT",
+                      "name": "Fiction",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "4Icbw",
+                          "name": "fictionLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "3Oe3L",
+                              "name": "fictionGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "Xk4QH",
+                              "name": "fictionIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "mexm0",
+                              "name": "fictionLabel",
+                              "fill": "$text-secondary",
+                              "content": "Fiction",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "Bkn8M",
+                          "name": "fictionCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "no35X",
+                      "name": "Scifi",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "BHr3M",
+                          "name": "scifiLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "7vZOz",
+                              "name": "scifiGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "QGDh3",
+                              "name": "scifiIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "LCthp",
+                              "name": "scifiLabel",
+                              "fill": "$text-secondary",
+                              "content": "Scifi",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "mTUa8",
+                          "name": "scifiCount",
+                          "fill": "$text-muted",
+                          "content": "5",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6QNUr",
+                      "name": "History",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "WjPwI",
+                          "name": "historyLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "GW0eF",
+                              "name": "historyGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "eDrgn",
+                              "name": "historyIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "EEqnG",
+                              "name": "historyLabel",
+                              "fill": "$text-secondary",
+                              "content": "History",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "sF8l9",
+                          "name": "historyCount",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jbki0",
+                      "name": "Chinese",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "zHXGo",
+                          "name": "chineseLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "hFG7F",
+                              "name": "chineseGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "MtB8v",
+                              "name": "chineseIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "wr89B",
+                              "name": "chineseLabel",
+                              "fill": "$text-secondary",
+                              "content": "Chinese",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "5Dg5l",
+                          "name": "chineseCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Xnjv5",
+                      "name": "Russian",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "n8Dbr",
+                          "name": "russianLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "B0g68",
+                              "name": "russianGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "yByDe",
+                              "name": "russianIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "N3N3w",
+                              "name": "russianLabel",
+                              "fill": "$text-secondary",
+                              "content": "Russian",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "zL1sW",
+                          "name": "russianCount",
+                          "fill": "$text-muted",
+                          "content": "2",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QLjFx",
+                      "name": "Japanese",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Lq9jS",
+                          "name": "japaneseLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "eVnmW",
+                              "name": "japaneseGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "TIkaG",
+                              "name": "japaneseIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "nM2be",
+                              "name": "japaneseLabel",
+                              "fill": "$text-secondary",
+                              "content": "Japanese",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "vyT9A",
+                          "name": "japaneseCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IfQB9",
+                      "name": "Fashion",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "sCK8n",
+                          "name": "fashionLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "5w5lv",
+                              "name": "fashionGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "HsRyD",
+                              "name": "fashionIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "hCp2O",
+                              "name": "fashionLabel",
+                              "fill": "$text-secondary",
+                              "content": "Fashion",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "ubKnl",
+                          "name": "fashionCount",
+                          "fill": "$text-muted",
+                          "content": "5",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zAi3F",
+                      "name": "Music",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Rlw3x",
+                          "name": "musicLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "zkCy7",
+                              "name": "musicGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "DuCZk",
+                              "name": "musicIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Stanb",
+                              "name": "musicLabel",
+                              "fill": "$text-secondary",
+                              "content": "Music",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "HuLHd",
+                          "name": "musicCount",
+                          "fill": "$text-muted",
+                          "content": "2",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XaaoU",
+                      "name": "Computer Science",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "DN9qT",
+                          "name": "csLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "NqQg0",
+                              "name": "csGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "Swpvw",
+                              "name": "csIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "1Qynv",
+                              "name": "csLabel",
+                              "fill": "$text-secondary",
+                              "content": "Computer Science",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "ojChz",
+                          "name": "csCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "lowr0",
+              "name": "User profile",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "padding": [
+                12,
+                0,
+                0,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "T43Rn",
+                  "name": "User button",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "N4HAu",
+                      "name": "Avatar",
+                      "width": 28,
+                      "height": 28,
+                      "fill": "$accent",
+                      "cornerRadius": 9999,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "pwrY3",
+                          "name": "userAvatarText",
+                          "fill": "$white",
+                          "content": "J",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "wCddt",
+                      "name": "userInfo",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "j7qQ7",
+                          "name": "userName",
+                          "fill": "$text-primary",
+                          "content": "Jason",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ejVZj",
+                          "name": "userSub",
+                          "fill": "$text-muted",
+                          "content": "Settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "aPmry",
+          "name": "Main content",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg-surface",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Ql6qg",
+              "name": "Header",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "gap": 16,
+              "padding": [
+                44,
+                24,
+                24,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "5L5Hh",
+                  "name": "Title row",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "P5Fom",
+                      "name": "title",
+                      "fill": "$text-primary",
+                      "content": "Dictionary",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.07
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7qRbR",
+                      "name": "View toggle",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "cOemB",
+                          "name": "Grid view (active)",
+                          "width": 36,
+                          "height": 36,
+                          "fill": {
+                            "type": "color",
+                            "color": "#ffffff",
+                            "enabled": false
+                          },
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "dltjL",
+                              "name": "gridIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "layout-grid",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fpDDw",
+                          "name": "List view",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "6OIwZ",
+                              "name": "listIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "list",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "7Ky83",
+                  "name": "Search",
+                  "width": "fill_container",
+                  "height": 36,
+                  "fill": "$bg-input",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Un4jU",
+                      "name": "searchIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xl474",
+                      "name": "searchPlaceholder",
+                      "fill": "$text-placeholder",
+                      "content": "Search words, definitions, or books...",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "EUokS",
+              "name": "Dictionary body",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jnjO2",
+                  "name": "Filter row",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$border-light"
+                  },
+                  "gap": 10,
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "5dzJa",
+                      "name": "All Books pill",
+                      "height": 32,
+                      "fill": "$accent-bg",
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#c4b5fd"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "10Abq",
+                          "name": "pillAllIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "book-open",
+                          "iconFontFamily": "lucide",
+                          "fill": "$accent"
+                        },
+                        {
+                          "type": "text",
+                          "id": "zIBZT",
+                          "name": "pillAllLabel",
+                          "fill": "$accent",
+                          "content": "All Books",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Lx70Y",
+                          "name": "pillAllCount",
+                          "fill": "$accent",
+                          "content": "27",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "1qDhY",
+                      "name": "IC pill",
+                      "height": 32,
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "QTCZc",
+                          "name": "pillICIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "book-open",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "GguHb",
+                          "name": "pillICLabel",
+                          "fill": "$text-secondary",
+                          "content": "Invisible Cities (tra...",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "iHqcR",
+                          "name": "pillICCount",
+                          "fill": "$text-muted",
+                          "content": "17",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pIVTf",
+                      "name": "FC pill",
+                      "height": 32,
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "xFFjR",
+                          "name": "pillFCIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "book-open",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "RFpUF",
+                          "name": "pillFCLabel",
+                          "fill": "$text-secondary",
+                          "content": "Fight Club",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "DsIgj",
+                          "name": "pillFCCount",
+                          "fill": "$text-muted",
+                          "content": "7",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RllJi",
+                      "name": "TOP pill",
+                      "height": 32,
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "MYIzA",
+                          "name": "pillTOPIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "book-open",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "5f0Lf",
+                          "name": "pillTOPLabel",
+                          "fill": "$text-secondary",
+                          "content": "The Theory of Poker",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Ku4Wo",
+                          "name": "pillTOPCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Lajen",
+                      "name": "NM pill",
+                      "height": 32,
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "ZrpYJ",
+                          "name": "pillNMIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "book-open",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "eT3bs",
+                          "name": "pillNMLabel",
+                          "fill": "$text-secondary",
+                          "content": "Neuromancer",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Oky4f",
+                          "name": "pillNMCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dE8Cv",
+                      "name": "Zen pill",
+                      "height": 32,
+                      "cornerRadius": 9999,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "oNg2u",
+                          "name": "pillZenIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "book-open",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "teWzR",
+                          "name": "pillZenLabel",
+                          "fill": "$text-secondary",
+                          "content": "Zen and the Art of ...",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "zVu9E",
+                          "name": "pillZenCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gcdsJ",
+                      "name": "sortSpacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NzZ4r",
+                      "name": "sortNewest",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "GksE5",
+                          "name": "sortNewestIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "arrow-down-wide-narrow",
+                          "iconFontFamily": "lucide",
+                          "fill": "$accent"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ShaAJ",
+                          "name": "sortNewestLabel",
+                          "fill": "$accent",
+                          "content": "Newest",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "aJHS3",
+                      "name": "sortOldest",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "WY1sU",
+                          "name": "sortOldestIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "arrow-up-narrow-wide",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "5YXDV",
+                          "name": "sortOldestLabel",
+                          "fill": "$text-muted",
+                          "content": "Oldest",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "8Zm5A",
+                      "name": "sortAZ",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "hpdF4",
+                          "name": "sortAZIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "arrow-down-a-z",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "EaNwi",
+                          "name": "sortAZLabel",
+                          "fill": "$text-muted",
+                          "content": "A-Z",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Hg4Lv",
+                  "name": "Entries list",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 32,
+                  "padding": [
+                    24,
+                    24,
+                    40,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "HVmGs",
+                      "name": "Section A",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fDsmC",
+                          "name": "A header",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "padding": [
+                            0,
+                            0,
+                            8,
+                            0
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gkUxO",
+                              "name": "sectionALetter",
+                              "fill": "$accent",
+                              "content": "A",
+                              "fontFamily": "Inter",
+                              "fontSize": 28,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Av1Kt",
+                              "name": "sectionACount",
+                              "fill": "$text-muted",
+                              "content": "5",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nNTIE",
+                          "name": "armature entry",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "gap": 24,
+                          "padding": [
+                            4,
+                            8,
+                            12,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "vukoN",
+                              "name": "armLeft",
+                              "width": 160,
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "MP21t",
+                                  "name": "armWord",
+                                  "fill": "$text-primary",
+                                  "content": "armature",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "QfFwl",
+                                  "name": "armSource",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "slS6O",
+                                      "name": "armSourceIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "book-open",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$text-muted"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "XVOam",
+                                      "name": "armSourceText",
+                                      "fill": "$text-muted",
+                                      "content": "Invisible Cities (transl. Will...",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "WMYFY",
+                              "name": "armTrans",
+                              "fill": "$text-primary",
+                              "textGrowth": "fixed-width",
+                              "width": 120,
+                              "content": "骨架；电枢",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "HTTEZ",
+                              "name": "armDef",
+                              "fill": "$text-secondary",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "\"/ˈɑːrmətʃər/ noun. A framework or supporting structure, especially the hidden skeleton around which something is built; in technical use, it ca...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "WcaDB",
+                              "name": "armMeta",
+                              "gap": 16,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "8CXzo",
+                                  "name": "armDate",
+                                  "fill": "$text-muted",
+                                  "content": "1d ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "L2OwC",
+                                  "name": "armOpen",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "asai4",
+                                      "name": "armOpenText",
+                                      "fill": "$accent",
+                                      "content": "Open in Reader",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "tWuz5",
+                                      "name": "armOpenArrow",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "arrow-right",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$accent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "6Y0eZ",
+                          "name": "awning entry",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "gap": 24,
+                          "padding": [
+                            4,
+                            8,
+                            12,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "TN4sn",
+                              "name": "awnLeft",
+                              "width": 160,
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Qwhxw",
+                                  "name": "awnWord",
+                                  "fill": "$text-primary",
+                                  "content": "awning",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "c4YPx",
+                                  "name": "awnSrc",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "TIzpt",
+                                      "name": "awnSrcIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "book-open",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$text-muted"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "kjrFk",
+                                      "name": "awnSrcText",
+                                      "fill": "$text-muted",
+                                      "content": "Invisible Cities (transl. Will...",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "muzio",
+                              "name": "awnTrans",
+                              "fill": "$text-primary",
+                              "textGrowth": "fixed-width",
+                              "width": 120,
+                              "content": "遮阳篷",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "vHz7g",
+                              "name": "awnDef",
+                              "fill": "$text-secondary",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "\"/ˈɔːnɪŋ/ noun. A covering, usually made of cloth or metal, fixed above a window, door, or outdoor area to provide shade or shelter from rain. He...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "AcbPp",
+                              "name": "awnMeta",
+                              "gap": 16,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "DTJLP",
+                                  "name": "awnDate",
+                                  "fill": "$text-muted",
+                                  "content": "1d ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "tQGQY",
+                                  "name": "awnOpen",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "UJpv3",
+                                      "name": "awnOpenText",
+                                      "fill": "$accent",
+                                      "content": "Open in Reader",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "XB9NS",
+                                      "name": "awnOpenArrow",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "arrow-right",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$accent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ozh3I",
+                          "name": "astringent entry",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "gap": 24,
+                          "padding": [
+                            4,
+                            8,
+                            12,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "uyNPt",
+                              "name": "astLeft",
+                              "width": 160,
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "0FI7U",
+                                  "name": "astWord",
+                                  "fill": "$text-primary",
+                                  "content": "astringent",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "3K1MK",
+                                  "name": "astSrc",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "YbXpQ",
+                                      "name": "astSrcIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "book-open",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$text-muted"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "fI3G6",
+                                      "name": "astSrcText",
+                                      "fill": "$text-muted",
+                                      "content": "Fight Club",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "rzD2L",
+                              "name": "astTrans",
+                              "fill": "$text-primary",
+                              "textGrowth": "fixed-width",
+                              "width": 120,
+                              "content": "收敛剂；涩的",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "R5Avv",
+                              "name": "astDef",
+                              "fill": "$text-secondary",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "\"/əˈstrɪn.dʒənt/ adjective (also noun): Causing tissues to contract or tighten; in skincare, it refers to a substance that reduces oiliness and tigh...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "hLuC5",
+                              "name": "astMeta",
+                              "gap": 16,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Xuxhx",
+                                  "name": "astDate",
+                                  "fill": "$text-muted",
+                                  "content": "6d ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "k14YI",
+                                  "name": "astOpen",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "DPeQF",
+                                      "name": "astOpenText",
+                                      "fill": "$accent",
+                                      "content": "Open in Reader",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "fcBJy",
+                                      "name": "astOpenArrow",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "arrow-right",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$accent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "exJ7H",
+                          "name": "Arson entry",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "gap": 24,
+                          "padding": [
+                            4,
+                            8,
+                            12,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "4msSf",
+                              "name": "arsLeft",
+                              "width": 160,
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "fkN4l",
+                                  "name": "arsWord",
+                                  "fill": "$text-primary",
+                                  "content": "Arson",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "xZmUy",
+                                  "name": "arsSrc",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "IcedD",
+                                      "name": "arsSrcIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "book-open",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$text-muted"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "rOuTR",
+                                      "name": "arsSrcText",
+                                      "fill": "$text-muted",
+                                      "content": "Fight Club",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "HLHOs",
+                              "name": "arsTrans",
+                              "fill": "$text-primary",
+                              "textGrowth": "fixed-width",
+                              "width": 120,
+                              "content": "纵火",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "JFgpE",
+                              "name": "arsDef",
+                              "fill": "$text-secondary",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "\"/ˈɑːr.sən/ (n.) The criminal act of deliberately setting fire to property, buildings, or land. It is typically treated as a serious offense because it c...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "v02n5",
+                              "name": "arsMeta",
+                              "gap": 16,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "OVBDS",
+                                  "name": "arsDate",
+                                  "fill": "$text-muted",
+                                  "content": "7d ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "vi1zd",
+                                  "name": "arsOpen",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "RWKx9",
+                                      "name": "arsOpenText",
+                                      "fill": "$accent",
+                                      "content": "Open in Reader",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "4TZmW",
+                                      "name": "arsOpenArrow",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "arrow-right",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$accent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "RTI4U",
+                          "name": "avarice entry",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "gap": 24,
+                          "padding": [
+                            4,
+                            8,
+                            12,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "qqcdM",
+                              "name": "avaLeft",
+                              "width": 160,
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "rKPzy",
+                                  "name": "avaWord",
+                                  "fill": "$text-primary",
+                                  "content": "avarice",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "jz1JW",
+                                  "name": "avaSrc",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "m0lar",
+                                      "name": "avaSrcIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "book-open",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$text-muted"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "zruh0",
+                                      "name": "avaSrcText",
+                                      "fill": "$text-muted",
+                                      "content": "Fight Club",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "9XOA6",
+                              "name": "avaTrans",
+                              "fill": "$text-primary",
+                              "textGrowth": "fixed-width",
+                              "width": 120,
+                              "content": "贪婪，贪财",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "sqaNP",
+                              "name": "avaDef",
+                              "fill": "$text-secondary",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "\"/ˈævərɪs/ noun. Extreme greed, especially for wealth or material gain; an excessive desire to possess more than one needs. Here \"avarice\" me...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "L4FoN",
+                              "name": "avaMeta",
+                              "gap": 16,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "NZoz6",
+                                  "name": "avaDate",
+                                  "fill": "$text-muted",
+                                  "content": "8d ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "FTvW3",
+                                  "name": "avaOpen",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "KOVZ3",
+                                      "name": "avaOpenText",
+                                      "fill": "$accent",
+                                      "content": "Open in Reader",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "BuOoq",
+                                      "name": "avaOpenArrow",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "arrow-right",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$accent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "C5sdt",
+                      "name": "Section B",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "3oW4m",
+                          "name": "B header",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "padding": [
+                            0,
+                            0,
+                            8,
+                            0
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "5P2dL",
+                              "name": "sectionBLetter",
+                              "fill": "$accent",
+                              "content": "B",
+                              "fontFamily": "Inter",
+                              "fontSize": 28,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "tWKta",
+                              "name": "sectionBCount",
+                              "fill": "$text-muted",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "GkqkW",
+                          "name": "banisters entry",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "gap": 24,
+                          "padding": [
+                            4,
+                            8,
+                            12,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ytjyl",
+                              "name": "banLeft",
+                              "width": 160,
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "6QpKO",
+                                  "name": "banWord",
+                                  "fill": "$text-primary",
+                                  "content": "banisters",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "lzZzf",
+                                  "name": "banSrc",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "ldufz",
+                                      "name": "banSrcIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "book-open",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$text-muted"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "pZhf0",
+                                      "name": "banSrcText",
+                                      "fill": "$text-muted",
+                                      "content": "Invisible Cities (transl. Will...",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "YcpkR",
+                              "name": "banTrans",
+                              "fill": "$text-primary",
+                              "textGrowth": "fixed-width",
+                              "width": 120,
+                              "content": "栏杆扶手",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "WUjXF",
+                              "name": "banDef",
+                              "fill": "$text-secondary",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "\"/ˈbænɪstərz/ noun (plural): the handrails and supporting posts along stairs or balconies, used for safety and support. Here, \"banisters\" means...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "6hLWE",
+                              "name": "banMeta",
+                              "gap": 16,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "yahyc",
+                                  "name": "banDate",
+                                  "fill": "$text-muted",
+                                  "content": "4d ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Uhkqc",
+                                  "name": "banOpen",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "2g36V",
+                                      "name": "banOpenText",
+                                      "fill": "$accent",
+                                      "content": "Open in Reader",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "4qKQ6",
+                                      "name": "banOpenArrow",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "arrow-right",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$accent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "0Qp5h",
+                          "name": "beseech entry",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "gap": 24,
+                          "padding": [
+                            4,
+                            8,
+                            12,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "KbMve",
+                              "name": "besLeft",
+                              "width": 160,
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "R4aqs",
+                                  "name": "besWord",
+                                  "fill": "$text-primary",
+                                  "content": "beseech",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "tDJkR",
+                                  "name": "besSrc",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "AAbUT",
+                                      "name": "besSrcIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "book-open",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$text-muted"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "KJciH",
+                                      "name": "besSrcText",
+                                      "fill": "$text-muted",
+                                      "content": "Invisible Cities (transl. Will...",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "vkiSY",
+                              "name": "besTrans",
+                              "fill": "$text-primary",
+                              "textGrowth": "fixed-width",
+                              "width": 120,
+                              "content": "恳求",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Pohsi",
+                              "name": "besDef",
+                              "fill": "$text-secondary",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "/bɪˈsiːtʃ/ verb. To beseech means to ask someone urgently and earnestly for something, often in an emotional or pleading way. \"Beseech\" carries a courtly, intimate tone...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "YExQ1",
+                              "name": "besMeta",
+                              "gap": 16,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "wvJHi",
+                                  "name": "besDate",
+                                  "fill": "$text-muted",
+                                  "content": "5d ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "z1nX5",
+                                  "name": "besOpen",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "5Wp4S",
+                                      "name": "besOpenText",
+                                      "fill": "$accent",
+                                      "content": "Open in Reader",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "QmIbu",
+                                      "name": "besOpenArrow",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "arrow-right",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$accent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "2Bssy",
+                          "name": "braziers entry",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "gap": 24,
+                          "padding": [
+                            4,
+                            8,
+                            12,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "KReod",
+                              "name": "braLeft",
+                              "width": 160,
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "qYfWQ",
+                                  "name": "braWord",
+                                  "fill": "$text-primary",
+                                  "content": "braziers",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "hD39c",
+                                  "name": "braSrc",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "UQMI8",
+                                      "name": "braSrcIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "book-open",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$text-muted"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "z9PXz",
+                                      "name": "braSrcText",
+                                      "fill": "$text-muted",
+                                      "content": "Invisible Cities (transl. Will...",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "IlPf8",
+                              "name": "braTrans",
+                              "fill": "$text-primary",
+                              "textGrowth": "fixed-width",
+                              "width": 120,
+                              "content": "火盆",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "6fDmB",
+                              "name": "braDef",
+                              "fill": "$text-secondary",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "\"/ˈbreɪʒərz/ noun (plural): metal containers that hold burning coals or wood, used for heating, cooking, or providing light. Here, \"braziers\" refe...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "D9uC5",
+                              "name": "braMeta",
+                              "gap": 16,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "BH949",
+                                  "name": "braDate",
+                                  "fill": "$text-muted",
+                                  "content": "5d ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "aOcD5",
+                                  "name": "braOpen",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "xnpXc",
+                                      "name": "braOpenText",
+                                      "fill": "$accent",
+                                      "content": "Open in Reader",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "PyOri",
+                                      "name": "braOpenArrow",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "arrow-right",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$accent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bF5my",
+                      "name": "Section C",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "yYvnC",
+                          "name": "C header",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "padding": [
+                            0,
+                            0,
+                            8,
+                            0
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "auSLV",
+                              "name": "sectionCLetter",
+                              "fill": "$accent",
+                              "content": "C",
+                              "fontFamily": "Inter",
+                              "fontSize": 28,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "hheEX",
+                              "name": "sectionCCount",
+                              "fill": "$text-muted",
+                              "content": "2",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "hnL5e",
+                          "name": "cornucopia entry",
+                          "width": "fill_container",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 1
+                            },
+                            "fill": "$border-light"
+                          },
+                          "gap": 24,
+                          "padding": [
+                            4,
+                            8,
+                            12,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "QbOBv",
+                              "name": "corLeft",
+                              "width": 160,
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "L3wbX",
+                                  "name": "corWord",
+                                  "fill": "$text-primary",
+                                  "content": "cornucopia",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "kUqan",
+                                  "name": "corSrc",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "5130Z",
+                                      "name": "corSrcIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "book-open",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$text-muted"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "Dkf2x",
+                                      "name": "corSrcText",
+                                      "fill": "$text-muted",
+                                      "content": "Invisible Cities (transl. Will...",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "Cbzuc",
+                              "name": "corTrans",
+                              "fill": "$text-primary",
+                              "textGrowth": "fixed-width",
+                              "width": 120,
+                              "content": "丰饶角；聚宝盆 /ˌkɔːrnjuˈkoʊpiə/",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "1Hb2J",
+                              "name": "corDef",
+                              "fill": "$text-secondary",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "\" noun. A cornucopia is a symbol shaped like a horn overflowing with fruits, flowers, or other a... \"Cornucopia\" here evokes an overflowing abundance, fitting Tamara's streets crowded with signs and symbols. Calvino uses it to suggest not ...",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "cVsZ1",
+                              "name": "corMeta",
+                              "gap": 16,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "uQQjI",
+                                  "name": "corDate",
+                                  "fill": "$text-muted",
+                                  "content": "1d ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "pchlP",
+                                  "name": "corOpen",
+                                  "gap": 4,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "9fizS",
+                                      "name": "corOpenText",
+                                      "fill": "$accent",
+                                      "content": "Open in Reader",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "icon_font",
+                                      "id": "e2R0g",
+                                      "name": "corOpenArrow",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "arrow-right",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "$accent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "9yWy1",
+      "x": 1540,
+      "y": 2504,
+      "name": "Vocab Detail (modal over dictionary)",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "layout": "none",
+      "children": [
+        {
+          "type": "rectangle",
+          "id": "rIyjh",
+          "x": 0,
+          "y": 0,
+          "name": "Dim backdrop",
+          "fill": "#00000066",
+          "width": 1440,
+          "height": 960
+        },
+        {
+          "type": "frame",
+          "id": "BNnxJ",
+          "x": 460,
+          "y": 120,
+          "name": "Modal",
+          "width": 520,
+          "fill": "$bg-surface",
+          "cornerRadius": 14,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000033",
+            "offset": {
+              "x": 0,
+              "y": 24
+            },
+            "blur": 48
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "s1Z4q",
+              "name": "Header",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$border-light"
+              },
+              "padding": [
+                20,
+                24,
+                16,
+                24
+              ],
+              "justifyContent": "space_between",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "9KOMY",
+                  "name": "headerLeft",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "qqbM6",
+                      "name": "Word row",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bVwH6",
+                          "name": "word",
+                          "fill": "$text-primary",
+                          "content": "cornucopia",
+                          "fontFamily": "Inter",
+                          "fontSize": 24,
+                          "fontWeight": "700",
+                          "letterSpacing": -0.3
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "NrPFf",
+                      "name": "pron",
+                      "fill": "$text-muted",
+                      "content": "/ˌkɔːrnjuˈkoʊpiə/ · noun",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "r4t2B",
+                  "name": "Close",
+                  "width": 28,
+                  "height": 28,
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "TgNEi",
+                      "name": "closeIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "h3iwf",
+              "name": "Body",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 20,
+              "padding": [
+                16,
+                24,
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "6e2JA",
+                  "name": "Source section",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "eFNjr",
+                      "name": "srcLabel",
+                      "fill": "$text-muted",
+                      "content": "SOURCE",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.4
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ItD6O",
+                      "name": "srcRow",
+                      "width": "fill_container",
+                      "fill": "$bg-muted",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border-light"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        14
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "tFDW7",
+                          "name": "srcLeft",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "AOIGi",
+                              "name": "srcIconBox",
+                              "width": 32,
+                              "height": 32,
+                              "fill": "$accent-bg",
+                              "cornerRadius": 8,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "SR8SM",
+                                  "name": "srcIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "book-open",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$accent"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "KJfSk",
+                              "name": "srcMeta",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "DaYKp",
+                                  "name": "srcTitle",
+                                  "fill": "$text-primary",
+                                  "content": "Invisible Cities",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "0f7JS",
+                                  "name": "srcSub",
+                                  "fill": "$text-muted",
+                                  "content": "Italo Calvino",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Bhj8g",
+                          "name": "srcOpen",
+                          "height": 32,
+                          "fill": "$accent",
+                          "cornerRadius": 8,
+                          "gap": 6,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "38wGr",
+                              "name": "srcOpenLabel",
+                              "fill": "$white",
+                              "content": "Open in Reader",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "L4sXk",
+                              "name": "srcOpenIcon",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "arrow-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "$white"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "c8Vb5",
+                  "name": "Definition section",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "6Oq8d",
+                      "name": "defLabel",
+                      "fill": "$text-muted",
+                      "content": "DEFINITION",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.4
+                    },
+                    {
+                      "type": "text",
+                      "id": "e9R3V",
+                      "name": "defText",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "A symbol shaped like a horn overflowing with fruits, flowers, or other abundance — originally a mythic goat's horn from Greek legend of the infant Zeus. In modern usage it refers metaphorically to any overflowing supply or abundance.",
+                      "lineHeight": 1.55,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "E1BHX",
+                      "name": "In this context card",
+                      "width": "fill_container",
+                      "fill": "$bg-muted",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border-light"
+                      },
+                      "layout": "vertical",
+                      "gap": 6,
+                      "padding": [
+                        12,
+                        14
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "odErp",
+                          "name": "inCtxLabel",
+                          "fill": "$text-muted",
+                          "content": "In this context",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "WL6zk",
+                          "name": "inCtxBody",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Here \"cornucopia\" evokes Tamara's overflowing streets crowded with signs and symbols. Calvino uses it to suggest not wealth but semiotic excess: every object speaks, and the city is drowning in meaning.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Pb4dr",
+                  "name": "Context section",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Rk0Ro",
+                      "name": "ctxLabel",
+                      "fill": "$text-muted",
+                      "content": "FROM THE BOOK",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.4
+                    },
+                    {
+                      "type": "frame",
+                      "id": "79Oak",
+                      "name": "ctxQuote",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "left": 2
+                        },
+                        "fill": "$lavender"
+                      },
+                      "padding": [
+                        6,
+                        0,
+                        6,
+                        14
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "e6pJV",
+                          "name": "ctxQuoteText",
+                          "fill": "$text-secondary",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "\"The walls enclose a cornucopia of columns, domes, and steeples — a city stacked on a city, where every surface is signed with its own name.\"",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal",
+                          "fontStyle": "italic"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "273tO",
+              "name": "Footer",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "$border-light"
+              },
+              "padding": [
+                12,
+                20
+              ],
+              "justifyContent": "end",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ESIH4",
+                  "name": "Delete",
+                  "height": 32,
+                  "cornerRadius": 6,
+                  "gap": 6,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Qml6u",
+                      "name": "delIcon",
+                      "width": 15,
+                      "height": 15,
+                      "iconFontName": "trash-2",
+                      "iconFontFamily": "lucide",
+                      "fill": "$danger"
+                    },
+                    {
+                      "type": "text",
+                      "id": "XLf94",
+                      "name": "delLabel",
+                      "fill": "$danger",
+                      "content": "Delete",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "3wejV",
+      "x": 1540,
+      "y": 3633,
+      "name": "Chat Detail View",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "children": [
+        {
+          "type": "frame",
+          "id": "7W72Z",
+          "name": "Sidebar",
+          "clip": true,
+          "width": 224,
+          "height": "fill_container",
+          "fill": "$bg-muted",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "$border"
+          },
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            0,
+            16,
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "Wx4Tb",
+              "name": "Logo row",
+              "gap": 10,
+              "padding": [
+                44,
+                0,
+                8,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Pe9ma",
+                  "name": "Logo",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "$accent",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "bJnVf",
+                      "name": "logoIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "feather",
+                      "iconFontFamily": "lucide",
+                      "fill": "$white"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "ENvLy",
+                  "name": "logoText",
+                  "fill": "$text-primary",
+                  "content": "Quill",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.5
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vRVYy",
+              "name": "Library section",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "m8QPt",
+                  "name": "libHeader",
+                  "fill": "$text-muted",
+                  "content": "LIBRARY",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.3
+                },
+                {
+                  "type": "frame",
+                  "id": "lTVLm",
+                  "name": "Library items",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "VESQc",
+                      "name": "All Books",
+                      "width": "fill_container",
+                      "height": 36,
+                      "fill": {
+                        "type": "color",
+                        "color": "#ffffff",
+                        "enabled": false
+                      },
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "1aCdw",
+                          "name": "allBooksLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "JB1Zh",
+                              "name": "allBooksIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "library",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "KmUGd",
+                              "name": "allBooksLabel",
+                              "fill": "$text-secondary",
+                              "content": "All Books",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "3LhuZ",
+                          "name": "allBooksCount",
+                          "fill": "$text-muted",
+                          "content": "40",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qOaXr",
+                      "name": "Currently Reading",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "itS95",
+                          "name": "readingLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "e6m6D",
+                              "name": "readingIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "book-open",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "MVjuB",
+                              "name": "readingLabel",
+                              "fill": "$text-secondary",
+                              "content": "Currently Reading",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "joqGT",
+                          "name": "readingCount",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Eubxn",
+                      "name": "Finished",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "pzHFV",
+                          "name": "finishedLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Thu82",
+                              "name": "finishedIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "circle-check",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "p6fkr",
+                              "name": "finishedLabel",
+                              "fill": "$text-secondary",
+                              "content": "Finished",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "7ptUO",
+                          "name": "finishedCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "5dmoO",
+              "name": "Tools section",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "QnMWT",
+                  "name": "toolsHeader",
+                  "fill": "$text-muted",
+                  "content": "TOOLS",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.3
+                },
+                {
+                  "type": "frame",
+                  "id": "m3sII",
+                  "name": "toolsList",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "5BeAP",
+                      "name": "Dictionary",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Oz4z8",
+                          "name": "dictIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "book-a",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "g3q21",
+                          "name": "dictLabel",
+                          "fill": "$text-secondary",
+                          "content": "Dictionary",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OcpUs",
+                      "name": "Chats (active)",
+                      "width": "fill_container",
+                      "height": 36,
+                      "fill": "$accent-bg",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "A1GKG",
+                          "name": "chatsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "message-square",
+                          "iconFontFamily": "lucide",
+                          "fill": "$accent"
+                        },
+                        {
+                          "type": "text",
+                          "id": "mJyPq",
+                          "name": "chatsLabel",
+                          "fill": "$accent",
+                          "content": "Chats",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "utlLv",
+                      "name": "Translations",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "r3GIX",
+                          "name": "transIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "globe",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "c5208",
+                          "name": "transLabel",
+                          "fill": "$text-secondary",
+                          "content": "Translations",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "nKUAY",
+              "name": "Collections section",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "hLnRo",
+                  "name": "Collections header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "yi1Na",
+                      "name": "colsHeader",
+                      "fill": "$text-muted",
+                      "content": "COLLECTIONS",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.3
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "Us9OS",
+                      "name": "colsPlus",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "o6d0u",
+                  "name": "Collections list",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "LiwI4",
+                      "name": "Fiction",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "YKzTi",
+                          "name": "fictionLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "qVxTI",
+                              "name": "fictionGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "iJhpN",
+                              "name": "fictionIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "xTN8T",
+                              "name": "fictionLabel",
+                              "fill": "$text-secondary",
+                              "content": "Fiction",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "IxVoc",
+                          "name": "fictionCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ECohi",
+                      "name": "Scifi",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "TvwgS",
+                          "name": "scifiLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "xi7XW",
+                              "name": "scifiGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "3G8MS",
+                              "name": "scifiIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "ZFtjo",
+                              "name": "scifiLabel",
+                              "fill": "$text-secondary",
+                              "content": "Scifi",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "XvLxM",
+                          "name": "scifiCount",
+                          "fill": "$text-muted",
+                          "content": "5",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XJZs9",
+                      "name": "History",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "TbpXp",
+                          "name": "historyLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Ch0aN",
+                              "name": "historyGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "EQhef",
+                              "name": "historyIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "CllSs",
+                              "name": "historyLabel",
+                              "fill": "$text-secondary",
+                              "content": "History",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "HIVW8",
+                          "name": "historyCount",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "p5mBu",
+                      "name": "Chinese",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ctfU2",
+                          "name": "chineseLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "hrFrS",
+                              "name": "chineseGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "PVzcM",
+                              "name": "chineseIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "i6PTt",
+                              "name": "chineseLabel",
+                              "fill": "$text-secondary",
+                              "content": "Chinese",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "9Zb2Z",
+                          "name": "chineseCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "acHJX",
+                      "name": "Russian",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Zi7ov",
+                          "name": "russianLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "YFuLA",
+                              "name": "russianGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "VifIW",
+                              "name": "russianIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "xOZUy",
+                              "name": "russianLabel",
+                              "fill": "$text-secondary",
+                              "content": "Russian",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "uN9OZ",
+                          "name": "russianCount",
+                          "fill": "$text-muted",
+                          "content": "2",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L16tR",
+                      "name": "Japanese",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "k1Mju",
+                          "name": "japaneseLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "GB0rh",
+                              "name": "japaneseGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "YgHNh",
+                              "name": "japaneseIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Xod94",
+                              "name": "japaneseLabel",
+                              "fill": "$text-secondary",
+                              "content": "Japanese",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "L9hI8",
+                          "name": "japaneseCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bExxe",
+                      "name": "Fashion",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "6kxol",
+                          "name": "fashionLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "chZIL",
+                              "name": "fashionGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "OESjh",
+                              "name": "fashionIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "EU3e2",
+                              "name": "fashionLabel",
+                              "fill": "$text-secondary",
+                              "content": "Fashion",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "Jf0Mj",
+                          "name": "fashionCount",
+                          "fill": "$text-muted",
+                          "content": "5",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kJw59",
+                      "name": "Music",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "naVyK",
+                          "name": "musicLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "cXYeR",
+                              "name": "musicGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "S5piJ",
+                              "name": "musicIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "7YjfZ",
+                              "name": "musicLabel",
+                              "fill": "$text-secondary",
+                              "content": "Music",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "sXOt5",
+                          "name": "musicCount",
+                          "fill": "$text-muted",
+                          "content": "2",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jEM6p",
+                      "name": "Computer Science",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "vXFyl",
+                          "name": "csLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "ZgU0B",
+                              "name": "csGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "vB38w",
+                              "name": "csIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "PEmjm",
+                              "name": "csLabel",
+                              "fill": "$text-secondary",
+                              "content": "Computer Science",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "zttrY",
+                          "name": "csCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Pl0yo",
+              "name": "User profile",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "padding": [
+                12,
+                0,
+                0,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "aS8TU",
+                  "name": "User button",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "wYQtr",
+                      "name": "Avatar",
+                      "width": 28,
+                      "height": 28,
+                      "fill": "$accent",
+                      "cornerRadius": 9999,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "4qyhL",
+                          "name": "userAvatarText",
+                          "fill": "$white",
+                          "content": "J",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "tlqch",
+                      "name": "userInfo",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "KXwr8",
+                          "name": "userName",
+                          "fill": "$text-primary",
+                          "content": "Jason",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "S8FPL",
+                          "name": "userSub",
+                          "fill": "$text-muted",
+                          "content": "Settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Vn7hp",
+          "name": "Main content",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg-muted",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "BAGib",
+              "name": "Chat Detail Header",
+              "width": "fill_container",
+              "fill": "$bg-surface",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$border"
+              },
+              "padding": [
+                44,
+                24,
+                12,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "21Zu8",
+                  "name": "Header left",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "vAVyb",
+                      "name": "Back button",
+                      "width": 28,
+                      "height": 28,
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "v61gr",
+                          "name": "backIcon",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "arrow-left",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jELAG",
+                      "name": "Title column",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "q3K2j",
+                          "name": "titleText",
+                          "fill": "$text-primary",
+                          "content": "Tyler Explains Harsh Initiation Test",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.23
+                        },
+                        {
+                          "type": "text",
+                          "id": "F6aQh",
+                          "name": "bookLabel",
+                          "fill": "$text-muted",
+                          "content": "Fight Club",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "pjQId",
+                  "name": "Header right",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "litrB",
+                      "name": "Open in Reader",
+                      "height": 28,
+                      "fill": "$accent-bg",
+                      "cornerRadius": 10,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "a6qfZ",
+                          "name": "openLabel",
+                          "fill": "$accent",
+                          "content": "Open in Reader",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.06
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "sMob1",
+                          "name": "openArrow",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "arrow-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$accent"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "C8DBV",
+                      "name": "Delete button",
+                      "width": 28,
+                      "height": 28,
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "IjUJW",
+                          "name": "delIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "trash-2",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "NIObc",
+              "name": "Messages",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$bg-muted",
+              "layout": "vertical",
+              "gap": 12,
+              "padding": [
+                16,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "U19TE",
+                  "name": "User context msg",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "alignItems": "end",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "pRpxa",
+                      "name": "Context quote",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "left": 2
+                        },
+                        "fill": "$lavender"
+                      },
+                      "padding": [
+                        2,
+                        0,
+                        2,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QnyAW",
+                          "name": "ctxTxt",
+                          "fill": "$text-muted",
+                          "textGrowth": "fixed-width",
+                          "width": 500,
+                          "content": "This is how Buddhist temples have tested applicants going back for bah-zillion years, Tyler says. You tell the applicant to go away, and if...",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal",
+                          "fontStyle": "italic"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Otr4w",
+                      "name": "Explain bubble",
+                      "fill": "$user-bubble",
+                      "cornerRadius": 8,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "9M4ZD",
+                          "name": "uBubTxt1",
+                          "fill": "$text-primary",
+                          "content": "Explain",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "CnLMn",
+                  "name": "Assistant msg",
+                  "fill": "$bg-surface",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border"
+                  },
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": 13,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "i65SS",
+                      "name": "ap1",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": 700,
+                      "content": "In this passage, Tyler is justifying the harsh \"test\" he gives new recruits by comparing it to an old spiritual tradition.",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "XtQO1",
+                      "name": "ah1",
+                      "fill": "$text-primary",
+                      "content": "What he's saying",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "R1jQ0",
+                      "name": "ap2",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": 700,
+                      "content": "He claims Buddhist temples used to test people by rejecting them at first. Only if someone waited outside for days—hungry, uncomfortable, ignored—would they be accepted for training.",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "0LGXK",
+                      "name": "ah2",
+                      "fill": "$text-primary",
+                      "content": "Why this matters in Fight Club",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "71y12",
+                      "name": "ap3",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": 700,
+                      "content": "Tyler is using this idea to support his philosophy: commitment must be proven through suffering, only the truly devoted deserve entry, and ego gets stripped away by humiliation and endurance.",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ytVHA",
+                      "name": "ap4",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": 700,
+                      "content": "It turns Project Mayhem into something like a cult initiation: people must show total obedience before belonging.",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KBlmi",
+                  "name": "User msg 2",
+                  "width": "fill_container",
+                  "justifyContent": "end",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dHCXZ",
+                      "name": "userMsg2",
+                      "fill": "$user-bubble",
+                      "cornerRadius": 8,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "3dg9z",
+                          "name": "uTxt2",
+                          "fill": "$text-primary",
+                          "content": "Interesting — a lot of current society still works like this",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Q3149",
+                  "name": "Assistant msg 2",
+                  "fill": "$bg-surface",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border"
+                  },
+                  "layout": "vertical",
+                  "gap": 6,
+                  "padding": 13,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "BzPGt",
+                      "name": "a2p1",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": 700,
+                      "content": "Absolutely — you're picking up on one of the novel's biggest points.",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "vrScI",
+                      "name": "a2p2",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": 700,
+                      "content": "I think you're starting to say: a lot of current society still works like this — people are made to \"prove\" themselves through stress, rejection, and grind before they're accepted.",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "WyxDO",
+              "name": "Input bar",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": [
+                17,
+                24,
+                16,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "YwqwV",
+                  "name": "Input row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ldGhV",
+                      "name": "Input box",
+                      "width": "fill_container",
+                      "height": 60,
+                      "fill": "$bg-input",
+                      "cornerRadius": 8,
+                      "layout": "vertical",
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "voNlT",
+                          "name": "placeholder",
+                          "fill": "$text-placeholder",
+                          "content": "Ask anything about this conversation...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uTL1H",
+                      "name": "Send",
+                      "width": 60,
+                      "height": 60,
+                      "fill": "$accent",
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "rATYs",
+                          "name": "sendIcn",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "send",
+                          "iconFontFamily": "lucide",
+                          "fill": "$white"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Gdxnf",
+                  "name": "hint",
+                  "fill": "$text-muted",
+                  "content": "Press Enter to send, Shift+Enter for new line",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "DnQnD",
+      "x": 0,
+      "y": 3633,
+      "name": "Chat List View",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "children": [
+        {
+          "type": "frame",
+          "id": "z4BWj",
+          "name": "Sidebar",
+          "clip": true,
+          "width": 224,
+          "height": "fill_container",
+          "fill": "$bg-muted",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "$border"
+          },
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            0,
+            16,
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "yTQq4",
+              "name": "Logo row",
+              "gap": 10,
+              "padding": [
+                44,
+                0,
+                8,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fUUBs",
+                  "name": "Logo",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "$accent",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "zOiUP",
+                      "name": "logoIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "feather",
+                      "iconFontFamily": "lucide",
+                      "fill": "$white"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "OIMZj",
+                  "name": "logoText",
+                  "fill": "$text-primary",
+                  "content": "Quill",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.5
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "En2Vg",
+              "name": "Library section",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "XgySQ",
+                  "name": "libHeader",
+                  "fill": "$text-muted",
+                  "content": "LIBRARY",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.3
+                },
+                {
+                  "type": "frame",
+                  "id": "MoqRZ",
+                  "name": "Library items",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BO75d",
+                      "name": "All Books",
+                      "width": "fill_container",
+                      "height": 36,
+                      "fill": {
+                        "type": "color",
+                        "color": "#ffffff",
+                        "enabled": false
+                      },
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "U7pNU",
+                          "name": "allBooksLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "vv1CD",
+                              "name": "allBooksIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "library",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "YDSVS",
+                              "name": "allBooksLabel",
+                              "fill": "$text-secondary",
+                              "content": "All Books",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "OilWO",
+                          "name": "allBooksCount",
+                          "fill": "$text-muted",
+                          "content": "40",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "8aFUu",
+                      "name": "Currently Reading",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hple2",
+                          "name": "readingLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "aKcgT",
+                              "name": "readingIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "book-open",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "uMp4y",
+                              "name": "readingLabel",
+                              "fill": "$text-secondary",
+                              "content": "Currently Reading",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "1Ld92",
+                          "name": "readingCount",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jOM5N",
+                      "name": "Finished",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "vZhDp",
+                          "name": "finishedLeft",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "iooBR",
+                              "name": "finishedIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "circle-check",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "laAjn",
+                              "name": "finishedLabel",
+                              "fill": "$text-secondary",
+                              "content": "Finished",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "VWvXe",
+                          "name": "finishedCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "kI61B",
+              "name": "Tools section",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "AsWPy",
+                  "name": "toolsHeader",
+                  "fill": "$text-muted",
+                  "content": "TOOLS",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.3
+                },
+                {
+                  "type": "frame",
+                  "id": "DBesc",
+                  "name": "toolsList",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "B5yEy",
+                      "name": "Dictionary",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "SkWVB",
+                          "name": "dictIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "book-a",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ODmIp",
+                          "name": "dictLabel",
+                          "fill": "$text-secondary",
+                          "content": "Dictionary",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "b9SJV",
+                      "name": "Chats (active)",
+                      "width": "fill_container",
+                      "height": 36,
+                      "fill": "$accent-bg",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "SZwc7",
+                          "name": "chatsIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "message-square",
+                          "iconFontFamily": "lucide",
+                          "fill": "$accent"
+                        },
+                        {
+                          "type": "text",
+                          "id": "xa2Kb",
+                          "name": "chatsLabel",
+                          "fill": "$accent",
+                          "content": "Chats",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ygmFe",
+                      "name": "Translations",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "GFTAD",
+                          "name": "transIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "globe",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "SbYUQ",
+                          "name": "transLabel",
+                          "fill": "$text-secondary",
+                          "content": "Translations",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": -0.15
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "3pWu1",
+              "name": "Collections section",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EDy30",
+                  "name": "Collections header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "gQFqf",
+                      "name": "colsHeader",
+                      "fill": "$text-muted",
+                      "content": "COLLECTIONS",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.3
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "4PCUn",
+                      "name": "colsPlus",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "US5nQ",
+                  "name": "Collections list",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "DoonC",
+                      "name": "Fiction",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "yc3IM",
+                          "name": "fictionLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "V5aWk",
+                              "name": "fictionGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "MmAaI",
+                              "name": "fictionIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "ggf7r",
+                              "name": "fictionLabel",
+                              "fill": "$text-secondary",
+                              "content": "Fiction",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "tSObn",
+                          "name": "fictionCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Zms81",
+                      "name": "Scifi",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "3sGLW",
+                          "name": "scifiLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "TILX2",
+                              "name": "scifiGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "NhOJI",
+                              "name": "scifiIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "7gCv8",
+                              "name": "scifiLabel",
+                              "fill": "$text-secondary",
+                              "content": "Scifi",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "nmynl",
+                          "name": "scifiCount",
+                          "fill": "$text-muted",
+                          "content": "5",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Jml2C",
+                      "name": "History",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "1vV4U",
+                          "name": "historyLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "SQ16s",
+                              "name": "historyGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "7WKNt",
+                              "name": "historyIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "0FPm0",
+                              "name": "historyLabel",
+                              "fill": "$text-secondary",
+                              "content": "History",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "MFqYf",
+                          "name": "historyCount",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Hqx3v",
+                      "name": "Chinese",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "r86re",
+                          "name": "chineseLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "UF1zz",
+                              "name": "chineseGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "bQVsM",
+                              "name": "chineseIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "r7r6B",
+                              "name": "chineseLabel",
+                              "fill": "$text-secondary",
+                              "content": "Chinese",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "Xu6eT",
+                          "name": "chineseCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ouypD",
+                      "name": "Russian",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "gSesb",
+                          "name": "russianLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Yk4xP",
+                              "name": "russianGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "a83Dh",
+                              "name": "russianIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "aTrRn",
+                              "name": "russianLabel",
+                              "fill": "$text-secondary",
+                              "content": "Russian",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "JgU3A",
+                          "name": "russianCount",
+                          "fill": "$text-muted",
+                          "content": "2",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UmvfX",
+                      "name": "Japanese",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "IhS2w",
+                          "name": "japaneseLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "6hEAa",
+                              "name": "japaneseGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "XcB2n",
+                              "name": "japaneseIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "nrHbG",
+                              "name": "japaneseLabel",
+                              "fill": "$text-secondary",
+                              "content": "Japanese",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "XU0a4",
+                          "name": "japaneseCount",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HfhdU",
+                      "name": "Fashion",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "BB6Lo",
+                          "name": "fashionLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "EPD0q",
+                              "name": "fashionGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "uQe9C",
+                              "name": "fashionIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "pD85k",
+                              "name": "fashionLabel",
+                              "fill": "$text-secondary",
+                              "content": "Fashion",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "UgCy3",
+                          "name": "fashionCount",
+                          "fill": "$text-muted",
+                          "content": "5",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VAqhR",
+                      "name": "Music",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "rysT0",
+                          "name": "musicLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "mNwqt",
+                              "name": "musicGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "Ik3Aj",
+                              "name": "musicIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "EKi5X",
+                              "name": "musicLabel",
+                              "fill": "$text-secondary",
+                              "content": "Music",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "KEXxY",
+                          "name": "musicCount",
+                          "fill": "$text-muted",
+                          "content": "2",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "9nRp1",
+                      "name": "Computer Science",
+                      "width": "fill_container",
+                      "height": 36,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        4
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "DkjXz",
+                          "name": "csLeft",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "ZUqho",
+                              "name": "csGrip",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "grip-vertical",
+                              "iconFontFamily": "lucide",
+                              "fill": "#71717b66"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "FmvVp",
+                              "name": "csIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$text-muted"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Z1HBL",
+                              "name": "csLabel",
+                              "fill": "$text-secondary",
+                              "content": "Computer Science",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "XKx9d",
+                          "name": "csCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yl5ZU",
+              "name": "User profile",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "padding": [
+                12,
+                0,
+                0,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "X6wbi",
+                  "name": "User button",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    6,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ROTuK",
+                      "name": "Avatar",
+                      "width": 28,
+                      "height": 28,
+                      "fill": "$accent",
+                      "cornerRadius": 9999,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SSqjA",
+                          "name": "userAvatarText",
+                          "fill": "$white",
+                          "content": "J",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cqN80",
+                      "name": "userInfo",
+                      "layout": "vertical",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mrXLY",
+                          "name": "userName",
+                          "fill": "$text-primary",
+                          "content": "Jason",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "goq35",
+                          "name": "userSub",
+                          "fill": "$text-muted",
+                          "content": "Settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "FNxLn",
+          "name": "Main content",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg-surface",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "7XYSl",
+              "name": "Header",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "gap": 16,
+              "padding": [
+                44,
+                24,
+                12,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "hgiYW",
+                  "name": "Title row",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "H63By",
+                      "name": "title",
+                      "fill": "$text-primary",
+                      "content": "Chats",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.07
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vSJZJ",
+                  "name": "Search",
+                  "width": 448,
+                  "height": 36,
+                  "fill": "$bg-input",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ihtNp",
+                      "name": "searchIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "7AC2l",
+                      "name": "searchText",
+                      "fill": "$text-placeholder",
+                      "content": "Search chats...",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "9FmN9",
+              "name": "Filter pills row",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$border"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                24
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "LFQPt",
+                  "name": "All Books pill",
+                  "height": 32,
+                  "fill": "$accent-bg",
+                  "cornerRadius": 9999,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#7c3aed4d"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "mcBTX",
+                      "name": "allIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "lVJk8",
+                      "name": "allLabel",
+                      "fill": "$accent",
+                      "content": "All Books",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Rh4AU",
+                      "name": "allCount",
+                      "fill": "$accent",
+                      "content": "15",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "uLE81",
+                  "name": "Fight Club pill",
+                  "height": 32,
+                  "fill": "$bg-surface",
+                  "cornerRadius": 9999,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "wW19D",
+                      "name": "fcIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "6kIJF",
+                      "name": "fcLabel",
+                      "fill": "$text-secondary",
+                      "content": "Fight Club",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "N54pw",
+                      "name": "fcCount",
+                      "fill": "$text-muted",
+                      "content": "8",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "cBg1P",
+                  "name": "Invisible Cities pill",
+                  "height": 32,
+                  "fill": "$bg-surface",
+                  "cornerRadius": 9999,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "EKtjK",
+                      "name": "icIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qHiXD",
+                      "name": "icLabel",
+                      "fill": "$text-secondary",
+                      "content": "Invisible Cities (Ita...",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "j2bnM",
+                      "name": "icCount",
+                      "fill": "$text-muted",
+                      "content": "4",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jnsil",
+                  "name": "Blindsight pill",
+                  "height": 32,
+                  "fill": "$bg-surface",
+                  "cornerRadius": 9999,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "QYTMl",
+                      "name": "bsIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "wPrGR",
+                      "name": "bsLabel",
+                      "fill": "$text-secondary",
+                      "content": "Blindsight",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "vDcH1",
+                      "name": "bsCount",
+                      "fill": "$text-muted",
+                      "content": "3",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mfsfI",
+                  "name": "spacer",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "3iiQx",
+                  "name": "Sort buttons",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "SBkmx",
+                      "name": "Newest",
+                      "height": 28,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "cNcgc",
+                          "name": "newestIcon",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "arrow-down-wide-narrow",
+                          "iconFontFamily": "lucide",
+                          "fill": "$accent"
+                        },
+                        {
+                          "type": "text",
+                          "id": "rNg5K",
+                          "name": "newestLabel",
+                          "fill": "$accent",
+                          "content": "Newest",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qrfK3",
+                      "name": "Oldest",
+                      "height": 28,
+                      "cornerRadius": 8,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "QHPOw",
+                          "name": "oldestIcon",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "arrow-up-wide-narrow",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Qkdv8",
+                          "name": "oldestLabel",
+                          "fill": "$text-muted",
+                          "content": "Oldest",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OOjIf",
+              "name": "Chat list scroll",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 24,
+              "padding": 24,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Lb3ZJ",
+                  "name": "Fight Club group",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ZiFff",
+                      "name": "Book header",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        0,
+                        8,
+                        0
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "wR8gl",
+                          "name": "Book header left",
+                          "gap": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "jqTCa",
+                              "name": "fcHdrIcon",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "book-open",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            },
+                            {
+                              "type": "text",
+                              "id": "pZe15",
+                              "name": "fcHdrTitle",
+                              "fill": "$accent",
+                              "content": "Fight Club",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "npoiI",
+                          "name": "divider",
+                          "width": "fill_container",
+                          "height": 1,
+                          "fill": "$border-light"
+                        },
+                        {
+                          "type": "text",
+                          "id": "XehzH",
+                          "name": "fcHdrCount",
+                          "fill": "$text-muted",
+                          "content": "8",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "E6OD2",
+                      "name": "Chat item",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "FwnQl",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "LlvzR",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "wEljH",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "wAy14",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "tY5Qm",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Chapter 10 Core Tension",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "phkns",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "SGx4R",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "14",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "N4z6H",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: It's a big one. Without spoiling ahead, this chapter has...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "lhdiG",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "AeKjo",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "2h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "d4unB",
+                      "name": "fc2",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "zUmtN",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "YjVwI",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "IOsi3",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "FxnsN",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "wxXym",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Compliance and Liability Identity",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "KFITs",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "gUSnS",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "8",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "GP5p8",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: This passage shows fight club changing from a chaotic gathering into a \"system\"...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ViPB3",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "z3AFg",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "3h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hFLsw",
+                      "name": "fc3",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "edHvL",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "k6WEU",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "H3rE7",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "W5ACK",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "K31Fp",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Tyler Explains Harsh Initiation Test",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "3RYZ1",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "3wFgC",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "12",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "dQvU9",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: In Angel Clutch \"Project Mayhem\" are Tyler's bar-reading Project Mayhem doc...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qqr3w",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "7wd6z",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "5h ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HC3Bb",
+                      "name": "fc4",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "nKKnm",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "3SlEr",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "I8X3T",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "4ij89",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "xs42q",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Dark Sarcastic Nihilistic Outburst",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "IHBwe",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "7NC2D",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "6",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "iwfJe",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: When Tyler says \"self-destruction/self-improvement\" ? Tyler even: reject people who...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "WJqCs",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "rn5vs",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "1d ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "eZD6s",
+                      "name": "fc5",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "4Q4sc",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "o4ulZ",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "4qFFO",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "m12SG",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "bKWtG",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Invisible Man Title Satire",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "KVung",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "1UCat",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "4",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "W9UtZ",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: This is Tylercharleton rage language taken to an extreme. It's intentionally ug...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "AIQcJ",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "XKW7H",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "2d ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lgqn4",
+                      "name": "fc6",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dh4rh",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "vaA4z",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "oi8dP",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "sgCDf",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "gpZ7S",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Musashi Poem Interpretation",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "acd1p",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "ppYMU",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "10",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "3U5Rm",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: This describes a \"self-destruction spiritual practice\"— This parallels hist...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qHCr1",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "MiMvf",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "3d ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zuE03",
+                  "name": "Invisible Cities group",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hdxho",
+                      "name": "Book header",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        0,
+                        8,
+                        0
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "5PDiL",
+                          "name": "Book header left",
+                          "gap": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "g4aLq",
+                              "name": "icHdrIcon",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "book-open",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            },
+                            {
+                              "type": "text",
+                              "id": "u4HQp",
+                              "name": "icHdrTitle",
+                              "fill": "$accent",
+                              "content": "Invisible Cities (transl. William Weaver)",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ImvAU",
+                          "name": "divider",
+                          "width": "fill_container",
+                          "height": 1,
+                          "fill": "$border-light"
+                        },
+                        {
+                          "type": "text",
+                          "id": "3P0x5",
+                          "name": "icHdrCount",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IM1JT",
+                      "name": "ic1",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ZXyvg",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "bNnI4",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "9Xz8W",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "hzsIk",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "tZcjj",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Calvino Zara Memory Meditation",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "wQ6LC",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Wbcma",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "6",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "J8WT6",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: Yes the beauty of this piece: it sits much step perfectly fits...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "6UrUV",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "6JJQ9",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "1d ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "B6r7c",
+                      "name": "ic2",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "m07sm",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "nHUoe",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "URdmx",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "h400S",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "QwNeD",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Calvino Passage Interpretation",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "xxT0q",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "4liH4",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "4",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "SgF57",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: Calvino is describing a basic human habit \"See shapes meaning as randomness\"...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "1Mp8u",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Q0rBP",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "3d ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HdeRP",
+                      "name": "ic3",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Link0",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "3JKm1",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "EiMzx",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "pU3H9",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "nNAK0",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Kublai Khan Listening to Marco",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "KagfW",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "AGYkT",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "8",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "pMf7N",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: This key section. When a traveler arrives in that city at dusk, everything feels...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ahr6w",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "jww8X",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "5d ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ECqaR",
+                  "name": "Blindsight group",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "jZrjt",
+                      "name": "Book header",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        0,
+                        8,
+                        0
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "tb5Et",
+                          "name": "Book header left",
+                          "gap": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "5Vg5p",
+                              "name": "bsHdrIcon",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "book-open",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            },
+                            {
+                              "type": "text",
+                              "id": "LSweE",
+                              "name": "bsHdrTitle",
+                              "fill": "$accent",
+                              "content": "Blindsight",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jhrH8",
+                          "name": "divider",
+                          "width": "fill_container",
+                          "height": 1,
+                          "fill": "$border-light"
+                        },
+                        {
+                          "type": "text",
+                          "id": "2Ehr8",
+                          "name": "bsHdrCount",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ifX7N",
+                      "name": "bs1",
+                      "width": "fill_container",
+                      "cornerRadius": 10,
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dC3G2",
+                          "name": "Icon box",
+                          "width": 36,
+                          "height": 36,
+                          "fill": "$accent-bg",
+                          "cornerRadius": 10,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#7c3aed33"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "8wiZE",
+                              "name": "sparkle1",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "sparkles",
+                              "iconFontFamily": "lucide",
+                              "fill": "$accent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TiTF8",
+                          "name": "Text col",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "3gR4W",
+                              "name": "Title row",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Fg60R",
+                                  "name": "t1",
+                                  "fill": "$text-primary",
+                                  "content": "Cryptic Sci Fi Opening",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600",
+                                  "letterSpacing": -0.08
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "kDAwZ",
+                                  "name": "Msg badge",
+                                  "height": 18,
+                                  "fill": "$bg-input",
+                                  "cornerRadius": 9999,
+                                  "padding": [
+                                    0,
+                                    7
+                                  ],
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "IrXCz",
+                                      "name": "badgeTxt1",
+                                      "fill": "$text-muted",
+                                      "content": "3",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "J41pH",
+                              "name": "preview1",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "AI: Great opening—this passage is doing a lot in 3 lines. AKA What it means go...",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "MM2Cx",
+                          "name": "Meta row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "pmsKR",
+                              "name": "metaText",
+                              "fill": "$text-muted",
+                              "content": "1w ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "oo508",
+      "x": 0,
+      "y": 4793,
+      "name": "Settings / Language",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "layout": "none",
+      "children": [
+        {
+          "type": "rectangle",
+          "id": "gHrHc",
+          "x": 0,
+          "y": 0,
+          "name": "bg1",
+          "fill": "#00000066",
+          "width": 1440,
+          "height": 960
+        },
+        {
+          "type": "frame",
+          "id": "YaLjS",
+          "layoutPosition": "absolute",
+          "x": 460,
+          "y": 270,
+          "name": "Modal",
+          "theme": {
+            "Mode": "Light"
+          },
+          "clip": true,
+          "width": 520,
+          "height": 420,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000001A",
+            "offset": {
+              "x": 0,
+              "y": 8
+            },
+            "blur": 24
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "8pEHc",
+              "name": "sidebar",
+              "width": 170,
+              "fill": "#F9FAFB",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                16,
+                12
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "TacpI",
+                  "name": "stTitle",
+                  "fill": "#3F3F46",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "Kz4NT",
+                  "name": "i1",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "VnWz6",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dTG3r",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "a6jp4",
+                          "fill": "#3F3F46",
+                          "content": "General",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "du7hv",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Language & appearance",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "VdDHc",
+                  "name": "i2",
+                  "width": "fill_container",
+                  "fill": "#F3E8FF",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "H3QHI",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "globe",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A855F7"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "wzQXH",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "I9SIU",
+                          "fill": "#7C3AED",
+                          "content": "Language",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "5OS8w",
+                          "fill": "#A78BFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Interface language",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hHhCw",
+                  "name": "i3",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "0Oqu3",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "tqRhx",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "eE0CR",
+                          "fill": "#3F3F46",
+                          "content": "Reading",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "e1Ybp",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Font, spacing & layout",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "9wRxN",
+                  "name": "i4",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "FkvD8",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sparkles",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yztyt",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ibHLt",
+                          "fill": "#3F3F46",
+                          "content": "AI Assistant",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "jCz9G",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Provider & model",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BjuAs",
+                  "name": "i5",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "CJAE9",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DyGK6",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "X8C7P",
+                          "fill": "#3F3F46",
+                          "content": "Lookup",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ni4C3",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Translation & dictionary",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rVoro",
+                  "name": "i5b",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "pzWC5",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "languages",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "5rrOF",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "6zce7",
+                          "fill": "#3F3F46",
+                          "content": "Translation",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "yS6sh",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Language & settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "m6wiz",
+                  "name": "i6",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ZaEV9",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "cloud",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XnGW9",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SyO2y",
+                          "fill": "#3F3F46",
+                          "content": "iCloud Sync",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "6v8RK",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Sync your books",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SZq2c",
+                  "name": "i7",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "MyZeu",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "info",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "a2QEe",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "nMdxD",
+                          "fill": "#3F3F46",
+                          "content": "About",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "rdOs0",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Version information",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "t9rML",
+              "name": "divV",
+              "fill": "#E5E7EB",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "icon_font",
+              "id": "RL6PF",
+              "layoutPosition": "absolute",
+              "x": 492,
+              "y": 18,
+              "name": "closeBtn",
+              "width": 18,
+              "height": 18,
+              "iconFontName": "x",
+              "iconFontFamily": "lucide",
+              "fill": "#A1A1AA"
+            },
+            {
+              "type": "frame",
+              "id": "A4h1P",
+              "name": "content",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "padding": [
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "EhA0X",
+                  "name": "ctTitle",
+                  "fill": "#111111",
+                  "content": "Language",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "V4i3l",
+                  "name": "ctSub",
+                  "fill": "#71717A",
+                  "content": "App language",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "JKqxn",
+                  "name": "formDiv",
+                  "fill": "#E5E7EB",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "WuNt9",
+                  "name": "langRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "mH51R",
+                      "name": "langLbl",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "YxXJK",
+                          "name": "langName",
+                          "fill": "#111111",
+                          "content": "Language",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ydrYa",
+                          "name": "langDesc",
+                          "fill": "#71717A",
+                          "content": "Interface language",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "AGNUR",
+                      "name": "dropdown",
+                      "fill": "#F4F4F5",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "RN15F",
+                          "fill": "#111111",
+                          "content": "English",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "zkRoM",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#71717A"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "OaqCi",
+      "x": 1540,
+      "y": 4793,
+      "name": "Settings / Lookup",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "layout": "none",
+      "children": [
+        {
+          "type": "rectangle",
+          "id": "3thN4",
+          "x": 0,
+          "y": 0,
+          "name": "bg2",
+          "fill": "#00000066",
+          "width": 1440,
+          "height": 960
+        },
+        {
+          "type": "frame",
+          "id": "ch0lm",
+          "layoutPosition": "absolute",
+          "x": 460,
+          "y": 270,
+          "name": "Modal",
+          "theme": {
+            "Mode": "Light"
+          },
+          "clip": true,
+          "width": 520,
+          "height": 420,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000001A",
+            "offset": {
+              "x": 0,
+              "y": 8
+            },
+            "blur": 24
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "oUTI8",
+              "name": "sidebar",
+              "width": 170,
+              "fill": "#F9FAFB",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                16,
+                12
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "YXNmD",
+                  "name": "stTitle",
+                  "fill": "#3F3F46",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "qSMzX",
+                  "name": "i1",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "nnC7K",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lDbnB",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "f0I5C",
+                          "fill": "#3F3F46",
+                          "content": "General",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "M2h6B",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Language & appearance",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "k5hrA",
+                  "name": "i2",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "KU32t",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "globe",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FKOQj",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "AYze3",
+                          "fill": "#3F3F46",
+                          "content": "Language",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "PSUq0",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Interface language",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "IG3Kt",
+                  "name": "i3",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "jl5oE",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "5SAk8",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mcDt8",
+                          "fill": "#3F3F46",
+                          "content": "Reading",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "XhXEd",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Font, spacing & layout",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "nRFDx",
+                  "name": "i4",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "IQoFV",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sparkles",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "chp2B",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VB90g",
+                          "fill": "#3F3F46",
+                          "content": "AI Assistant",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "vXCjH",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Provider & model",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "9VmFO",
+                  "name": "i5",
+                  "width": "fill_container",
+                  "fill": "#F3E8FF",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "j4R6R",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A855F7"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WQeMs",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "YWru2",
+                          "fill": "#7C3AED",
+                          "content": "Lookup",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "m07Hq",
+                          "fill": "#A78BFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Translation & dictionary",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Sh2lO",
+                  "name": "i5b",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "q7vSD",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "languages",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "9mHyd",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "myRYJ",
+                          "fill": "#3F3F46",
+                          "content": "Translation",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "wPpee",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Language & settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "O4WZ6",
+                  "name": "i6",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "B608g",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "cloud",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rNVa3",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "PMHkY",
+                          "fill": "#3F3F46",
+                          "content": "iCloud Sync",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "wOJ2f",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Sync your books",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "LwC62",
+                  "name": "i7",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "lxZ68",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "info",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jeYBr",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZT2uA",
+                          "fill": "#3F3F46",
+                          "content": "About",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "O0hTh",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Version information",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "H6S4w",
+              "name": "divV",
+              "fill": "#E5E7EB",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "icon_font",
+              "id": "rk40n",
+              "layoutPosition": "absolute",
+              "x": 492,
+              "y": 18,
+              "name": "closeBtn",
+              "width": 18,
+              "height": 18,
+              "iconFontName": "x",
+              "iconFontFamily": "lucide",
+              "fill": "#A1A1AA"
+            },
+            {
+              "type": "frame",
+              "id": "x6r58",
+              "name": "newContent",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 14,
+              "padding": [
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "4yPSb",
+                  "name": "toolTitle",
+                  "fill": "#111111",
+                  "content": "Lookup",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "0DZB9",
+                  "name": "toolSub",
+                  "fill": "#71717A",
+                  "content": "Translation & dictionary",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "7VqSU",
+                  "name": "topDiv",
+                  "fill": "#E5E7EB",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "Kejyo",
+                  "name": "langRow",
+                  "width": "fill_container",
+                  "padding": [
+                    12,
+                    0
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "SNS2k",
+                      "name": "langLbl",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "tVvf4",
+                          "name": "langName",
+                          "fill": "#111111",
+                          "content": "Lookup Language",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "u5dds",
+                          "name": "langHint",
+                          "fill": "#71717A",
+                          "content": "Language for word lookup",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "8R8MN",
+                      "name": "langDrop",
+                      "fill": "#E5E7EB",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "klhaj",
+                          "fill": "#111111",
+                          "content": "English",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "MisUy",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#71717A"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "X2OnZ",
+                  "name": "langDiv",
+                  "fill": "#E5E7EB",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "dXO2g",
+                  "name": "toggleRow",
+                  "width": "fill_container",
+                  "padding": [
+                    12,
+                    0
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "pv0z3",
+                      "name": "toggleLbl",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "eXl2m",
+                          "name": "toggleName",
+                          "fill": "#111111",
+                          "content": "Show Translation",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "lrYDI",
+                          "name": "toggleDesc",
+                          "fill": "#71717A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Include translation to native language",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "doZxq",
+                      "name": "toggle",
+                      "width": 48,
+                      "height": 28,
+                      "fill": "#A855F7",
+                      "cornerRadius": 14,
+                      "padding": 2,
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "QAMYr",
+                          "fill": "#FFFFFF",
+                          "width": 24,
+                          "height": 24
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "XtskN",
+                  "name": "pvHdr",
+                  "fill": "#71717A",
+                  "content": "PREVIEW",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "frame",
+                  "id": "u9tcN",
+                  "name": "pvCard",
+                  "width": "fill_container",
+                  "fill": "#F4F4F5",
+                  "cornerRadius": 10,
+                  "layout": "vertical",
+                  "gap": 6,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "17ZTR",
+                      "name": "pvWord",
+                      "fill": "#111111",
+                      "content": "interfaces",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "D4HMP",
+                      "name": "pvTrans",
+                      "fill": "#A855F7",
+                      "content": "界面・接口",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "IH7T5",
+                      "name": "pvDef",
+                      "fill": "#71717A",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "A term used to convey a specific quality relevant to themes of technological advancement.",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ugGGG",
+      "x": 3080,
+      "y": 4793,
+      "name": "Settings / Translation",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "layout": "none",
+      "children": [
+        {
+          "type": "rectangle",
+          "id": "navVM",
+          "x": 0,
+          "y": 0,
+          "name": "bg3",
+          "fill": "#00000066",
+          "width": 1440,
+          "height": 960
+        },
+        {
+          "type": "frame",
+          "id": "poYFn",
+          "layoutPosition": "absolute",
+          "x": 460,
+          "y": 270,
+          "name": "Modal",
+          "theme": {
+            "Mode": "Light"
+          },
+          "clip": true,
+          "width": 520,
+          "height": 420,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000001A",
+            "offset": {
+              "x": 0,
+              "y": 8
+            },
+            "blur": 24
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "7SBzD",
+              "name": "sidebar",
+              "width": 170,
+              "fill": "#F9FAFB",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                16,
+                12
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "AY9ez",
+                  "name": "stTitle",
+                  "fill": "#3F3F46",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "fsWuW",
+                  "name": "i1",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Lf6iR",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ulIEs",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qEOlW",
+                          "fill": "#3F3F46",
+                          "content": "General",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "GQnDm",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Language & appearance",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "booJb",
+                  "name": "i2",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "WO1bS",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "globe",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BFTaG",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WSAxY",
+                          "fill": "#3F3F46",
+                          "content": "Language",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "WOcab",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Interface language",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "q4v81",
+                  "name": "i3",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "uQmiV",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "9Zspf",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Gotxp",
+                          "fill": "#3F3F46",
+                          "content": "Reading",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Jxlgj",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Font, spacing & layout",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NKyE8",
+                  "name": "i4",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "aRH8Z",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sparkles",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "P6lQo",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "TXYmG",
+                          "fill": "#3F3F46",
+                          "content": "AI Assistant",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "zu8VM",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Provider & model",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jmETY",
+                  "name": "i5",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "GL0Py",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gEfhV",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rEUTp",
+                          "fill": "#3F3F46",
+                          "content": "Lookup",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "a5QPC",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Translation & dictionary",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "PLlvd",
+                  "name": "i5b",
+                  "width": "fill_container",
+                  "fill": "#F3E8FF",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "RfV1z",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "languages",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A855F7"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "X4TZf",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "KxXUE",
+                          "fill": "#7C3AED",
+                          "content": "Translation",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "nwmeA",
+                          "fill": "#A78BFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Language & settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "E0d7I",
+                  "name": "i6",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "X29og",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "cloud",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pYhsQ",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QNwuv",
+                          "fill": "#3F3F46",
+                          "content": "iCloud Sync",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "NJH17",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Sync your books",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "7yMUe",
+                  "name": "i7",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "yEvRX",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "info",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HWyAX",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "7bshu",
+                          "fill": "#3F3F46",
+                          "content": "About",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "1jH2u",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Version information",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "VAbxI",
+              "name": "divV",
+              "fill": "#E5E7EB",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "icon_font",
+              "id": "E5IXM",
+              "layoutPosition": "absolute",
+              "x": 492,
+              "y": 18,
+              "name": "closeBtn",
+              "width": 18,
+              "height": 18,
+              "iconFontName": "x",
+              "iconFontFamily": "lucide",
+              "fill": "#A1A1AA"
+            },
+            {
+              "type": "frame",
+              "id": "Ach0B",
+              "name": "content",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "padding": [
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "42OkN",
+                  "name": "ctTitle",
+                  "fill": "#111111",
+                  "content": "Translation",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "JxRxv",
+                  "name": "ctSub",
+                  "fill": "#71717A",
+                  "content": "Language & settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "xdzS6",
+                  "name": "formDiv",
+                  "fill": "#E5E7EB",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "Lf49r",
+                  "name": "langRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "6enEE",
+                      "name": "langLbl",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "DJSjr",
+                          "name": "langName",
+                          "fill": "#111111",
+                          "content": "Translation Language",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "zkvoU",
+                          "name": "langDesc",
+                          "fill": "#71717A",
+                          "content": "Target language for translations",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "JO4bE",
+                      "name": "dropdown",
+                      "fill": "#F4F4F5",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "eF9P9",
+                          "fill": "#111111",
+                          "content": "简体中文",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "RNAt4",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#71717A"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "4XEa2",
+      "x": 3287,
+      "y": 2013,
+      "name": "Reader — Back Button State",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "p2ChJ",
+          "name": "Top bar",
+          "width": "fill_container",
+          "fill": "$bg-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$border"
+          },
+          "padding": [
+            32,
+            24,
+            8,
+            24
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "6G6Dp",
+              "name": "Top left",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KD2Vp",
+                  "name": "Back icon",
+                  "width": 40,
+                  "height": 40,
+                  "fill": "$accent",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "acxBy",
+                      "name": "backIcon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "$white"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SrI6u",
+                  "name": "TOC",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "FmfqS",
+                      "name": "tocIcon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "list",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ZsKbY",
+              "name": "Title center",
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "1OM6N",
+                  "name": "titleText",
+                  "fill": "$text-primary",
+                  "content": "Fight Club",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "MJG6c",
+                  "name": "chapterText",
+                  "fill": "$text-muted",
+                  "content": "Chapter 22 of 38",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "twz5X",
+              "name": "Top right",
+              "gap": 2,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rjccN",
+                  "name": "Font",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "gap": 1,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "l8UWH",
+                      "name": "fontBig",
+                      "fill": "$text-primary",
+                      "content": "A",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Nh2NB",
+                      "name": "fontSmall",
+                      "fill": "$text-primary",
+                      "content": "A",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BG7xd",
+                  "name": "Bookmark",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Zo2Sn",
+                      "name": "bookmarkIcon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "bookmark",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Enkso",
+                  "name": "Translate",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "a0fsT",
+                      "name": "translateIcon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "languages",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "I3Am1",
+                  "name": "dividerWrap",
+                  "padding": [
+                    0,
+                    4
+                  ],
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "q0Jl8",
+                      "name": "divider",
+                      "fill": "$border",
+                      "width": 1,
+                      "height": 24
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "oPyxc",
+                  "name": "AI Assistant",
+                  "height": 32,
+                  "fill": "$accent-bg",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "hnXlY",
+                      "name": "aiIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "sparkles",
+                      "iconFontFamily": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "UKwBF",
+                      "name": "aiLabel",
+                      "fill": "$accent",
+                      "content": "AI Assistant",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.15
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "jw79q",
+          "layoutPosition": "absolute",
+          "x": 284,
+          "y": 340,
+          "name": "Look Up popover",
+          "enabled": false,
+          "width": 440,
+          "fill": "#ffffff",
+          "cornerRadius": 14,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000026",
+            "offset": {
+              "x": 0,
+              "y": 20
+            },
+            "blur": 25
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "hfMEM",
+              "name": "Header",
+              "width": "fill_container",
+              "fill": "$accent-bg",
+              "padding": [
+                12,
+                16,
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rJ4D2",
+                  "name": "popHdrLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "x7JSt",
+                      "name": "popHdrIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sparkles",
+                      "iconFontFamily": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "9QoBU",
+                      "name": "popHdrTitle",
+                      "fill": "$accent",
+                      "content": "Look Up",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.15
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "eLNNW",
+                  "name": "popHdrClose",
+                  "width": 24,
+                  "height": 24,
+                  "cornerRadius": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "7O103",
+                      "name": "popHdrCloseIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "AnfV3",
+              "name": "Body",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "padding": [
+                12,
+                16,
+                8,
+                16
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "5xsVt",
+                  "name": "popWord",
+                  "fill": "$text-primary",
+                  "content": "Another nigh",
+                  "fontFamily": "Inter",
+                  "fontSize": 20,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "lzHKe",
+                  "name": "popTrans",
+                  "fill": "$accent",
+                  "content": "又一个夜晚",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "D5aze",
+                  "name": "popDef",
+                  "fill": "$text-primary",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "/əˈnʌðər naɪ/ phrase. Means \"one more night\" or \"an additional night\"; in this context, it introduces yet another night when Tyler did not come home.",
+                  "lineHeight": 1.55,
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "SrQVX",
+                  "name": "In this context card",
+                  "width": "fill_container",
+                  "fill": "$bg-muted",
+                  "cornerRadius": 8,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "EcAPK",
+                      "name": "popCtxLabel",
+                      "fill": "$text-muted",
+                      "content": "In this context",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "hfFhS",
+                      "name": "popCtxBody",
+                      "fill": "$text-secondary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "\"Another nigh[t]\" signals repetition and escalation: this isn't a one-off event, but part of a continuing pattern of Tyler's absence and chaos. The clipped, slightly off phrasing also matches the narrator's frantic, exhausted voice, as if thoughts are tumbling out faster than they can be neatly framed. It sets a tone of inevitability before launching into the absurd sabotage details.",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "PcOuq",
+              "name": "Footer",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "top": 1
+                },
+                "fill": "$border"
+              },
+              "padding": [
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "L1Voe",
+                  "name": "popSave",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "aPope",
+                      "name": "popSaveIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "bookmark-plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "uwywF",
+                      "name": "popSaveLabel",
+                      "fill": "$accent",
+                      "content": "Save to Dict",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "m1lSL",
+                  "name": "popCopy",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "BXqEs",
+                      "name": "popCopyIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "copy",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "vaJDa",
+                      "name": "popCopyLabel",
+                      "fill": "$text-muted",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "CMFrA",
+          "name": "Body",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg-surface",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Xucv8",
+              "name": "Reader column",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$bg-surface",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZSaIh",
+                  "name": "Reading area",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": [
+                    32,
+                    120,
+                    16,
+                    120
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "crg6F",
+                      "name": "p1",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "And one night in an uptown square park, another group of men poured gasoline around every tree and from tree to tree and set a perfect little forest fire. It was in the newspaper, how townhouse windows across the street from the fire melted, and parked cars farted and settled on melted flat tires.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "m762d",
+                      "name": "p2",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    Tyler's rented house on Paper Street is a living thing wet on the inside from so many people sweating and breathing. So many people are moving inside, the house moves.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "jYUf2",
+                      "name": "p4",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    And Tyler was a few of the space monkeys had Tyler drilling holes in their hand. Then those space monkeys are on the front porch to replace them.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "blGlr",
+                      "name": "p3",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    Another night that Tyler didn't come home, someone was drilling bank machines and lube fittings into the drilled holes... bank machines and pay telephones.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "uvLS6",
+                      "name": "p5",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    And every day in different cars. You never saw the same car twice. One evening, I hear Marla on the front",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "4a3ue",
+                  "name": "Bottom progress",
+                  "width": "fill_container",
+                  "fill": "$bg-surface",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    24,
+                    8,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "yRLYi",
+                      "name": "Progress track",
+                      "width": "fill_container",
+                      "height": 2,
+                      "fill": "$border",
+                      "cornerRadius": 9999,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "RTaFx",
+                          "name": "Progress fill",
+                          "width": 760,
+                          "height": 2,
+                          "fill": "$accent",
+                          "cornerRadius": 9999
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6BorP",
+                      "name": "Progress row",
+                      "width": "fill_container",
+                      "height": 32,
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "e9O4b",
+                          "name": "pageText",
+                          "fill": "$text-muted",
+                          "content": "Page 162 of 267",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qrEmh",
+                          "name": "Nav arrows",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "3AVQa",
+                              "name": "leftArrow",
+                              "width": 24,
+                              "height": 24,
+                              "cornerRadius": 4,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "SFqG0",
+                                  "name": "leftIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "chevron-left",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$text-muted"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "NlhBT",
+                              "name": "pctText",
+                              "fill": "$text-muted",
+                              "content": "61%",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "LAk3T",
+                              "name": "rightArrow",
+                              "width": 24,
+                              "height": 24,
+                              "cornerRadius": 4,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "EPOpo",
+                                  "name": "rightIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "chevron-right",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "$text-muted"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "WrlIT",
+                          "name": "leftText",
+                          "fill": "$text-muted",
+                          "content": "105 pages left",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "OAg5I",
+                  "layoutPosition": "absolute",
+                  "x": 27,
+                  "y": 781,
+                  "name": "Back Button",
+                  "fill": "$accent-bg",
+                  "cornerRadius": 20,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 0,
+                    "fill": "$accent"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#7c3aed18",
+                    "offset": {
+                      "x": 0,
+                      "y": 6
+                    },
+                    "blur": 20
+                  },
+                  "gap": 6,
+                  "padding": [
+                    8,
+                    14,
+                    8,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "i3LVV",
+                      "name": "backIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "arrow-left",
+                      "iconFontFamily": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "NhAbB",
+                      "name": "backText",
+                      "fill": "$accent",
+                      "content": "Back",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "nSRhi",
+              "name": "AI Panel",
+              "clip": true,
+              "width": 440,
+              "height": "fill_container",
+              "fill": "$bg-muted",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "left": 1
+                },
+                "fill": "$border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "MbyJ0",
+                  "name": "AI header",
+                  "width": "fill_container",
+                  "height": 63,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$border"
+                  },
+                  "padding": [
+                    0,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "VEKfr",
+                      "name": "aiHeaderLeft",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "mI3sp",
+                          "name": "aiHeaderIcon",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "sparkles",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "q1COn",
+                          "name": "aiHeaderTitle",
+                          "fill": "$text-primary",
+                          "content": "Tyler Explains Harsh Initiation Test",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.23
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "ZF2B2",
+                          "name": "aiHeaderChevron",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "1A1Y5",
+                      "name": "aiHeaderPlus",
+                      "width": 28,
+                      "height": 28,
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "JxM0f",
+                          "name": "aiHeaderPlusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RtHa6",
+                  "name": "Messages",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "EEtWo",
+                      "name": "User context msg",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "O2i4C",
+                          "name": "Context quote",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "left": 2
+                            },
+                            "fill": "$lavender"
+                          },
+                          "padding": [
+                            2,
+                            0,
+                            2,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "FtSVF",
+                              "name": "userCtxText",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": 340,
+                              "content": "This is how Buddhist temples have tested applicants going back for bah-zillion years, Tyler says. You tell the applicant to go away, and if...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Ux1O9",
+                          "name": "Explain bubble",
+                          "fill": "$user-bubble",
+                          "cornerRadius": 8,
+                          "padding": 13,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "MpSTJ",
+                              "name": "userExplainText",
+                              "fill": "$text-primary",
+                              "content": "Explain",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "F6k8q",
+                      "name": "Assistant msg",
+                      "fill": "$bg-surface",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border"
+                      },
+                      "layout": "vertical",
+                      "gap": 10,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Ncdh3",
+                          "name": "assistIntro",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "In this passage, Tyler is justifying the harsh \"test\" he gives new recruits by comparing it to an old spiritual tradition.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "nfohn",
+                          "name": "assistH1",
+                          "fill": "$text-primary",
+                          "content": "What he's saying",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "v8Xjm",
+                          "name": "assistP1",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "He claims Buddhist temples used to test people by rejecting them at first. Only if someone waited outside for days—hungry, uncomfortable, ignored—would they be accepted for training.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "raKNQ",
+                          "name": "assistH2",
+                          "fill": "$text-primary",
+                          "content": "Why this matters in Fight Club",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "EhWhx",
+                          "name": "assistP2",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Tyler is using this idea to support his philosophy:",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "s92CG",
+                          "name": "assistBullets",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Commitment must be proven through suffering\nOnly the truly devoted deserve entry\nEgo gets stripped away by humiliation and endurance",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "lFGWp",
+                          "name": "assistP3",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "It turns Project Mayhem into something like a cult initiation: people must show total obedience before belonging.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "uai59",
+                          "name": "assistH3",
+                          "fill": "$text-primary",
+                          "content": "Tone / characterization",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "tVYZC",
+                          "name": "assistP4",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "The \"bah-zillion years\" phrasing is sarcastic and exaggerated. It shows Tyler's charismatic, performative style — he mixes half-history, myth, and confidence to make extreme behavior sound meaningful and inevitable.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vimoQ",
+                      "name": "User msg 2",
+                      "width": "fill_container",
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "5eT0J",
+                          "name": "userMsg2",
+                          "fill": "$user-bubble",
+                          "cornerRadius": 8,
+                          "padding": 13,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "IZ7gF",
+                              "name": "userMsg2Text",
+                              "fill": "$text-primary",
+                              "content": "Interesting a lot of current society",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "p0z8L",
+                      "name": "Assistant msg 2",
+                      "fill": "$bg-surface",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$border"
+                      },
+                      "layout": "vertical",
+                      "gap": 6,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XpeFv",
+                          "name": "assist2P1",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Absolutely — you're picking up on one of the novel's biggest points.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "sGG43",
+                          "name": "assist2P2",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "I think you're starting to say: a lot of current society still works like this—people are made to \"prove\" themselves through stress, rejection, and grind before they're accepted.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "EKldD",
+                  "name": "AI input",
+                  "width": "fill_container",
+                  "fill": "$bg-muted",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1
+                    },
+                    "fill": "$border"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    17,
+                    16,
+                    16,
+                    16
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "wWIpD",
+                      "name": "aiInputRow",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "JDQLN",
+                          "name": "aiInputBox",
+                          "width": "fill_container",
+                          "height": 60,
+                          "fill": "$bg-input",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "POIoz",
+                              "name": "aiInputPlaceholder",
+                              "fill": "$text-placeholder",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask me anything about what you're reading...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "xVjMW",
+                          "name": "Send",
+                          "width": 60,
+                          "height": 60,
+                          "fill": "$accent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "3UvX0",
+                              "name": "aiSendIcon",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "send",
+                              "iconFontFamily": "lucide",
+                              "fill": "$white"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "PEcTn",
+                      "name": "aiHint",
+                      "fill": "$text-muted",
+                      "content": "Press Enter to send, Shift+Enter for new line",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "vEswX",
+      "x": 4540,
+      "y": 4793,
+      "name": "Settings / iCloud Sync",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "layout": "none",
+      "children": [
+        {
+          "type": "rectangle",
+          "id": "y8hnI",
+          "x": 0,
+          "y": 0,
+          "name": "bg2",
+          "fill": "#00000066",
+          "width": 1440,
+          "height": 960
+        },
+        {
+          "type": "frame",
+          "id": "AOXuZ",
+          "layoutPosition": "absolute",
+          "x": 460,
+          "y": 270,
+          "name": "Modal",
+          "theme": {
+            "Mode": "Light"
+          },
+          "clip": true,
+          "width": 520,
+          "height": 420,
+          "fill": "#FFFFFF",
+          "cornerRadius": 12,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000001A",
+            "offset": {
+              "x": 0,
+              "y": 8
+            },
+            "blur": 24
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "XZnEy",
+              "name": "sidebar",
+              "width": 170,
+              "fill": "#F9FAFB",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                16,
+                12
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "vMcnC",
+                  "name": "stTitle",
+                  "fill": "#3F3F46",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "I1KfN",
+                  "name": "i1",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "QUCT1",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "J8zs1",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "0o7Kl",
+                          "fill": "#3F3F46",
+                          "content": "General",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "mgf8i",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Language & appearance",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xqbDg",
+                  "name": "i2",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "sSvQx",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "globe",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Czv8h",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SqlYr",
+                          "fill": "#3F3F46",
+                          "content": "Language",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "sDZbc",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Interface language",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "emXVT",
+                  "name": "i3",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "M5NQf",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "z90x9",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VWQfy",
+                          "fill": "#3F3F46",
+                          "content": "Reading",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "wCAdZ",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Font, spacing & layout",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "9rymk",
+                  "name": "i4",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "oITFX",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "sparkles",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Bzf4g",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "V79Av",
+                          "fill": "#3F3F46",
+                          "content": "AI Assistant",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "LmTN1",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Provider & model",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "0CeP3",
+                  "name": "i5",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "I9fFZ",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7Mch2",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "EbCgt",
+                          "fill": "#3F3F46",
+                          "content": "Lookup",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "zct5k",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Translation & dictionary",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RH2yU",
+                  "name": "i5b",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "aVPC2",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "languages",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ySzxS",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "T4cxA",
+                          "fill": "#3F3F46",
+                          "content": "Translation",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "3pcgF",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Language & settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "XXnna",
+                  "name": "i6",
+                  "width": "fill_container",
+                  "fill": "#F3E8FF",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "t1ALn",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "cloud",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A855F7"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "o3tw4",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mkZ13",
+                          "fill": "#7C3AED",
+                          "content": "iCloud Sync",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ljSXf",
+                          "fill": "#A78BFA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Sync your books",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "VRC6s",
+                  "name": "i7",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "DisvU",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "info",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VtLoE",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "DDUub",
+                          "fill": "#3F3F46",
+                          "content": "About",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "updDl",
+                          "fill": "#A1A1AA",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Version information",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "1tSGW",
+              "name": "divV",
+              "fill": "#E5E7EB",
+              "width": 1,
+              "height": "fill_container"
+            },
+            {
+              "type": "icon_font",
+              "id": "ijQ2w",
+              "layoutPosition": "absolute",
+              "x": 492,
+              "y": 18,
+              "name": "closeBtn",
+              "width": 18,
+              "height": 18,
+              "iconFontName": "x",
+              "iconFontFamily": "lucide",
+              "fill": "#A1A1AA"
+            },
+            {
+              "type": "frame",
+              "id": "fonGl",
+              "name": "newContent",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 14,
+              "padding": [
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "QJEHC",
+                  "name": "toolTitle",
+                  "fill": "#111111",
+                  "content": "iCloud Sync",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "5QNFk",
+                  "name": "toolSub",
+                  "fill": "#71717A",
+                  "content": "Store your library in iCloud",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "UCncx",
+                  "name": "topDiv",
+                  "fill": "#E5E7EB",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "HEL0n",
+                  "name": "toggleRow",
+                  "width": "fill_container",
+                  "padding": [
+                    12,
+                    0
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "pdmgU",
+                      "name": "toggleLbl",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "xAkzF",
+                          "name": "toggleName",
+                          "fill": "#111111",
+                          "content": "Sync with iCloud",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "3Baa0",
+                          "name": "toggleDesc",
+                          "fill": "#71717A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Keep your library and reading progress in iCloud Drive",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7oLrk",
+                      "name": "toggle",
+                      "width": 48,
+                      "height": 28,
+                      "fill": "#A855F7",
+                      "cornerRadius": 14,
+                      "padding": 2,
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "DvgIx",
+                          "fill": "#FFFFFF",
+                          "width": 24,
+                          "height": 24
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "W80zj",
+                  "name": "div1",
+                  "fill": "#E5E7EB",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "text",
+                  "id": "ip3GO",
+                  "name": "peersHdr",
+                  "fill": "#71717A",
+                  "content": "OTHER DEVICES",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "frame",
+                  "id": "IZr35",
+                  "name": "peerCard",
+                  "width": "fill_container",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    10,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "i2oNi",
+                      "name": "peerIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "monitor",
+                      "iconFontFamily": "lucide",
+                      "fill": "#71717A"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6BXq8",
+                      "name": "peerLbl",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Et85G",
+                          "name": "peerName",
+                          "fill": "#18181B",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "MacBook Pro",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "eEpQF",
+                          "name": "peerSeen",
+                          "fill": "#71717A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Last seen 2 minutes ago",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "RFp0G",
+                  "name": "div2",
+                  "fill": "#E5E7EB",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "vh1L0",
+                  "name": "actions",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zv1Hj",
+                      "name": "actLeft",
+                      "gap": 16,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "IzXS2",
+                          "name": "syncBtn",
+                          "fill": "#7C3AED",
+                          "content": "Sync now",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "DHyXV",
+                          "name": "compactBtn",
+                          "fill": "#7C3AED",
+                          "content": "Compact log",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "WL7qa",
+                      "name": "syncStatus",
+                      "fill": "#A1A1AA",
+                      "content": "Last sync 2m ago",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "accent": {
+      "type": "color",
+      "value": "#7c3aed"
+    },
+    "accent-bg": {
+      "type": "color",
+      "value": "#f3e8ff"
+    },
+    "bg-input": {
+      "type": "color",
+      "value": "#f3f3f5"
+    },
+    "bg-muted": {
+      "type": "color",
+      "value": "#fafafa"
+    },
+    "bg-page": {
+      "type": "color",
+      "value": "#f4f4f5"
+    },
+    "bg-surface": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "border": {
+      "type": "color",
+      "value": "#e4e4e7"
+    },
+    "border-light": {
+      "type": "color",
+      "value": "#f4f4f5"
+    },
+    "danger": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "font-sans": {
+      "type": "string",
+      "value": "Inter"
+    },
+    "font-serif": {
+      "type": "string",
+      "value": "Georgia"
+    },
+    "lavender": {
+      "type": "color",
+      "value": "#c084fc"
+    },
+    "radius-lg": {
+      "type": "number",
+      "value": 10
+    },
+    "radius-md": {
+      "type": "number",
+      "value": 8
+    },
+    "radius-sm": {
+      "type": "number",
+      "value": 4
+    },
+    "radius-xl": {
+      "type": "number",
+      "value": 14
+    },
+    "soft-lilac": {
+      "type": "color",
+      "value": "#d8b4fe"
+    },
+    "success": {
+      "type": "color",
+      "value": "#00c950"
+    },
+    "text-muted": {
+      "type": "color",
+      "value": "#71717b"
+    },
+    "text-placeholder": {
+      "type": "color",
+      "value": "#717182"
+    },
+    "text-primary": {
+      "type": "color",
+      "value": "#18181b"
+    },
+    "text-secondary": {
+      "type": "color",
+      "value": "#52525c"
+    },
+    "user-bubble": {
+      "type": "color",
+      "value": "#c084fc26"
+    },
+    "white": {
+      "type": "color",
+      "value": "#ffffff"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Pulls `quill-desktop.pen` from the standalone `quill-design` repo into this repo's `design/` dir, matching runner's convention
- Adds a short `design/README.md` following `runner/design/README.md`'s shape
- The `quill-design` repo continues to exist for iOS designs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)