### PR TITLE
fix: convert cover_path "none" sentinel to null in resolve_book_paths

### DIFF
--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -139,7 +139,9 @@ fn resolve_book_paths(book: &mut Book, db: &Db) {
             .to_string();
     }
     if let Some(ref cover) = book.cover_path {
-        if cover != "none" && !std::path::Path::new(cover).is_absolute() {
+        if cover == "none" {
+            book.cover_path = None;
+        } else if !std::path::Path::new(cover).is_absolute() {
             book.cover_path = Some(
                 db.resolve_path(cover)
                     .to_string_lossy()


### PR DESCRIPTION
## Summary
- The squash merge from #233 skipped resolving `"none"` but still returned it to the frontend as a string
- This converts it to `None` so the UI correctly treats it as no cover

One-line fix in `resolve_book_paths`.