### PR TITLE
fix: refresh collection counts on MCP book mutations

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -155,6 +155,7 @@ export default function Home() {
     const unlistenBooks = listen("mcp:books-changed", async () => {
       refreshRef.current();
       allBooksRefreshRef.current();
+      collectionsRefreshRef.current();
       await backfillMissingCovers();
       refreshRef.current();
       allBooksRefreshRef.current();


### PR DESCRIPTION
## Summary
- `mcp:books-changed` handler now also refreshes collections, so book deletions via MCP update sidebar counts immediately

Fixes #229

## Test plan
- [ ] Delete a book that belongs to a collection via MCP `delete_book` — sidebar count should decrement without page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)