### PR TITLE
chore: release v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quill",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "1.0.5"
+version = "1.1.0"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "1.0.5"
+version = "1.1.0"
 description = "An AI-powered ebook reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quill",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "identifier": "com.wycstudios.quill",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bump version to v1.1.0
- MCP server with 17 tools (9 read + 8 write) for library management
- Settings UI for MCP client integrations (Claude Code, Codex)
- Consolidated PDF import (lopdf metadata + pdf.js cover backfill)