### PR TITLE
refactor: sync engine architecture — read/write split, batch flush, read timeout

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -32,7 +32,7 @@ pub async fn ai_lookup(
 ) -> AppResult<()> {
     // Read provider settings
     let (provider, model, base_url, keep_alive, auth_mode, language, native_language, show_translation) = {
-        let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+        let conn = db.reader();
         let get = |key: &str| -> Option<String> {
             conn.query_row(
                 "SELECT value FROM settings WHERE key = ?1",
@@ -179,7 +179,7 @@ pub async fn ai_generate_title(
     secrets: State<'_, Secrets>,
 ) -> AppResult<()> {
     let (provider, model, base_url, keep_alive, auth_mode, language) = {
-        let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+        let conn = db.reader();
         let get = |key: &str| -> Option<String> {
             conn.query_row(
                 "SELECT value FROM settings WHERE key = ?1",
@@ -268,7 +268,7 @@ pub async fn ai_chat(
 ) -> AppResult<()> {
     // Read provider settings
     let (provider, model, base_url, temperature, keep_alive, auth_mode, language) = {
-        let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+        let conn = db.reader();
         let get = |key: &str| -> Option<String> {
             conn.query_row(
                 "SELECT value FROM settings WHERE key = ?1",

--- a/src-tauri/src/commands/bookmarks.rs
+++ b/src-tauri/src/commands/bookmarks.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::db::Db;
-use crate::error::{AppError, AppResult};
+use crate::error::AppResult;
 use crate::sync::events::{BookmarkPayload, EventBody, HighlightPayload};
 use crate::sync::writer::SyncWriter;
 
@@ -84,7 +84,7 @@ pub fn remove_bookmark(
 /// command and the MCP `get_bookmarks` tool call this so the column
 /// list lives in exactly one place.
 pub(crate) fn query_bookmarks(db: &Db, book_id: &str) -> AppResult<Vec<Bookmark>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT id, book_id, cfi, label, created_at, updated_at FROM bookmarks WHERE book_id = ?1 ORDER BY created_at DESC",
     )?;
@@ -173,7 +173,7 @@ pub fn remove_highlight(
 /// Shared query helper. Mirror of `list_highlights` for the MCP
 /// `get_highlights` tool — keeps the column list canonical.
 pub(crate) fn query_highlights(db: &Db, book_id: &str) -> AppResult<Vec<Highlight>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT id, book_id, cfi_range, color, note, text_content, created_at, updated_at FROM highlights WHERE book_id = ?1 ORDER BY created_at DESC",
     )?;

--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -322,7 +322,7 @@ pub(crate) fn query_books(
     filter: Option<&str>,
     search: Option<&str>,
 ) -> AppResult<Vec<Book>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
 
     let mut sql = "SELECT id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at FROM books".to_string();
     let mut conditions: Vec<String> = Vec::new();
@@ -388,7 +388,7 @@ pub(crate) fn query_books(
 /// Shared query helper for the single-book lookup. Same relative-path
 /// guarantee as `query_books`.
 pub(crate) fn query_book(db: &Db, id: &str) -> AppResult<Book> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let book = conn.query_row(
         "SELECT id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at FROM books WHERE id = ?1",
         params![id],
@@ -438,7 +438,7 @@ pub fn get_book(id: String, db: State<'_, Db>) -> AppResult<Book> {
 /// Check if a book's file is locally available and trigger iCloud download if not.
 #[tauri::command]
 pub fn check_book_available(id: String, db: State<'_, Db>) -> AppResult<bool> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let file_path: String = conn.query_row(
         "SELECT file_path FROM books WHERE id = ?1",
         params![id],

--- a/src-tauri/src/commands/chats.rs
+++ b/src-tauri/src/commands/chats.rs
@@ -4,7 +4,7 @@ use tauri::State;
 use uuid::Uuid;
 
 use crate::db::Db;
-use crate::error::{AppError, AppResult};
+use crate::error::AppResult;
 use crate::sync::events::{ChatMessagePayload, EventBody};
 use crate::sync::writer::SyncWriter;
 
@@ -129,7 +129,7 @@ pub fn create_chat(
 }
 
 pub(crate) fn query_chats(db: &Db, book_id: &str) -> AppResult<Vec<Chat>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT id, book_id, title, model, pinned, metadata, created_at, updated_at
          FROM chats WHERE book_id = ?1
@@ -148,7 +148,7 @@ pub fn list_chats(book_id: String, db: State<'_, Db>) -> AppResult<Vec<Chat>> {
 
 #[tauri::command]
 pub fn list_all_chats(db: State<'_, Db>) -> AppResult<Vec<Chat>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT c.id, c.book_id, c.title, c.model, c.pinned, c.metadata, c.created_at, c.updated_at,
                 b.title,
@@ -165,7 +165,7 @@ pub fn list_all_chats(db: State<'_, Db>) -> AppResult<Vec<Chat>> {
 
 #[tauri::command]
 pub fn get_chat(chat_id: String, db: State<'_, Db>) -> AppResult<Chat> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let chat = conn.query_row(
         "SELECT id, book_id, title, model, pinned, metadata, created_at, updated_at
          FROM chats WHERE id = ?1",
@@ -218,7 +218,7 @@ pub fn rename_chat(
 }
 
 pub(crate) fn query_chat_messages(db: &Db, chat_id: &str) -> AppResult<Vec<ChatMsg>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT id, chat_id, role, content, context, metadata, created_at, updated_at
          FROM chat_messages WHERE chat_id = ?1

--- a/src-tauri/src/commands/collections.rs
+++ b/src-tauri/src/commands/collections.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::db::Db;
-use crate::error::{AppError, AppResult};
+use crate::error::AppResult;
 use crate::sync::events::EventBody;
 use crate::sync::writer::SyncWriter;
 
@@ -18,7 +18,7 @@ pub struct Collection {
 }
 
 pub(crate) fn query_collections(db: &Db) -> AppResult<Vec<Collection>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT c.id, c.name, c.created_at, c.updated_at, c.sort_order, COUNT(cb.book_id) as book_count
          FROM collections c
@@ -238,7 +238,7 @@ pub fn list_books_in_collection(
     collection_id: String,
     db: State<'_, Db>,
 ) -> AppResult<Vec<String>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT book_id FROM collection_books WHERE collection_id = ?1",
     )?;

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -233,7 +233,7 @@ pub fn mcp_integration_status(db: State<'_, Db>) -> AppResult<McpIntegrationStat
         .and_then(|p| codex_is_enabled_at(&p))
         .unwrap_or(false);
     let write_enabled = {
-        let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+        let conn = db.reader();
         conn.query_row(
             "SELECT value FROM settings WHERE key = 'mcp_write_enabled'",
             [],

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -8,7 +8,7 @@ use crate::secrets::Secrets;
 
 #[tauri::command]
 pub fn get_all_settings(db: State<'_, Db>, secrets: State<'_, Secrets>) -> AppResult<HashMap<String, String>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare("SELECT key, value FROM settings")?;
     let mut settings = stmt
         .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?
@@ -28,7 +28,7 @@ pub fn get_setting(key: String, db: State<'_, Db>, secrets: State<'_, Secrets>) 
         return Ok(secrets.get(&key));
     }
 
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let result = conn.query_row(
         "SELECT value FROM settings WHERE key = ?1",
         params![key],
@@ -73,7 +73,7 @@ pub fn set_settings_bulk(settings: HashMap<String, String>, db: State<'_, Db>, s
 
 #[tauri::command]
 pub fn get_book_settings(book_id: String, db: State<'_, Db>) -> AppResult<HashMap<String, String>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare("SELECT key, value FROM book_settings WHERE book_id = ?1")?;
     let settings = stmt
         .query_map(params![book_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -553,10 +553,7 @@ fn publish_bootstrap_snapshot(
 }
 
 fn read_watermarks(db: &Db) -> AppResult<Vec<(String, Option<String>)>> {
-    let conn = db
-        .conn
-        .lock()
-        .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT peer_device, last_event_id FROM _replay_state",
     )?;
@@ -567,10 +564,7 @@ fn read_watermarks(db: &Db) -> AppResult<Vec<(String, Option<String>)>> {
 }
 
 fn count_local_outbox(db: &Db) -> AppResult<i64> {
-    let conn = db
-        .conn
-        .lock()
-        .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
+    let conn = db.reader();
     let n: i64 = conn
         .query_row("SELECT COUNT(*) FROM _pending_publish", [], |r| r.get(0))
         .unwrap_or(0);
@@ -578,10 +572,7 @@ fn count_local_outbox(db: &Db) -> AppResult<i64> {
 }
 
 fn read_last_replay_at(db: &Db) -> AppResult<Option<i64>> {
-    let conn = db
-        .conn
-        .lock()
-        .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
+    let conn = db.reader();
     let v: Option<i64> = conn
         .query_row(
             "SELECT MAX(updated_at) FROM _replay_state",
@@ -599,7 +590,11 @@ fn read_last_replay_at(db: &Db) -> AppResult<Option<i64>> {
 /// field. Returns 0 on any read/parse error — the count is purely
 /// for the settings UI's "pending" pill.
 fn count_pending_for_peer(shared_dir: &Path, peer: &str, watermark: Option<&str>) -> i64 {
+    use crate::icloud;
     let log_path = shared_dir.join("logs").join(format!("{peer}.jsonl"));
+    if !log_path.exists() || icloud::has_icloud_placeholder(&log_path) {
+        return 0;
+    }
     let bytes = match fs::read(&log_path) {
         Ok(b) => b,
         Err(_) => return 0,

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -595,9 +595,16 @@ fn count_pending_for_peer(shared_dir: &Path, peer: &str, watermark: Option<&str>
     if !log_path.exists() || icloud::has_icloud_placeholder(&log_path) {
         return 0;
     }
-    let bytes = match fs::read(&log_path) {
-        Ok(b) => b,
-        Err(_) => return 0,
+    let bytes = {
+        let path = log_path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(fs::read(&path));
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(2)) {
+            Ok(Ok(b)) => b,
+            _ => return 0,
+        }
     };
     let mut count = 0i64;
     for line in bytes.split(|&b| b == b'\n') {

--- a/src-tauri/src/commands/translation.rs
+++ b/src-tauri/src/commands/translation.rs
@@ -55,7 +55,7 @@ pub async fn ai_translate_passage(
 ) -> AppResult<()> {
     // Read target language setting
     let (target_lang, provider, model, base_url, keep_alive, auth_mode) = {
-        let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+        let conn = db.reader();
         let get = |key: &str| -> Option<String> {
             conn.query_row(
                 "SELECT value FROM settings WHERE key = ?1",
@@ -213,7 +213,7 @@ pub(crate) fn query_translations(
     db: &Db,
     book_id: Option<&str>,
 ) -> AppResult<Vec<Translation>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
 
     let mut sql = "SELECT t.id, t.book_id, t.source_text, t.translated_text, t.target_language, t.cfi, t.created_at, t.updated_at, b.title FROM translations t LEFT JOIN books b ON t.book_id = b.id".to_string();
     let mut sql_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();

--- a/src-tauri/src/commands/vocab.rs
+++ b/src-tauri/src/commands/vocab.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::db::Db;
-use crate::error::{AppError, AppResult};
+use crate::error::AppResult;
 use crate::sync::events::{EventBody, VocabPayload};
 use crate::sync::writer::SyncWriter;
 
@@ -166,7 +166,7 @@ pub fn remove_vocab_word(
 }
 
 pub(crate) fn query_vocab_words(db: &Db, book_id: &str) -> AppResult<Vec<VocabWord>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(&format!(
         "SELECT {} FROM vocab_words WHERE book_id = ?1 ORDER BY created_at DESC",
         SELECT_COLS
@@ -188,7 +188,7 @@ pub fn check_vocab_exists(
     word: String,
     db: State<'_, Db>,
 ) -> AppResult<Option<String>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT id FROM vocab_words WHERE book_id = ?1 AND word = ?2 COLLATE NOCASE LIMIT 1",
     )?;
@@ -201,7 +201,7 @@ pub fn check_vocab_exists(
 
 #[tauri::command]
 pub fn list_all_vocab_words(db: State<'_, Db>) -> AppResult<Vec<VocabWord>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let mut stmt = conn.prepare(
         "SELECT v.id, v.book_id, v.word, v.definition, v.context_sentence, v.cfi, v.mastery, v.review_count, v.next_review_at, v.created_at, v.updated_at, v.context_explanation, b.title FROM vocab_words v LEFT JOIN books b ON v.book_id = b.id ORDER BY v.created_at DESC"
     )?;
@@ -247,7 +247,7 @@ pub fn update_vocab_mastery(
 }
 
 pub(crate) fn query_vocab_due(db: &Db) -> AppResult<Vec<VocabWord>> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let now_ms = chrono::Utc::now().timestamp_millis();
     let mut stmt = conn.prepare(&format!(
         "SELECT {} FROM vocab_words WHERE next_review_at IS NOT NULL AND next_review_at <= ?1 ORDER BY next_review_at ASC",
@@ -265,7 +265,7 @@ pub fn list_vocab_due_for_review(db: State<'_, Db>) -> AppResult<Vec<VocabWord>>
 }
 
 pub(crate) fn query_vocab_stats(db: &Db) -> AppResult<VocabStats> {
-    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    let conn = db.reader();
     let now_ms = chrono::Utc::now().timestamp_millis();
     let total: i64 = conn.query_row("SELECT COUNT(*) FROM vocab_words", [], |r| r.get(0))?;
     let new_count: i64 = conn.query_row(

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -22,15 +22,21 @@ const MIGRATIONS: &[(i64, &str)] = &[
 
 /// SQLite handle for the local materialized view.
 ///
-/// `conn` and `data_dir` live behind `Arc<Mutex<…>>` so `Db` is cheaply
-/// `Clone`-able. Cloning shares the underlying mutex; the sync watcher
-/// holds one clone in its dedicated thread while Tauri's command
-/// dispatcher holds another in app state. Without the `Arc` we would
-/// either force every command signature to switch to `State<Arc<Db>>`
-/// or push `app_handle.state::<Db>()` indirection into the watcher
-/// loop — both worse than this two-line shape change.
+/// Two connections: `conn` (write) and `read_conn` (read). SQLite WAL
+/// mode allows concurrent readers alongside a single writer, but
+/// `rusqlite::Connection` isn't `Sync` so each needs its own mutex.
+/// Separating them means the sync engine's 500-event replay never
+/// blocks a frontend `list_books` — the two mutexes are independent.
+///
+/// Both fields live behind `Arc<Mutex<…>>` so `Db` is cheaply
+/// `Clone`-able. Cloning shares the underlying mutexes; the sync
+/// watcher holds one clone in its dedicated thread while Tauri's
+/// command dispatcher holds another in app state.
 pub struct Db {
+    /// Write connection — used by sync engine, import, delete, etc.
     pub conn: Arc<Mutex<Connection>>,
+    /// Read-only connection — used by frontend query commands.
+    pub read_conn: Arc<Mutex<Connection>>,
     pub data_dir: Arc<Mutex<PathBuf>>,
 }
 
@@ -38,12 +44,20 @@ impl Clone for Db {
     fn clone(&self) -> Self {
         Self {
             conn: Arc::clone(&self.conn),
+            read_conn: Arc::clone(&self.read_conn),
             data_dir: Arc::clone(&self.data_dir),
         }
     }
 }
 
 impl Db {
+    /// Lock the read-only connection. Frontend query commands should
+    /// call this instead of `conn.lock()` so they never contend with
+    /// sync engine writes.
+    pub fn reader(&self) -> std::sync::MutexGuard<'_, Connection> {
+        self.read_conn.lock().expect("read_conn mutex")
+    }
+
     /// Override the data_dir after construction. Used by `mcp_stdio_main`
     /// to point at the iCloud ubiquity container when the user has
     /// migrated, so blob paths (books/, covers/) resolve correctly.
@@ -80,8 +94,10 @@ impl Db {
             .parent()
             .unwrap_or_else(|| Path::new(""))
             .to_path_buf();
+        let conn = Arc::new(Mutex::new(conn));
         Ok(Self {
-            conn: Arc::new(Mutex::new(conn)),
+            read_conn: conn.clone(),
+            conn,
             data_dir: Arc::new(Mutex::new(dummy_data_dir)),
         })
     }
@@ -103,8 +119,10 @@ impl Db {
             .parent()
             .unwrap_or_else(|| Path::new(""))
             .to_path_buf();
+        let conn = Arc::new(Mutex::new(conn));
         Ok(Self {
-            conn: Arc::new(Mutex::new(conn)),
+            read_conn: conn.clone(),
+            conn,
             data_dir: Arc::new(Mutex::new(data_dir)),
         })
     }
@@ -142,8 +160,20 @@ impl Db {
         // One-time migration: convert absolute paths to relative
         Self::migrate_to_relative_paths(&conn, data_dir)?;
 
+        // Separate read connection so frontend queries never contend
+        // with sync engine writes. WAL mode allows concurrent readers
+        // alongside one writer at the SQLite level; the two Rust
+        // mutexes are independent.
+        let read_conn = Connection::open_with_flags(
+            &db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
+                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+        )?;
+
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
+            read_conn: Arc::new(Mutex::new(read_conn)),
             data_dir: Arc::new(Mutex::new(data_dir.to_path_buf())),
         })
     }
@@ -188,7 +218,7 @@ impl Db {
     /// migrations ran) or the read fails. Used by the startup banner so a
     /// triaged log file leads with the actual on-disk version.
     pub fn schema_version(&self) -> i64 {
-        let conn = match self.conn.lock() {
+        let conn = match self.read_conn.lock() {
             Ok(c) => c,
             Err(_) => return 0,
         };

--- a/src-tauri/src/sync/log.rs
+++ b/src-tauri/src/sync/log.rs
@@ -196,11 +196,17 @@ pub fn read_log_file(path: &Path) -> AppResult<Vec<Event>> {
 /// Callers pass `on_stall` / `on_success` callbacks so the replay
 /// engine can track which paths have stalled and skip them on
 /// subsequent ticks (preventing blocked-thread accumulation).
+///
+/// `on_thread_done` runs inside the spawned thread when `fs::read`
+/// completes (success or error). Used by the replay engine to clear
+/// the path's in-flight flag so a subsequent tick knows no reader
+/// thread is still blocked on this path.
 pub fn read_log_file_with_timeout(
     path: &Path,
     timeout: std::time::Duration,
     on_stall: impl FnOnce(&Path),
     on_success: impl FnOnce(&Path),
+    on_thread_done: impl FnOnce() + Send + 'static,
 ) -> AppResult<Vec<Event>> {
     use crate::icloud;
     if !path.exists() {
@@ -217,7 +223,9 @@ pub fn read_log_file_with_timeout(
     let path_buf = path.to_path_buf();
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let _ = tx.send(fs::read(&path_buf));
+        let result = fs::read(&path_buf);
+        on_thread_done();
+        let _ = tx.send(result);
     });
     match rx.recv_timeout(timeout) {
         Ok(Ok(bytes)) => {

--- a/src-tauri/src/sync/log.rs
+++ b/src-tauri/src/sync/log.rs
@@ -184,15 +184,31 @@ pub fn read_log_file(path: &Path) -> AppResult<Vec<Event>> {
     parse_log_bytes(&bytes, path)
 }
 
-/// Like `read_log_file` but aborts if the read takes longer than
-/// `timeout`. iCloud-evicted peer log files block `fs::read` until
-/// the download completes — on cold caches that's unbounded. Returns
-/// an empty vec on timeout so the tick skips the peer and retries
-/// next time.
+/// Like `read_log_file` but skips iCloud-evicted files and applies a
+/// timeout to the read. Returns an empty vec when the file is evicted
+/// or the read exceeds `timeout`, so the tick skips the peer and
+/// retries next time.
+///
+/// **Thread safety**: before spawning a read thread, checks for the
+/// `.foo.icloud` placeholder. If the file is evicted, triggers a
+/// background download and returns immediately — no thread spawned,
+/// no accumulation of blocked OS threads across repeated ticks.
 pub fn read_log_file_with_timeout(
     path: &Path,
     timeout: std::time::Duration,
 ) -> AppResult<Vec<Event>> {
+    use crate::icloud;
+    if !path.exists() {
+        if icloud::has_icloud_placeholder(path) {
+            log::info!(
+                "sync: peer log {} is iCloud-evicted — triggering download, skipping this tick",
+                path.display(),
+            );
+            icloud::trigger_download_file(path);
+            return Ok(Vec::new());
+        }
+        return Ok(Vec::new());
+    }
     let path_buf = path.to_path_buf();
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {

--- a/src-tauri/src/sync/log.rs
+++ b/src-tauri/src/sync/log.rs
@@ -105,7 +105,15 @@ impl EventLog {
     /// generation and the file write happen under it. See the module
     /// docstring for why that's required.
     pub fn append_batch(&self, bodies: Vec<EventBody>, ts: i64) -> AppResult<Vec<Event>> {
-        if bodies.is_empty() {
+        let entries: Vec<(EventBody, i64)> = bodies.into_iter().map(|b| (b, ts)).collect();
+        self.append_batch_varied(entries)
+    }
+
+    /// Like `append_batch` but each event carries its own timestamp.
+    /// Used by the outbox flush where pending events may span multiple
+    /// commands with different `ts` values.
+    pub fn append_batch_varied(&self, entries: Vec<(EventBody, i64)>) -> AppResult<Vec<Event>> {
+        if entries.is_empty() {
             return Ok(Vec::new());
         }
 
@@ -118,8 +126,8 @@ impl EventLog {
         // monotonicity across process restarts; `ts` on the event is the
         // caller-supplied value (usually a few milliseconds earlier).
         let now = SystemTime::now();
-        let mut events = Vec::with_capacity(bodies.len());
-        for body in bodies {
+        let mut events = Vec::with_capacity(entries.len());
+        for (body, ts) in entries {
             let ulid = inner
                 .gen
                 .generate_from_datetime(now)
@@ -173,6 +181,39 @@ pub fn read_log_file(path: &Path) -> AppResult<Vec<Event>> {
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => return Err(AppError::Io(e)),
     };
+    parse_log_bytes(&bytes, path)
+}
+
+/// Like `read_log_file` but aborts if the read takes longer than
+/// `timeout`. iCloud-evicted peer log files block `fs::read` until
+/// the download completes — on cold caches that's unbounded. Returns
+/// an empty vec on timeout so the tick skips the peer and retries
+/// next time.
+pub fn read_log_file_with_timeout(
+    path: &Path,
+    timeout: std::time::Duration,
+) -> AppResult<Vec<Event>> {
+    let path_buf = path.to_path_buf();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(fs::read(&path_buf));
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(bytes)) => parse_log_bytes(&bytes, path),
+        Ok(Err(e)) if e.kind() == io::ErrorKind::NotFound => Ok(Vec::new()),
+        Ok(Err(e)) => Err(AppError::Io(e)),
+        Err(_) => {
+            log::warn!(
+                "sync: timed out reading peer log {} after {}s — skipping this tick",
+                path.display(),
+                timeout.as_secs(),
+            );
+            Ok(Vec::new())
+        }
+    }
+}
+
+fn parse_log_bytes(bytes: &[u8], path: &Path) -> AppResult<Vec<Event>> {
     let mut out = Vec::new();
     for (idx, line) in bytes.split(|&b| b == b'\n').enumerate() {
         if line.is_empty() {

--- a/src-tauri/src/sync/log.rs
+++ b/src-tauri/src/sync/log.rs
@@ -191,11 +191,16 @@ pub fn read_log_file(path: &Path) -> AppResult<Vec<Event>> {
 ///
 /// **Thread safety**: before spawning a read thread, checks for the
 /// `.foo.icloud` placeholder. If the file is evicted, triggers a
-/// background download and returns immediately — no thread spawned,
-/// no accumulation of blocked OS threads across repeated ticks.
+/// background download and returns immediately — no thread spawned.
+///
+/// Callers pass `on_stall` / `on_success` callbacks so the replay
+/// engine can track which paths have stalled and skip them on
+/// subsequent ticks (preventing blocked-thread accumulation).
 pub fn read_log_file_with_timeout(
     path: &Path,
     timeout: std::time::Duration,
+    on_stall: impl FnOnce(&Path),
+    on_success: impl FnOnce(&Path),
 ) -> AppResult<Vec<Event>> {
     use crate::icloud;
     if !path.exists() {
@@ -215,15 +220,19 @@ pub fn read_log_file_with_timeout(
         let _ = tx.send(fs::read(&path_buf));
     });
     match rx.recv_timeout(timeout) {
-        Ok(Ok(bytes)) => parse_log_bytes(&bytes, path),
+        Ok(Ok(bytes)) => {
+            on_success(path);
+            parse_log_bytes(&bytes, path)
+        }
         Ok(Err(e)) if e.kind() == io::ErrorKind::NotFound => Ok(Vec::new()),
         Ok(Err(e)) => Err(AppError::Io(e)),
         Err(_) => {
             log::warn!(
-                "sync: timed out reading peer log {} after {}s — skipping this tick",
+                "sync: timed out reading peer log {} after {}s — backing off",
                 path.display(),
                 timeout.as_secs(),
             );
+            on_stall(path);
             Ok(Vec::new())
         }
     }

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -26,7 +26,7 @@
 //! scheduler decides which one runs first, but both produce the same end
 //! state because every operation is idempotent.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -67,6 +67,18 @@ static FLUSH_OUTBOX_MUTEX: Mutex<()> = Mutex::new(());
 /// (e.g. iCloud file materialization in progress).
 static STALLED_PATHS: Mutex<Option<HashMap<PathBuf, Instant>>> = Mutex::new(None);
 
+/// Paths that currently have a reader thread blocked on `fs::read`.
+/// Checked before spawning a new reader — if the previous thread is
+/// still alive (timed out but not yet returned), we skip instead of
+/// accumulating another blocked OS thread.
+///
+/// The spawned thread clears its entry via `on_thread_done` when
+/// `fs::read` returns, regardless of success or error. On timeout the
+/// entry stays set, preventing a duplicate thread until the original
+/// completes. Combined with `STALLED_PATHS` backoff, this bounds
+/// blocked threads to at most one per path.
+static IN_FLIGHT: Mutex<Option<HashSet<PathBuf>>> = Mutex::new(None);
+
 const STALL_BACKOFF: std::time::Duration = std::time::Duration::from_secs(120);
 
 fn is_stalled(path: &Path) -> bool {
@@ -87,6 +99,24 @@ fn clear_stalled(path: &Path) {
     let mut guard = STALLED_PATHS.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(map) = guard.as_mut() {
         map.remove(path);
+    }
+}
+
+fn is_in_flight(path: &Path) -> bool {
+    let guard = IN_FLIGHT.lock().unwrap_or_else(|e| e.into_inner());
+    guard.as_ref().is_some_and(|set| set.contains(path))
+}
+
+fn mark_in_flight(path: &Path) {
+    let mut guard = IN_FLIGHT.lock().unwrap_or_else(|e| e.into_inner());
+    let set = guard.get_or_insert_with(HashSet::new);
+    set.insert(path.to_path_buf());
+}
+
+fn clear_in_flight(path: &Path) {
+    let mut guard = IN_FLIGHT.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(set) = guard.as_mut() {
+        set.remove(path);
     }
 }
 
@@ -231,8 +261,10 @@ impl ReplayEngine {
     ///
     /// - **Phase A — read** (no lock): deserialize peer snapshots
     ///   and log files from disk.
-    /// - **Phase B — snapshots** (one tx per snapshot): apply each
-    ///   peer snapshot, read watermarks, build filtered event list.
+    /// - **Phase B — snapshots** (one write tx per peer, then read
+    ///   watermarks via reader): apply each peer snapshot in its own
+    ///   short-lived write tx, then read watermarks through
+    ///   `db.reader()` to filter the event list.
     /// - **Phase C — events** (one tx per event): apply events one
     ///   at a time, advancing watermarks after each. Idempotent
     ///   events + per-event watermark means a crash mid-replay
@@ -244,23 +276,36 @@ impl ReplayEngine {
     ) -> AppResult<(usize, usize)> {
         // -- Phase A — read everything from disk. No SQL lock held. --
         // Paths that previously timed out are skipped for STALL_BACKOFF
-        // (2 min) to avoid spawning another blocked reader thread.
+        // (2 min) to avoid spawning another blocked reader thread. Paths
+        // with a reader thread still blocked from a prior tick are also
+        // skipped (IN_FLIGHT) — at most one OS thread per path.
         let read_timeout = std::time::Duration::from_secs(30);
         let mut snapshots: Vec<(String, Snapshot)> = Vec::new();
         for (device, files) in peers {
             let Some(snap_path) = &files.snap_path else {
                 continue;
             };
-            if is_stalled(snap_path) {
-                ::log::debug!("sync: skipping stalled snapshot {}", snap_path.display());
+            if is_stalled(snap_path) || is_in_flight(snap_path) {
+                ::log::debug!("sync: skipping stalled/in-flight snapshot {}", snap_path.display());
                 continue;
             }
+            mark_in_flight(snap_path);
+            let snap_path_owned = snap_path.to_path_buf();
             match Snapshot::read_from_with_timeout(
                 snap_path, read_timeout, mark_stalled, clear_stalled,
+                move || clear_in_flight(&snap_path_owned),
             ) {
                 Ok(Some(s)) => snapshots.push((device.clone(), s)),
-                Ok(None) => {} // evicted or timed out — skip
+                Ok(None) => {
+                    if !is_stalled(snap_path) {
+                        // No thread was spawned (evicted/missing) — clear now.
+                        clear_in_flight(snap_path);
+                    }
+                    // If stalled: thread timed out and is still blocked.
+                    // on_thread_done will clear in-flight when fs::read returns.
+                }
                 Err(e) => {
+                    clear_in_flight(snap_path);
                     ::log::warn!(
                         "sync: skipping malformed snapshot {}: {e}",
                         snap_path.display()
@@ -273,38 +318,54 @@ impl ReplayEngine {
             let Some(log_path) = &files.log_path else {
                 continue;
             };
-            if is_stalled(log_path) {
-                ::log::debug!("sync: skipping stalled log {}", log_path.display());
+            if is_stalled(log_path) || is_in_flight(log_path) {
+                ::log::debug!("sync: skipping stalled/in-flight log {}", log_path.display());
                 continue;
             }
+            mark_in_flight(log_path);
+            let log_path_owned = log_path.to_path_buf();
             let events = log::read_log_file_with_timeout(
                 log_path, read_timeout, mark_stalled, clear_stalled,
+                move || clear_in_flight(&log_path_owned),
             )?;
+            if events.is_empty() {
+                // No thread was spawned (evicted/missing) or read returned
+                // empty — clear in-flight. If a thread timed out, on_stall
+                // already fired and the thread's on_thread_done will clear
+                // in-flight when fs::read eventually returns.
+                if !is_stalled(log_path) {
+                    clear_in_flight(log_path);
+                }
+            }
             peer_logs.push((device.clone(), events));
         }
 
-        // -- Phase B — apply snapshots, collect filtered events. --
+        // -- Phase B — apply snapshots (one write tx per peer). --
         let mut snapshots_applied = 0usize;
-        let mut all_events: Vec<Event> = Vec::new();
-        {
+        for (device, snap) in &snapshots {
             let mut conn = db
                 .conn
                 .lock()
                 .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
-
             let tx = conn.transaction()?;
-            for (device, snap) in &snapshots {
-                let outcome = snap.apply_peer(&tx, device)?;
-                if matches!(
-                    outcome,
-                    super::snapshot::ApplyOutcome::Applied
-                        | super::snapshot::ApplyOutcome::HeaderOnly
-                ) {
-                    snapshots_applied += 1;
-                }
+            let outcome = snap.apply_peer(&tx, device)?;
+            tx.commit()?;
+            drop(conn);
+            if matches!(
+                outcome,
+                super::snapshot::ApplyOutcome::Applied
+                    | super::snapshot::ApplyOutcome::HeaderOnly
+            ) {
+                snapshots_applied += 1;
             }
+        }
+
+        // Read watermarks through the reader — no write lock needed.
+        let mut all_events: Vec<Event> = Vec::new();
+        {
+            let reader = db.reader();
             for (device, events) in &peer_logs {
-                let last_id = read_last_event_id(&tx, device)?;
+                let last_id = read_last_event_id(&reader, device)?;
                 for ev in events {
                     if let Some(w) = last_id.as_deref() {
                         if ev.id.as_str() <= w {
@@ -314,9 +375,7 @@ impl ReplayEngine {
                     all_events.push(ev.clone());
                 }
             }
-            tx.commit()?;
         }
-        // conn released.
 
         all_events.sort_by(|a, b| (a.ts, &a.device).cmp(&(b.ts, &b.device)));
 
@@ -480,8 +539,8 @@ fn discover_peers(shared_dir: &Path) -> AppResult<BTreeMap<String, PeerFiles>> {
 // Watermark + outbox SQL.
 // ---------------------------------------------------------------------------
 
-fn read_last_event_id(tx: &rusqlite::Transaction, peer: &str) -> AppResult<Option<String>> {
-    let v: Option<Option<String>> = tx
+fn read_last_event_id(conn: &Connection, peer: &str) -> AppResult<Option<String>> {
+    let v: Option<Option<String>> = conn
         .query_row(
             "SELECT last_event_id FROM _replay_state WHERE peer_device = ?1",
             params![peer],
@@ -1009,6 +1068,154 @@ mod tests {
             parsed.last_seen >= before,
             "last_seen ({}) should be >= pre-tick ts ({before})",
             parsed.last_seen
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // iCloud placeholder discovery
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn discover_peers_recognizes_icloud_placeholders() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let shared = dir.path().join("shared");
+        let logs = shared.join("logs");
+        fs::create_dir_all(&logs).unwrap();
+
+        // Real file for peer-A.
+        fs::write(logs.join("peer-A.jsonl"), b"").unwrap();
+
+        // iCloud placeholders only for peer-B (evicted by iCloud daemon).
+        fs::write(logs.join(".peer-B.jsonl.icloud"), b"").unwrap();
+        fs::write(logs.join(".peer-B.snapshot.json.icloud"), b"").unwrap();
+
+        let peers = discover_peers(&shared).unwrap();
+
+        assert!(peers.contains_key("peer-A"), "real file should be discovered");
+        assert_eq!(peers["peer-A"].log_path.as_deref(), Some(logs.join("peer-A.jsonl").as_path()));
+
+        assert!(peers.contains_key("peer-B"), "placeholder should be discovered");
+        assert_eq!(
+            peers["peer-B"].log_path.as_deref(),
+            Some(logs.join("peer-B.jsonl").as_path()),
+            "placeholder should derive the real (non-.icloud) path",
+        );
+        assert_eq!(
+            peers["peer-B"].snap_path.as_deref(),
+            Some(logs.join("peer-B.snapshot.json").as_path()),
+        );
+    }
+
+    #[test]
+    fn discover_peers_real_file_wins_over_placeholder() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let shared = dir.path().join("shared");
+        let logs = shared.join("logs");
+        fs::create_dir_all(&logs).unwrap();
+
+        // Both real file and placeholder exist (transient state during
+        // iCloud download — daemon materializes the file then removes
+        // the placeholder).
+        fs::write(logs.join("peer-A.jsonl"), b"").unwrap();
+        fs::write(logs.join(".peer-A.jsonl.icloud"), b"").unwrap();
+
+        let peers = discover_peers(&shared).unwrap();
+        assert_eq!(peers.len(), 1);
+        assert!(peers.contains_key("peer-A"));
+        // The real path should be set (both the real-file branch and
+        // the placeholder branch produce the same path, but the
+        // real-file branch uses direct assignment while the placeholder
+        // branch uses get_or_insert, so neither clobbers the other).
+        assert_eq!(
+            peers["peer-A"].log_path.as_deref(),
+            Some(logs.join("peer-A.jsonl").as_path()),
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Stall + in-flight tracking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn stall_tracking_marks_and_clears() {
+        let path = PathBuf::from("/tmp/quill-test-stall-tracking.jsonl");
+        assert!(!is_stalled(&path));
+        mark_stalled(&path);
+        assert!(is_stalled(&path));
+        clear_stalled(&path);
+        assert!(!is_stalled(&path));
+    }
+
+    #[test]
+    fn in_flight_tracking_marks_and_clears() {
+        let path = PathBuf::from("/tmp/quill-test-in-flight-tracking.jsonl");
+        assert!(!is_in_flight(&path));
+        mark_in_flight(&path);
+        assert!(is_in_flight(&path));
+        clear_in_flight(&path);
+        assert!(!is_in_flight(&path));
+    }
+
+    #[test]
+    fn tick_skips_stalled_peer_log() {
+        let env = setup("self");
+        write_peer_log(&env.shared, "peer-A", &[ev(1000, "peer-A", import("b1"))]);
+
+        // Mark peer-A's log as stalled. The path must match what
+        // discover_peers returns.
+        let stalled_path = env.shared.join("logs/peer-A.jsonl");
+        mark_stalled(&stalled_path);
+
+        let report = env.engine.tick(&env.db).unwrap();
+        assert_eq!(
+            report.events_applied, 0,
+            "stalled peer log should be skipped",
+        );
+        let n_books: i64 = env
+            .conn()
+            .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_books, 0, "no events applied → no books");
+
+        // Clear stall — next tick picks it up.
+        clear_stalled(&stalled_path);
+        let report = env.engine.tick(&env.db).unwrap();
+        assert_eq!(report.events_applied, 1);
+    }
+
+    #[test]
+    fn tick_skips_in_flight_peer_log() {
+        let env = setup("self");
+        write_peer_log(&env.shared, "peer-A", &[ev(1000, "peer-A", import("b1"))]);
+
+        let in_flight_path = env.shared.join("logs/peer-A.jsonl");
+        mark_in_flight(&in_flight_path);
+
+        let report = env.engine.tick(&env.db).unwrap();
+        assert_eq!(
+            report.events_applied, 0,
+            "in-flight peer log should be skipped",
+        );
+
+        clear_in_flight(&in_flight_path);
+        let report = env.engine.tick(&env.db).unwrap();
+        assert_eq!(report.events_applied, 1);
+    }
+
+    #[test]
+    fn successful_read_clears_in_flight() {
+        let env = setup("self");
+        write_peer_log(&env.shared, "peer-A", &[ev(1000, "peer-A", import("b1"))]);
+
+        let log_path = env.shared.join("logs/peer-A.jsonl");
+        // Tick reads the file successfully → on_thread_done clears in-flight.
+        let report = env.engine.tick(&env.db).unwrap();
+        assert_eq!(report.events_applied, 1);
+        // Give the reader thread time to call on_thread_done.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            !is_in_flight(&log_path),
+            "in-flight should be cleared after successful read",
         );
     }
 

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -211,13 +211,15 @@ impl ReplayEngine {
         peers: &BTreeMap<String, PeerFiles>,
     ) -> AppResult<(usize, usize)> {
         // -- Phase A — read everything from disk. No SQL lock held. --
+        let read_timeout = std::time::Duration::from_secs(30);
         let mut snapshots: Vec<(String, Snapshot)> = Vec::new();
         for (device, files) in peers {
             let Some(snap_path) = &files.snap_path else {
                 continue;
             };
-            match Snapshot::read_from(snap_path) {
-                Ok(s) => snapshots.push((device.clone(), s)),
+            match Snapshot::read_from_with_timeout(snap_path, read_timeout) {
+                Ok(Some(s)) => snapshots.push((device.clone(), s)),
+                Ok(None) => {} // evicted or timed out — skip
                 Err(e) => {
                     ::log::warn!(
                         "sync: skipping malformed snapshot {}: {e}",
@@ -227,7 +229,6 @@ impl ReplayEngine {
             }
         }
         let mut peer_logs: Vec<(String, Vec<Event>)> = Vec::new();
-        let read_timeout = std::time::Duration::from_secs(30);
         for (device, files) in peers {
             let Some(log_path) = &files.log_path else {
                 continue;

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -26,10 +26,11 @@
 //! scheduler decides which one runs first, but both produce the same end
 //! state because every operation is idempotent.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use rusqlite::{params, Connection};
 
@@ -57,6 +58,37 @@ static TICK_MUTEX: Mutex<()> = Mutex::new(());
 /// and even idempotent ones balloon the log. The mutex is entirely
 /// outside `db.conn`, so a flush in flight does not block UI writes.
 static FLUSH_OUTBOX_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Paths where a timed read stalled (timeout or in-flight). Keyed by
+/// canonical path, value is the `Instant` the backoff expires. A path
+/// in this set is skipped (no thread spawned) until the backoff
+/// elapses. Prevents blocked-thread accumulation when `fs::read`
+/// passes the `path.exists()` check but stalls inside the kernel
+/// (e.g. iCloud file materialization in progress).
+static STALLED_PATHS: Mutex<Option<HashMap<PathBuf, Instant>>> = Mutex::new(None);
+
+const STALL_BACKOFF: std::time::Duration = std::time::Duration::from_secs(120);
+
+fn is_stalled(path: &Path) -> bool {
+    let guard = STALLED_PATHS.lock().unwrap_or_else(|e| e.into_inner());
+    match guard.as_ref() {
+        Some(map) => map.get(path).is_some_and(|exp| Instant::now() < *exp),
+        None => false,
+    }
+}
+
+fn mark_stalled(path: &Path) {
+    let mut guard = STALLED_PATHS.lock().unwrap_or_else(|e| e.into_inner());
+    let map = guard.get_or_insert_with(HashMap::new);
+    map.insert(path.to_path_buf(), Instant::now() + STALL_BACKOFF);
+}
+
+fn clear_stalled(path: &Path) {
+    let mut guard = STALLED_PATHS.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(map) = guard.as_mut() {
+        map.remove(path);
+    }
+}
 
 /// What `tick()` did, surfaced for the "Sync now" UI and for tests.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -211,13 +243,21 @@ impl ReplayEngine {
         peers: &BTreeMap<String, PeerFiles>,
     ) -> AppResult<(usize, usize)> {
         // -- Phase A — read everything from disk. No SQL lock held. --
+        // Paths that previously timed out are skipped for STALL_BACKOFF
+        // (2 min) to avoid spawning another blocked reader thread.
         let read_timeout = std::time::Duration::from_secs(30);
         let mut snapshots: Vec<(String, Snapshot)> = Vec::new();
         for (device, files) in peers {
             let Some(snap_path) = &files.snap_path else {
                 continue;
             };
-            match Snapshot::read_from_with_timeout(snap_path, read_timeout) {
+            if is_stalled(snap_path) {
+                ::log::debug!("sync: skipping stalled snapshot {}", snap_path.display());
+                continue;
+            }
+            match Snapshot::read_from_with_timeout(
+                snap_path, read_timeout, mark_stalled, clear_stalled,
+            ) {
                 Ok(Some(s)) => snapshots.push((device.clone(), s)),
                 Ok(None) => {} // evicted or timed out — skip
                 Err(e) => {
@@ -233,7 +273,13 @@ impl ReplayEngine {
             let Some(log_path) = &files.log_path else {
                 continue;
             };
-            let events = log::read_log_file_with_timeout(log_path, read_timeout)?;
+            if is_stalled(log_path) {
+                ::log::debug!("sync: skipping stalled log {}", log_path.display());
+                continue;
+            }
+            let events = log::read_log_file_with_timeout(
+                log_path, read_timeout, mark_stalled, clear_stalled,
+            )?;
             peer_logs.push((device.clone(), events));
         }
 
@@ -393,6 +439,11 @@ struct PeerFiles {
 
 /// Walk `<shared>/logs/` and bucket files by device UUID. Returns a sorted
 /// map (BTreeMap) so iteration order is deterministic for tests.
+///
+/// Recognizes iCloud placeholders (`.foo.icloud`) alongside real files.
+/// When only a placeholder exists, the peer entry carries the *real*
+/// (non-placeholder) path so downstream readers can detect the eviction
+/// and trigger a download.
 fn discover_peers(shared_dir: &Path) -> AppResult<BTreeMap<String, PeerFiles>> {
     let logs_dir = shared_dir.join("logs");
     let mut peers: BTreeMap<String, PeerFiles> = BTreeMap::new();
@@ -410,8 +461,17 @@ fn discover_peers(shared_dir: &Path) -> AppResult<BTreeMap<String, PeerFiles>> {
             peers.entry(device.to_string()).or_default().snap_path = Some(path);
         } else if let Some(device) = name.strip_suffix(".jsonl") {
             peers.entry(device.to_string()).or_default().log_path = Some(path);
+        } else if let Some(inner) = name.strip_prefix('.').and_then(|s| s.strip_suffix(".icloud")) {
+            // iCloud placeholder: `.dev-uuid.jsonl.icloud` → real path `dev-uuid.jsonl`
+            let real_path = logs_dir.join(inner);
+            if let Some(device) = inner.strip_suffix(".snapshot.json") {
+                peers.entry(device.to_string()).or_default().snap_path
+                    .get_or_insert(real_path);
+            } else if let Some(device) = inner.strip_suffix(".jsonl") {
+                peers.entry(device.to_string()).or_default().log_path
+                    .get_or_insert(real_path);
+            }
         }
-        // Anything else (e.g. `*.tmp` from in-progress writes) is skipped.
     }
     Ok(peers)
 }

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -2,26 +2,29 @@
 //!
 //! Five phases per call:
 //! 0. **Drain `_pending_publish`.** Any events the local `SyncWriter`
-//!    committed to SQL but failed to append to the device log get appended
-//!    here. Until they're in the log, peers don't see them — so this is the
-//!    publish-retry path that bounds Step 3's commit-then-flush failure
-//!    asymmetry. (See [`docs/impls/sync/31-sync-known-problems.md`] §1.)
+//!    committed to SQL but failed to append to the device log get
+//!    appended here — as a single batched write (one `NSFileCoordinator`
+//!    call) instead of per-event. Until they're in the log, peers don't
+//!    see them — so this is the publish-retry path that bounds Step 3's
+//!    commit-then-flush failure asymmetry.
 //! 1. **Discover peers.** Walk `<shared>/logs/*.{jsonl,snapshot.json}` and
 //!    bucket by device UUID. The local device is included — its snapshot
 //!    is what pulls conflict-copy rows back into local SQL during migration
 //!    apply-back, and re-applying its own log events is idempotent.
 //! 2. **Read.** For each peer: read snapshot if `_replay_state` says it's
-//!    new; read log events with id > `last_event_id` watermark.
+//!    new; read log events with id > `last_event_id` watermark. Peer log
+//!    reads have a 30s timeout so iCloud-evicted files don't block
+//!    indefinitely — timed-out peers are skipped and retried next tick.
 //! 3. **Sort + apply.** Snapshots applied per-peer first (each updates its
 //!    own watermarks). Events from every peer merged into one global vec
-//!    sorted by `(ts, device)`, then `merge::apply_event` runs them in one
-//!    SQL transaction.
+//!    sorted by `(ts, device)`, then applied one per transaction via the
+//!    write connection. The separate read connection (`Db::reader()`)
+//!    ensures frontend queries are never blocked by the replay engine.
 //! 4. **Commit + advance event watermarks** to the max id seen per peer.
 //!
-//! Foreign keys are toggled OFF before BEGIN and ON after COMMIT — see the
-//! `merge` module's docstring for why. Concurrent ticks are serialized by a
-//! process-wide mutex; the OS scheduler decides which one runs first, but
-//! both produce the same end state because every operation is idempotent.
+//! Concurrent ticks are serialized by a process-wide mutex; the OS
+//! scheduler decides which one runs first, but both produce the same end
+//! state because every operation is idempotent.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -224,11 +227,12 @@ impl ReplayEngine {
             }
         }
         let mut peer_logs: Vec<(String, Vec<Event>)> = Vec::new();
+        let read_timeout = std::time::Duration::from_secs(30);
         for (device, files) in peers {
             let Some(log_path) = &files.log_path else {
                 continue;
             };
-            let events = log::read_log_file_after(log_path, None)?;
+            let events = log::read_log_file_with_timeout(log_path, read_timeout)?;
             peer_logs.push((device.clone(), events));
         }
 
@@ -309,28 +313,19 @@ impl ReplayEngine {
 
 }
 
-/// Drain `_pending_publish` into `log`. Each row is re-serialized into an
-/// `EventBody`, appended (which mints a fresh ULID), and on success deleted
-/// from the outbox. If the append fails, the row stays put for the next
-/// caller to retry.
+/// Drain `_pending_publish` into `log` as a single batched write. All
+/// pending rows are deserialized, appended atomically via
+/// `append_batch_varied` (one `NSFileCoordinator` call, one fsync), then
+/// bulk-deleted from the outbox. If the batch write fails, no rows are
+/// deleted and the entire batch retries on the next call.
 ///
 /// Shared between `ReplayEngine::tick` (Phase 0) and `SyncWriter::with_tx`
-/// (post-commit step) so the publish-retry guarantee holds end-to-end:
-/// every committed-but-not-yet-published event lands in the device log on
-/// the next successful flush from either path.
-///
-/// **Locking discipline.** Takes `&Db` (not `&mut Connection`) so we can
-/// release the SQLite mutex around `log.append`. On macOS that append
-/// goes through `NSFileCoordinator` and synchronously waits for Apple's
-/// `bird` daemon — often several seconds. Holding `db.conn` across that
-/// wait would serialize every UI write behind the watcher's tick, which
-/// is exactly the "import spinner hangs" symptom users hit. Per-row
-/// lock/unlock is cheap relative to the iCloud I/O.
+/// (post-commit step) so the publish-retry guarantee holds end-to-end.
 ///
 /// **Single-flight via `FLUSH_OUTBOX_MUTEX`.** Concurrent callers (the
 /// `SyncWriter` background worker + a watcher-driven `tick`) would
-/// otherwise both read the same pending row, both append, and both
-/// delete — duplicating the event in the device log. The mutex sits
+/// otherwise both read the same pending rows, both append, and both
+/// delete — duplicating events in the device log. The mutex sits
 /// outside `db.conn` so a flush in flight does not block UI writes.
 pub fn flush_outbox(db: &Db, log: &EventLog) -> AppResult<usize> {
     let _guard = FLUSH_OUTBOX_MUTEX
@@ -347,31 +342,42 @@ pub fn flush_outbox(db: &Db, log: &EventLog) -> AppResult<usize> {
         return Ok(0);
     }
 
-    let mut flushed = 0usize;
+    // Deserialize all bodies up front so a malformed row fails before
+    // any I/O. Per-event timestamps are preserved from the outbox row.
+    let entries: Vec<(EventBody, i64)> = pending
+        .iter()
+        .map(|row| {
+            let body: EventBody = serde_json::from_str(&row.body_json).map_err(|e| {
+                AppError::Other(format!(
+                    "outbox row {}: malformed body_json: {e}",
+                    row.id
+                ))
+            })?;
+            Ok((body, row.ts))
+        })
+        .collect::<AppResult<_>>()?;
+
+    // Single coordinated write for all events — one NSFileCoordinator
+    // call instead of N. This is the big win: 500 pending events go
+    // from 500 × bird-latency to 1 × bird-latency.
+    log.append_batch_varied(entries)?;
+
+    // Bulk delete from outbox. The batch append already succeeded so
+    // all rows are published; deleting them prevents re-publish on
+    // the next flush.
+    let conn = db
+        .conn
+        .lock()
+        .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
     for row in &pending {
-        let body: EventBody = serde_json::from_str(&row.body_json).map_err(|e| {
-            AppError::Other(format!(
-                "outbox row {}: malformed body_json: {e}",
-                row.id
-            ))
-        })?;
-        // Slow part — runs WITHOUT holding db.conn so concurrent UI
-        // writes (import_book, highlight.add, etc.) are not blocked.
-        log.append(body, row.ts)?;
-        // Per-row delete: if a later append in this batch fails, the
-        // earlier rows are already published and can be removed cleanly.
-        let conn = db
-            .conn
-            .lock()
-            .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
         conn.execute(
             "DELETE FROM _pending_publish WHERE id = ?1",
             params![row.id],
         )?;
-        drop(conn);
-        flushed += 1;
     }
-    Ok(flushed)
+    drop(conn);
+
+    Ok(pending.len())
 }
 
 // ---------------------------------------------------------------------------
@@ -512,8 +518,10 @@ mod tests {
 
         let conn = Connection::open_in_memory().unwrap();
         Db::run_migrations_on(&conn).unwrap();
+        let conn = Arc::new(Mutex::new(conn));
         let db = Db {
-            conn: Arc::new(Mutex::new(conn)),
+            read_conn: conn.clone(),
+            conn,
             data_dir: Arc::new(Mutex::new(dir.path().to_path_buf())),
         };
 

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -334,6 +334,48 @@ impl Snapshot {
             .map_err(|e| AppError::Other(format!("snapshot parse: {e}")))
     }
 
+    /// Like `read_from` but skips iCloud-evicted files and applies a
+    /// timeout. Returns `None` when the file is evicted or the read
+    /// exceeds `timeout`.
+    pub fn read_from_with_timeout(
+        path: &Path,
+        timeout: std::time::Duration,
+    ) -> AppResult<Option<Self>> {
+        use crate::icloud;
+        if !path.exists() {
+            if icloud::has_icloud_placeholder(path) {
+                log::info!(
+                    "sync: peer snapshot {} is iCloud-evicted — triggering download, skipping",
+                    path.display(),
+                );
+                icloud::trigger_download_file(path);
+            }
+            return Ok(None);
+        }
+        let path_buf = path.to_path_buf();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(fs::read(&path_buf));
+        });
+        match rx.recv_timeout(timeout) {
+            Ok(Ok(bytes)) => {
+                let snap: Self = serde_json::from_slice(&bytes)
+                    .map_err(|e| AppError::Other(format!("snapshot parse: {e}")))?;
+                Ok(Some(snap))
+            }
+            Ok(Err(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Ok(Err(e)) => Err(AppError::Io(e)),
+            Err(_) => {
+                log::warn!(
+                    "sync: timed out reading peer snapshot {} after {}s — skipping",
+                    path.display(),
+                    timeout.as_secs(),
+                );
+                Ok(None)
+            }
+        }
+    }
+
     /// Apply this snapshot into local SQLite. Idempotent under repeated
     /// application; tombstones in `state.tombstones` are written first so
     /// the entity rows that follow can short-circuit on the local-tombstone

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -339,12 +339,15 @@ impl Snapshot {
     /// exceeds `timeout`.
     ///
     /// `on_stall` / `on_success` callbacks let the caller track stalled
-    /// paths and skip them on subsequent ticks.
+    /// paths and skip them on subsequent ticks. `on_thread_done` runs
+    /// inside the spawned thread when `fs::read` completes — used for
+    /// in-flight tracking.
     pub fn read_from_with_timeout(
         path: &Path,
         timeout: std::time::Duration,
         on_stall: impl FnOnce(&Path),
         on_success: impl FnOnce(&Path),
+        on_thread_done: impl FnOnce() + Send + 'static,
     ) -> AppResult<Option<Self>> {
         use crate::icloud;
         if !path.exists() {
@@ -360,7 +363,9 @@ impl Snapshot {
         let path_buf = path.to_path_buf();
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            let _ = tx.send(fs::read(&path_buf));
+            let result = fs::read(&path_buf);
+            on_thread_done();
+            let _ = tx.send(result);
         });
         match rx.recv_timeout(timeout) {
             Ok(Ok(bytes)) => {

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -337,9 +337,14 @@ impl Snapshot {
     /// Like `read_from` but skips iCloud-evicted files and applies a
     /// timeout. Returns `None` when the file is evicted or the read
     /// exceeds `timeout`.
+    ///
+    /// `on_stall` / `on_success` callbacks let the caller track stalled
+    /// paths and skip them on subsequent ticks.
     pub fn read_from_with_timeout(
         path: &Path,
         timeout: std::time::Duration,
+        on_stall: impl FnOnce(&Path),
+        on_success: impl FnOnce(&Path),
     ) -> AppResult<Option<Self>> {
         use crate::icloud;
         if !path.exists() {
@@ -359,6 +364,7 @@ impl Snapshot {
         });
         match rx.recv_timeout(timeout) {
             Ok(Ok(bytes)) => {
+                on_success(path);
                 let snap: Self = serde_json::from_slice(&bytes)
                     .map_err(|e| AppError::Other(format!("snapshot parse: {e}")))?;
                 Ok(Some(snap))
@@ -367,10 +373,11 @@ impl Snapshot {
             Ok(Err(e)) => Err(AppError::Io(e)),
             Err(_) => {
                 log::warn!(
-                    "sync: timed out reading peer snapshot {} after {}s — skipping",
+                    "sync: timed out reading peer snapshot {} after {}s — backing off",
                     path.display(),
                     timeout.as_secs(),
                 );
+                on_stall(path);
                 Ok(None)
             }
         }


### PR DESCRIPTION
## Summary

Addresses #237. Four architectural changes to eliminate UI freezes during large iCloud syncs:

- **Separate read/write DB connections**: `Db` now has a dedicated `read_conn` (opened `SQLITE_OPEN_READ_ONLY`) alongside the existing write `conn`. All frontend query commands (`list_books`, `get_all_settings`, `list_highlights`, etc.) use `db.reader()` and never contend with sync engine writes. WAL mode already supports concurrent readers at the SQLite level; now the Rust mutexes are independent too.

- **Batch outbox flush**: `flush_outbox` now collects all pending events and writes them in a single `append_batch_varied()` call — one `NSFileCoordinator` + one `fsync` instead of N. For a 500-book import, this reduces flush time from 500 × bird-latency to 1 × bird-latency.

- **30s timeout on peer reads + in-flight tracking**: `read_log_file_with_timeout()` and `Snapshot::read_from_with_timeout()` spawn a reader thread and abort if `fs::read` takes longer than 30s. Timed-out peers are backed off for 2 min (`STALLED_PATHS`). Per-path `IN_FLIGHT` tracking ensures at most one blocked OS thread per path — the spawned thread clears its flag via `on_thread_done` when `fs::read` returns. iCloud placeholders (`.foo.icloud`) are detected before spawning, triggering a background download instead.

- **Per-snapshot write transactions**: Phase B now applies each peer's snapshot in its own short-lived write tx (instead of one big tx for all peers). Watermark reads go through `db.reader()` — no write lock contention during event filtering.

## Test plan

- [x] All 250 tests pass (248 unit + 2 integration)
- [ ] Import 500 books on device A with sync enabled, launch device B — UI should remain responsive during sync
- [ ] Verify `list_books` / `get_all_settings` return instantly while sync engine applies events
- [ ] Disconnect iCloud, accumulate writes, reconnect — batch flush should drain outbox in one shot
- [ ] Evict a peer log file, verify tick doesn't hang (logs "timed out reading peer log")

🤖 Generated with [Claude Code](https://claude.com/claude-code)