### PR TITLE
refactor: remove legacy file-sync, rename marker to .icloud_setting JSON

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,21 +1,14 @@
 use tauri::{AppHandle, Manager};
 use tauri_plugin_opener::OpenerExt;
 
-#[cfg(target_os = "macos")]
-use tauri::Emitter;
-
 use crate::error::{AppError, AppResult};
-use crate::{resolve_log_dir, LocalDir};
+use crate::resolve_log_dir;
 
 /// Called by the frontend after React has mounted and painted its first frame.
 /// Shows the main window — the window starts hidden so the user sees the dock
 /// bounce → fully-rendered window instead of a beach ball over a blank webview.
-///
-/// Also kicks off background iCloud daemon registration + evicted-file downloads.
-/// We do this here (not in setup) so the frontend event listeners are already
-/// registered and can show the sync indicator.
 #[tauri::command]
-pub fn app_ready(app: AppHandle, _local_dir: tauri::State<'_, LocalDir>) -> AppResult<()> {
+pub fn app_ready(app: AppHandle) -> AppResult<()> {
     let window = app
         .get_webview_window("main")
         .ok_or_else(|| AppError::Other("main window not found".into()))?;
@@ -25,46 +18,10 @@ pub fn app_ready(app: AppHandle, _local_dir: tauri::State<'_, LocalDir>) -> AppR
     window
         .set_focus()
         .map_err(|e| AppError::Other(e.to_string()))?;
-
-    // Trigger iCloud downloads for the binaries directory whenever
-    // sync is on — either via the new event-log sync (marker present)
-    // or the legacy file-sync (`is_icloud_enabled`). Without this,
-    // evicted books / covers stay as `.icloud` placeholders until the
-    // user opens them individually. The browser-style sync indicator
-    // in the sidebar is driven off this same emit pair.
-    #[cfg(target_os = "macos")]
-    {
-        let new_sync = crate::sync::migration::is_migration_complete(&_local_dir.0);
-        let legacy = crate::icloud::is_icloud_enabled(&_local_dir.0);
-        if new_sync || legacy {
-            let handle = app.clone();
-            tauri::async_runtime::spawn_blocking(move || {
-                let _ = handle.emit("icloud-sync-start", ());
-                if let Some(icloud_dir) = crate::icloud::icloud_data_dir() {
-                    let _ = crate::icloud::ensure_downloaded(&icloud_dir);
-                } else {
-                    log::warn!(
-                        "iCloud: daemon unreachable; running against the cached path. Sync will resume on next launch."
-                    );
-                }
-                let _ = handle.emit("icloud-sync-done", ());
-            });
-        }
-    }
-
     Ok(())
 }
 
-/// Reveal the per-user app log directory in the OS file manager. Both the
-/// Help menu item ("Reveal Logs in Finder" / "Show Logs in Explorer") and
-/// the Settings → General → Diagnostics row route here.
-///
-/// Uses the same `resolve_log_dir()` helper as the plugin registration so
-/// the two surfaces can never drift — in debug builds, both point at
-/// `<base>/com.wycstudios.quill-dev/...` so dev runs don't pollute the
-/// release log path. The directory exists by the time this command can be
-/// invoked because the tauri-plugin-log file target creates it on the
-/// first `log::` call.
+/// Reveal the per-user app log directory in the OS file manager.
 #[tauri::command]
 pub fn reveal_logs(app: AppHandle) -> AppResult<()> {
     let log_dir = resolve_log_dir();

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -1,23 +1,11 @@
 //! Sync commands exposed to the frontend.
 //!
-//! Surface area for the per-device event-log sync (issue #185):
-//!
-//! - `sync_status` — read-only snapshot for the settings UI, including
-//!   the peer manifest list.
-//! - `sync_enable` — first-time enable: ensure iCloud subdirs, move
-//!   local binaries into the ubiquity container, stamp the migration
-//!   marker, publish the device manifest, open the EventLog, and boot
-//!   the replay engine + watcher in this process. Idempotent — calling
-//!   it while sync is already on is a cheap no-op.
-//! - `sync_disable` — stop the engine + watcher, stop publishing,
-//!   copy binaries back to local, remove markers and own manifest.
-//!   Symmetric with the today's `icloud_disable` UX.
-//! - `sync_now` — manual replay tick (Chunk 6 shipped this; the
-//!   `SyncState` indirection is the only code change here).
-//! - `sync_revert_to_legacy` — placeholder for the 30-day grace-window
-//!   rollback to the legacy file-sync model. Stubbed in v1 because the
-//!   legacy implementation has been removed; tracked for v1.1 if a real
-//!   user actually needs it.
+//! - `sync_status` — read-only snapshot for the settings UI.
+//! - `sync_enable` — move binaries to iCloud, stamp marker, boot engine.
+//! - `sync_disable` — stop engine, copy binaries back, remove marker.
+//! - `sync_now` — manual replay tick.
+//! - `sync_compact` — trigger log compaction.
+//! - `sync_remove_peer` — remove a peer's log/snapshot/manifest.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -88,11 +76,10 @@ pub struct SyncStatus {
     /// True when this Mac currently has access to an iCloud container.
     /// `enabled` requires `available` but not the other way around —
     /// a migrated user with iCloud temporarily down has `enabled =
-    /// false, available = false, migration_complete = true`.
+    /// false, available = false, sync_enabled = true`.
     pub available: bool,
-    /// True once the legacy file-sync migration has run successfully.
-    /// Used by the UI to decide whether to show the migration banner.
-    pub migration_complete: bool,
+    /// True when the user has enabled iCloud sync via the settings toggle.
+    pub sync_enabled: bool,
     pub shared_dir: Option<String>,
     pub device_uuid: String,
     pub device_name: String,
@@ -163,7 +150,7 @@ pub fn sync_status(
     device: State<'_, DeviceIdentity>,
     sync_state: State<'_, SyncState>,
 ) -> AppResult<SyncStatus> {
-    let migration_complete = sync::migration::is_migration_complete(&local.0);
+    let sync_enabled = sync::migration::is_sync_enabled(&local.0);
     let shared_dir = sync::migration::recorded_data_dir(&local.0)
         .or_else(icloud::icloud_data_dir_deterministic);
     let available = icloud::icloud_data_dir_fast().is_some()
@@ -208,7 +195,7 @@ pub fn sync_status(
     Ok(SyncStatus {
         enabled,
         available,
-        migration_complete,
+        sync_enabled,
         shared_dir: shared_dir.map(|p| p.to_string_lossy().into_owned()),
         device_uuid: device.device_uuid.clone(),
         device_name: peers::device_name(),
@@ -241,7 +228,6 @@ pub fn sync_enable(
 
     let icloud_dir = icloud::icloud_data_dir()
         .ok_or_else(|| AppError::Other("iCloud is not available".into()))?;
-    icloud::ensure_downloaded(&icloud_dir)?;
 
     fs::create_dir_all(icloud_dir.join("logs"))?;
     fs::create_dir_all(icloud_dir.join("devices"))?;
@@ -300,7 +286,7 @@ pub fn sync_enable(
         chrono::Utc::now().timestamp_millis(),
     )?;
 
-    sync::migration::write_marker(&local.0, Some(&icloud_dir))?;
+    sync::migration::write_sync_settings(&local.0, Some(&icloud_dir))?;
 
     {
         let mut data_dir = db
@@ -479,10 +465,7 @@ pub fn sync_disable(
         }
     }
 
-    // Remove markers. Both legacy (`.icloud_enabled`) and new (`.migration_complete`).
-    sync::migration::remove_marker(&local.0)?;
-    let legacy_marker = local.0.join(".icloud_enabled");
-    let _ = fs::remove_file(&legacy_marker);
+    sync::migration::remove_sync_settings(&local.0)?;
 
     Ok(())
 }
@@ -573,15 +556,6 @@ pub fn simulate_sync_progress(app: tauri::AppHandle) -> AppResult<()> {
         let _ = app.emit("sync-initial-tick-done", ());
     });
     Ok(())
-}
-
-#[tauri::command]
-pub fn sync_revert_to_legacy() -> AppResult<()> {
-    Err(AppError::Other(
-        "Reverting to legacy iCloud file-sync is not supported in this version. \
-         To stop syncing, use the Sync toggle above."
-            .into(),
-    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -1023,12 +997,6 @@ mod tests {
             count_pending_for_peer(tmp.path(), "peer-A", Some("01HZA00000000000000000A003")),
             0
         );
-    }
-
-    #[test]
-    fn sync_revert_to_legacy_returns_error_in_v1() {
-        let result = sync_revert_to_legacy();
-        assert!(result.is_err());
     }
 
     /// Regression for PR #193's review finding: enabling sync on a

--- a/src-tauri/src/icloud.rs
+++ b/src-tauri/src/icloud.rs
@@ -1,32 +1,19 @@
 //! iCloud helpers — container-path resolution + file-presence checks.
 //!
-//! Post-Chunk 7 this module no longer ships the DB through iCloud (the
-//! per-device event log replaces that). What remains:
-//!
 //! - **Path helpers** (`icloud_data_dir*`, `get_icloud_container_url`)
-//!   used by the new sync code (`sync::peers`, `sync::migration`,
-//!   `commands::sync`) to resolve the ubiquity Documents directory.
+//!   used by the sync code to resolve the ubiquity Documents directory.
 //! - **Eviction handling** (`is_file_downloaded`,
 //!   `icloud_placeholder_path`, `has_icloud_placeholder`,
-//!   `trigger_download_file`, `ensure_downloaded`) for book and cover
-//!   binaries that live in iCloud Documents and may be evicted.
-//! - **Legacy marker** (`is_icloud_enabled`) so launch-time can detect
-//!   users upgrading from the file-sync model and trigger
-//!   `sync::migration::run_migration`. The marker is no longer
-//!   *written* anywhere — `sync_enable` writes `.migration_complete`
-//!   directly. Once we're confident every legacy user has migrated we
-//!   can drop the legacy marker check and this last carve-out.
+//!   `trigger_download_file`) for book and cover binaries that live in
+//!   iCloud Documents and may be evicted.
 
 use std::path::{Path, PathBuf};
-
-use crate::error::AppResult;
 
 #[cfg(target_os = "macos")]
 use objc2_foundation::{NSFileManager, NSString};
 
 #[cfg(target_os = "macos")]
 const ICLOUD_CONTAINER_ID: &str = "iCloud.com.wycstudios.quill";
-const MARKER_FILE: &str = ".icloud_enabled";
 
 /// Get the iCloud ubiquity container URL for this app.
 /// Returns `None` if iCloud is unavailable (not signed in, no entitlement).
@@ -60,13 +47,7 @@ pub fn icloud_data_dir() -> Option<PathBuf> {
 /// (e.g. user signed out of iCloud since enabling sync). Callers should fall
 /// back to the local directory in that case.
 ///
-/// Sync engine callers prefer `icloud_data_dir_deterministic` so blob path
-/// resolution stays stable across launches even when the container hasn't
-/// materialized yet — `_fast` is kept for the legacy `icloud::*` flows that
-/// genuinely need the existence check (Chunk 9 cleanup will delete both
-/// once the file-sync code is gone).
 #[cfg(target_os = "macos")]
-#[allow(dead_code)] // used by tests + legacy flows; cleanup tracked in Chunk 9
 pub fn icloud_data_dir_fast() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     let folder_name = ICLOUD_CONTAINER_ID.replace('.', "~");
@@ -126,33 +107,6 @@ pub fn is_icloud_available() -> bool {
 #[cfg(not(target_os = "macos"))]
 pub fn is_icloud_available() -> bool {
     false
-}
-
-/// Check if iCloud sync is enabled by looking for the marker file in the local app dir.
-pub fn is_icloud_enabled(local_dir: &Path) -> bool {
-    local_dir.join(MARKER_FILE).exists()
-}
-
-/// Flush the WAL to the main database file for safe iCloud sync.
-/// Trigger iCloud to download evicted files. Best-effort — errors are logged but don't block.
-#[cfg(target_os = "macos")]
-pub fn ensure_downloaded(icloud_dir: &Path) -> AppResult<()> {
-    use objc2_foundation::NSURL;
-    let fm = NSFileManager::defaultManager();
-    for name in &["quill.db", "books", "covers"] {
-        let path = icloud_dir.join(name);
-        let path_str = NSString::from_str(&path.to_string_lossy());
-        let url = NSURL::fileURLWithPath(&path_str);
-        if let Err(e) = fm.startDownloadingUbiquitousItemAtURL_error(&url) {
-            log::warn!("iCloud: failed to trigger download for {}: {}", name, e);
-        }
-    }
-    Ok(())
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn ensure_downloaded(_icloud_dir: &Path) -> AppResult<()> {
-    Ok(())
 }
 
 /// Check whether a file is locally available (not an iCloud placeholder).
@@ -317,21 +271,6 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("book.epub");
         assert!(!has_icloud_placeholder(&file));
-    }
-
-    // --- is_icloud_enabled ---
-
-    #[test]
-    fn test_is_icloud_enabled_false_by_default() {
-        let dir = TempDir::new().unwrap();
-        assert!(!is_icloud_enabled(dir.path()));
-    }
-
-    #[test]
-    fn test_is_icloud_enabled_true_with_marker() {
-        let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join(".icloud_enabled"), "").unwrap();
-        assert!(is_icloud_enabled(dir.path()));
     }
 
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -165,7 +165,7 @@ pub fn mcp_stdio_main() {
     // Resolve the data_dir the same way the Tauri app does: if the
     // user has migrated to iCloud sync, blobs (books/, covers/) live
     // under the ubiquity container, not the local app-data dir.
-    let data_dir = if sync::migration::is_migration_complete(&local_dir) {
+    let data_dir = if sync::migration::is_sync_enabled(&local_dir) {
         sync::migration::recorded_data_dir(&local_dir)
             .or_else(icloud::icloud_data_dir_deterministic)
             .unwrap_or_else(|| local_dir.clone())
@@ -187,7 +187,7 @@ pub fn mcp_stdio_main() {
         let device = sync::device::DeviceIdentity::load_or_create(&local_dir)
             .expect("failed to load device identity");
         let sw = SyncWriter::new(device.device_uuid);
-        if sync::migration::is_migration_complete(&local_dir) {
+        if sync::migration::is_sync_enabled(&local_dir) {
             sw.set_should_queue(true);
         }
         (db, Some(sw))
@@ -422,122 +422,34 @@ pub fn run() {
             };
             std::fs::create_dir_all(&local_dir).expect("failed to create app data dir");
 
-            // Resolve the iCloud Documents path from the deterministic
-            // hardcoded location whenever **either** sync marker is on:
-            //   - `.icloud_enabled` (legacy file-sync user, migration
-            //     still pending)
-            //   - `.migration_complete` (new-UI enabler, post-migration
-            //     user, or legacy user who has migrated)
-            //
-            // Avoids `URLForUbiquityContainerIdentifier` on the main
-            // thread (slow cold-start IPC to the iCloud daemon).
-            //
-            // We use the `_deterministic` variant — not `_fast` — so
-            // migration is always at least *attempted* with a concrete
-            // path, even when the iCloud container hasn't materialized
-            // yet. `run_migration` itself detects the missing dir and
-            // defers (without writing the marker) so the next launch
-            // retries. Using `_fast` here would short-circuit migration
-            // entirely on a cold-iCloud first launch, leaving the user
-            // open to the data-loss path documented in PR #192's
-            // first-launch-without-iCloud finding.
-            //
-            // Gating the legacy-marker path only here (the pre-PR #190
-            // bug) meant new-UI enablers — who never get
-            // `.icloud_enabled` written — came back next launch with
-            // `ubiquity_dir = None` and therefore no engine boot, even
-            // though their durable state said "sync on." Every write
-            // after that stayed in `_pending_publish` indefinitely.
-            // Self-heal: if .migration_complete survived but quill.db
+            // Self-heal: if .icloud_setting survived but quill.db
             // was deleted (e.g. user cleared app data via Finder, which
             // skips hidden dot-files), remove the stale marker so the
-            // app starts fresh instead of booting the sync engine into
-            // an empty database — which blocks setup() reading iCloud
-            // peer files that may be evicted/slow.
-            if !local_dir.join("quill.db").exists() {
-                let had_migration = sync::migration::is_migration_complete(&local_dir);
-                let had_legacy = icloud::is_icloud_enabled(&local_dir);
-                if had_migration || had_legacy {
-                    log::warn!(
-                        "sync: quill.db missing but sync markers survived \
-                         (migration={had_migration}, legacy={had_legacy}) — \
-                         clearing stale markers to start fresh"
-                    );
-                    let _ = std::fs::remove_file(local_dir.join(".migration_complete"));
-                    let _ = std::fs::remove_file(local_dir.join(".icloud_enabled"));
-                }
+            // app starts fresh.
+            if !local_dir.join("quill.db").exists()
+                && sync::migration::is_sync_enabled(&local_dir)
+            {
+                log::warn!(
+                    "sync: quill.db missing but .icloud_setting survived — \
+                     clearing stale marker to start fresh"
+                );
+                let _ = std::fs::remove_file(local_dir.join(".icloud_setting"));
             }
 
-            let icloud_was_enabled = icloud::is_icloud_enabled(&local_dir);
-            let ubiquity_dir =
-                sync::migration::resolve_ubiquity_dir(&local_dir, icloud_was_enabled);
+            // Resolve the iCloud Documents path when sync is enabled.
+            let ubiquity_dir = if sync::migration::is_sync_enabled(&local_dir) {
+                sync::migration::recorded_data_dir(&local_dir)
+                    .or_else(icloud::icloud_data_dir_deterministic)
+            } else {
+                None
+            };
 
-            // Per-install device UUID — stamped into every LWW write so
-            // peer reconciliation stays deterministic on equal-millisecond
-            // ties. Lives in `<local>/device.json`; never synced. Loaded
-            // here because the migration routine below needs it.
             let device =
                 DeviceIdentity::load_or_create(&local_dir).expect("failed to load device id");
 
-            // Chunk 6 — one-shot migration from legacy file-sync to the
-            // per-device event log. Runs only when the legacy marker is
-            // present and the new `.migration_complete` marker isn't.
-            // Failures are logged and retried on the next launch (the
-            // marker is only written on success).
-            if icloud_was_enabled && !sync::migration::is_migration_complete(&local_dir) {
-                if let Some(ub) = &ubiquity_dir {
-                    match sync::migration::run_migration(&local_dir, ub, &device.device_uuid) {
-                        Ok(outcome) if outcome.deferred_for_download => log::info!(
-                            "sync: migration deferred — ubiquity quill.db is iCloud-evicted. \
-                             Download triggered; will retry on next launch."
-                        ),
-                        Ok(outcome) => log::info!(
-                            "sync: migration complete: copied_db={} wrote_snapshot={} retired={} conflict_copies_discarded={}",
-                            outcome.copied_db,
-                            outcome.wrote_snapshot,
-                            outcome.retired_files,
-                            outcome.conflict_copies_discarded,
-                        ),
-                        Err(e) => log::error!(
-                            "sync: migration failed (will retry next launch): {e}"
-                        ),
-                    }
-                }
-            }
-
-            // Open the DB. Post-migration the SQLite file lives at
-            // local_dir/quill.db, but books/ and covers/ stay in the
-            // iCloud Documents container per spec — we keep `data_dir`
-            // pointing at the ubiquity dir so `Db::resolve_path`
-            // resolves binaries against the right place.
-            //
-            // Resolution chain (post-migration, in order):
-            //   1. Path recorded in the marker at migration time. This
-            //      is the source of truth — guarantees stability across
-            //      launches, even if iCloud is signed out right now.
-            //   2. Deterministic iCloud Documents path (no `is_dir`
-            //      check). Backstop for legacy markers from the first
-            //      Chunk 6 build that wrote an empty marker.
-            //   3. Local dir as a last resort, with a loud log line.
-            //      The user is offline AND on a non-macOS platform
-            //      AND has a legacy empty marker — vanishingly rare,
-            //      but we don't want to crash the app.
-            //
-            // Pre-migration and non-iCloud users get data_dir = local.
-            let data_dir = if sync::migration::is_migration_complete(&local_dir) {
-                sync::migration::recorded_data_dir(&local_dir)
-                    .or_else(icloud::icloud_data_dir_deterministic)
-                    .unwrap_or_else(|| {
-                        log::warn!(
-                            "sync: migration is complete but no stable data_dir is \
-                             available; falling back to local. Newly-imported binaries \
-                             may not be visible to peers."
-                        );
-                        local_dir.clone()
-                    })
-            } else {
-                local_dir.clone()
-            };
+            // When sync is on, blobs (books/, covers/) live in iCloud;
+            // otherwise they're local.
+            let data_dir = ubiquity_dir.clone().unwrap_or_else(|| local_dir.clone());
             let db = Db::init_split(&local_dir, &data_dir)
                 .expect("failed to initialize database");
 
@@ -546,83 +458,28 @@ pub fn run() {
                 version = env!("CARGO_PKG_VERSION"),
                 os = std::env::consts::OS,
                 arch = std::env::consts::ARCH,
-                data_dir = local_dir.display(),
+                data_dir = data_dir.display(),
                 schema = db.schema_version(),
             );
 
-            // Self-healing: if migration is complete, retire any ubiquity
-            // DB files that crept back (a legacy build temporarily
-            // running on this iCloud account, file restore, etc.) and
-            // reconcile any local binaries left over from a partial
-            // `sync_enable` move. The reconcile is a no-op for the
-            // common case (local/books empty post-enable); when a
-            // previous enable wrote the marker but failed mid-move,
-            // it drains the leftover files into iCloud so they're
-            // resolvable through the now-active data_dir.
-            if sync::migration::is_migration_complete(&local_dir) {
-                if let Some(ub) = &ubiquity_dir {
-                    let _ = sync::migration::retire_ubiquity_db(ub);
-                    if let Err(e) =
-                        sync::migration::reconcile_local_blobs_to_ubiquity(&local_dir, ub)
-                    {
-                        log::warn!("sync: blob reconcile failed (continuing): {e}");
-                    }
-                }
-            }
-
-            // Secrets DB always lives at the local app_data_dir (never syncs to iCloud)
             let secrets =
                 Secrets::init(&local_dir).expect("failed to initialize secrets store");
-
-            // One-time migration: move sensitive keys from settings to secrets
             secrets
                 .migrate_from_settings(&db)
                 .expect("failed to migrate secrets");
 
             let sync_writer = SyncWriter::new(device.device_uuid.clone());
-
-            // If migration is complete, every write must persist into
-            // `_pending_publish` regardless of whether the engine boots
-            // this session. The post-commit flush only runs when the log
-            // is open (set inside boot_sync_engine), so a queue-only
-            // session accumulates events for the next launch's replay
-            // tick to drain. Without this flag set, writes made while
-            // iCloud is unreachable are silently dropped — peers never
-            // see them. See `SyncWriter`'s module docstring for the
-            // three-mode model.
-            if sync::migration::is_migration_complete(&local_dir) {
+            if sync::migration::is_sync_enabled(&local_dir) {
                 sync_writer.set_should_queue(true);
             }
 
-            // Wire the replay engine + watcher when sync is on. "Sync on"
-            // for Chunk 6 is detected via the migration-complete marker:
-            // if we migrated (or a future install joined an already-
-            // migrated iCloud), spin up the engine. Chunk 7's
-            // `sync_enable` will replace this trigger with an explicit
-            // user toggle.
-            //
-            // Important: deterministic vs existence-checked path. The
-            // deterministic path is correct for blob resolution (so
-            // `books/foo.epub` always resolves to the same place across
-            // launches) and for migration source selection (so we can
-            // defer a missing source instead of falling through). But
-            // it's WRONG for booting EventLog + ReplayEngine: if the
-            // iCloud container hasn't materialized yet (signed-out
-            // account, daemon race), `EventLog::open` would create a
-            // file at the deterministic path — physically located
-            // outside any real ubiquity container — and the post-commit
-            // outbox flush would drain `_pending_publish` rows into it.
-            // Peers would never see those events but the rows would be
-            // gone, breaking the publish-retry guarantee. So we re-gate
-            // on `.exists()` here. If iCloud isn't actually present
-            // this launch, sync stays inert and the outbox preserves
-            // pending events for the next successful boot.
-            let (replay_engine, watcher_handle) = match sync::migration::is_migration_complete(
-                &local_dir,
-            )
-            .then(|| ubiquity_dir.clone().filter(|p| p.exists()))
-            .flatten()
-            {
+            // Boot the sync engine on a background thread when sync is
+            // on. The `.exists()` gate ensures we don't create files at
+            // a deterministic path outside a real ubiquity container.
+            let should_boot = sync::migration::is_sync_enabled(&local_dir)
+                .then(|| ubiquity_dir.filter(|p| p.exists()))
+                .flatten();
+            let (replay_engine, watcher_handle) = match should_boot {
                 Some(ub) => match boot_sync_engine(ub, &device.device_uuid, &db, &sync_writer, app.handle()) {
                     Ok(pair) => {
                         log::info!("sync: engine booted (replay + watcher active)");
@@ -634,7 +491,7 @@ pub fn run() {
                     }
                 },
                 None => {
-                    if sync::migration::is_migration_complete(&local_dir) {
+                    if sync::migration::is_sync_enabled(&local_dir) {
                         log::warn!(
                             "sync: skipping engine boot — iCloud container not reachable \
                              this launch; outbox preserved for the next launch"
@@ -743,15 +600,13 @@ pub fn run() {
             commands::mcp::mcp_set_integration,
             commands::mcp::mcp_config_snippet,
             commands::mcp::mcp_set_write_access,
-            // Sync (Chunk 7 — replaces the legacy icloud_* commands;
-            // sync_compact added in Chunk 8).
+            // Sync
             commands::sync::sync_status,
             commands::sync::sync_enable,
             commands::sync::sync_disable,
             commands::sync::sync_now,
             commands::sync::sync_cancel,
             commands::sync::sync_compact,
-            commands::sync::sync_revert_to_legacy,
             #[cfg(debug_assertions)]
             commands::sync::simulate_sync_progress,
             commands::sync::sync_remove_peer,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -422,6 +422,10 @@ pub fn run() {
             };
             std::fs::create_dir_all(&local_dir).expect("failed to create app data dir");
 
+            // Clean up stale legacy markers.
+            let _ = std::fs::remove_file(local_dir.join(".migration_complete"));
+            let _ = std::fs::remove_file(local_dir.join(".icloud_enabled"));
+
             // Self-heal: if .icloud_setting survived but quill.db
             // was deleted (e.g. user cleared app data via Finder, which
             // skips hidden dot-files), remove the stale marker so the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -422,10 +422,6 @@ pub fn run() {
             };
             std::fs::create_dir_all(&local_dir).expect("failed to create app data dir");
 
-            // Clean up stale legacy markers.
-            let _ = std::fs::remove_file(local_dir.join(".migration_complete"));
-            let _ = std::fs::remove_file(local_dir.join(".icloud_enabled"));
-
             // Self-heal: if .icloud_setting survived but quill.db
             // was deleted (e.g. user cleared app data via Finder, which
             // skips hidden dot-files), remove the stale marker so the

--- a/src-tauri/src/sync/migration.rs
+++ b/src-tauri/src/sync/migration.rs
@@ -1,125 +1,62 @@
-//! One-shot migration from the legacy file-sync (shipped DB as a binary
-//! file through iCloud) to the per-device event log.
+//! Sync settings file — read/write/remove `.icloud_setting` which
+//! controls whether the event-log sync engine boots at launch.
 //!
-//! Triggered on launch when (a) the legacy `.icloud_enabled` marker exists
-//! and (b) the new `.migration_complete` marker does not. Idempotent: a
-//! second run after success is a no-op (caller checks the marker), and a
-//! crash mid-flight leaves the source DB and ubiquity files untouched
-//! until the very last step (the marker write + retire), so the next
-//! launch re-runs cleanly.
-//!
-//! ## Procedure
-//!
-//! 1. Copy `<ubiquity>/quill.db` → `<local>/quill.db` (bit-exact). The
-//!    ubiquity DB stays in place — the retire step at the end renames it
-//!    to `quill.db.migrated-<iso>` only after the rest of the migration
-//!    has succeeded.
-//! 2. Open the local DB. `Db::init` runs migrations 1-11, so a legacy
-//!    file at any older schema is brought forward to the per-device-log
-//!    shape (`updated_by_device`, `_pending_publish`, `_replay_state`,
-//!    `_tombstones`).
-//! 3. Build a `Snapshot::from_legacy_db` from the local DB. This is the
-//!    materialized view that becomes the bootstrap for every peer.
-//! 4. Write the snapshot to `<ubiquity>/logs/<device>.snapshot.json` and
-//!    create an empty `<ubiquity>/logs/<device>.jsonl` log file. Atomic
-//!    via temp + fsync + rename so a crash here doesn't leave a partial
-//!    snapshot for peers to consume.
-//! 5. Write the `<local>/.migration_complete` marker. From this point on,
-//!    launch flow knows to skip migration and just open the local DB +
-//!    replay tick.
-//! 6. Retire the ubiquity DB (rename to `quill.db.migrated-<iso>`).
-//!    Idempotent — if a previous run already retired it, this is a no-op.
-//!
-//! Conflict-copy merge (`quill (1).db`, `quill (2).db`) is
-//! **deliberately not implemented** in v1. Those files are artifacts of
-//! the old whole-DB iCloud file-sync design and belong with it; the
-//! event-log design has no equivalent representation. Detected conflict
-//! copies are retired alongside the primary DB and a warning is logged
-//! so a user with divergent libraries sees something concrete in the
-//! console / report. Given the early-release scope and small user count
-//! we accept the data-loss risk on this rare path; if a real user hits
-//! it we'll write a one-off recovery tool. Tracked as the v1 trade-off
-//! in PR #192's review.
-//!
-//! See `docs/impls/sync/31-sync.md` Step 7 for the spec.
+//! Written by `sync_enable`, removed by `sync_disable`. JSON format
+//! for future extensibility.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::db::Db;
+use serde::{Deserialize, Serialize};
+
 use crate::error::{AppError, AppResult};
-use crate::sync::log::EventLog;
-use crate::sync::snapshot::Snapshot;
 
-/// Marker written to `<local>/.migration_complete` after a successful
-/// migration. Lives next to `.icloud_enabled`. Presence means "DB is
-/// already local; per-device log lives in iCloud".
-pub const MIGRATION_COMPLETE_MARKER: &str = ".migration_complete";
+const SYNC_SETTINGS_FILE: &str = ".icloud_setting";
 
-/// What `run_migration` did, surfaced for tests and logging.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct MigrationOutcome {
-    pub copied_db: bool,
-    pub wrote_snapshot: bool,
-    pub created_log: bool,
-    pub retired_files: usize,
-    /// True when ubiquity/quill.db is currently an iCloud-evicted
-    /// placeholder (`.quill.db.icloud`). The migration deferred and
-    /// will retry next launch — the marker is intentionally NOT
-    /// written. Surfaced separately from `copied_db = false` so callers
-    /// can distinguish "nothing to migrate" from "wait for download".
-    pub deferred_for_download: bool,
-    /// Number of `quill (N).db*` conflict copies retired without merge.
-    /// Counted separately so the log line at the call site can flag
-    /// the data-loss risk to the user.
-    pub conflict_copies_discarded: usize,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncSettings {
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_dir: Option<String>,
 }
 
-pub fn migration_complete_path(local_dir: &Path) -> PathBuf {
-    local_dir.join(MIGRATION_COMPLETE_MARKER)
+pub fn sync_settings_path(local_dir: &Path) -> PathBuf {
+    local_dir.join(SYNC_SETTINGS_FILE)
 }
 
-pub fn is_migration_complete(local_dir: &Path) -> bool {
-    migration_complete_path(local_dir).exists()
+pub fn is_sync_enabled(local_dir: &Path) -> bool {
+    read_sync_settings(local_dir)
+        .map(|s| s.enabled)
+        .unwrap_or(false)
 }
 
-/// Read the data_dir path that was active at migration time. Returns
-/// `Some(path)` when the marker file holds a non-empty path string,
-/// `None` for legacy markers (empty file from earlier Chunk 6 builds)
-/// or when the marker is missing. Callers that need a stable
-/// post-migration path must combine this with a deterministic
-/// fallback (`icloud::icloud_data_dir_deterministic`) so the result
-/// doesn't flip launch-to-launch when iCloud is temporarily down.
+pub fn read_sync_settings(local_dir: &Path) -> Option<SyncSettings> {
+    let bytes = fs::read(sync_settings_path(local_dir)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
 pub fn recorded_data_dir(local_dir: &Path) -> Option<PathBuf> {
-    let bytes = fs::read(migration_complete_path(local_dir)).ok()?;
-    let s = String::from_utf8(bytes).ok()?;
-    let trimmed = s.trim();
-    if trimmed.is_empty() {
+    let settings = read_sync_settings(local_dir)?;
+    let dir = settings.data_dir?;
+    if dir.is_empty() {
         return None;
     }
-    Some(PathBuf::from(trimmed))
+    Some(PathBuf::from(dir))
 }
 
-/// Persist the marker with the absolute path of the binaries directory
-/// so future launches resolve `books/`, `covers/` against the same
-/// location regardless of whether iCloud is currently reachable. Empty
-/// `data_dir` (passed when there was no legacy DB to migrate) writes
-/// an empty marker — the launch-flow chain will fall back to the
-/// deterministic iCloud path for that case.
-pub fn write_marker(local_dir: &Path, data_dir: Option<&Path>) -> AppResult<()> {
-    let bytes: Vec<u8> = match data_dir {
-        Some(p) => p.to_string_lossy().into_owned().into_bytes(),
-        None => Vec::new(),
+pub fn write_sync_settings(local_dir: &Path, data_dir: Option<&Path>) -> AppResult<()> {
+    let settings = SyncSettings {
+        enabled: true,
+        data_dir: data_dir.map(|p| p.to_string_lossy().into_owned()),
     };
-    fs::write(migration_complete_path(local_dir), bytes)?;
+    let bytes = serde_json::to_vec_pretty(&settings)
+        .map_err(|e| AppError::Other(format!("serialize sync settings: {e}")))?;
+    fs::write(sync_settings_path(local_dir), bytes)?;
     Ok(())
 }
 
-/// Remove the `.migration_complete` marker. Used by `sync_disable` so
-/// the next launch treats this device as un-synced and skips engine
-/// boot. Idempotent — missing marker is fine.
-pub fn remove_marker(local_dir: &Path) -> AppResult<()> {
-    let path = migration_complete_path(local_dir);
+pub fn remove_sync_settings(local_dir: &Path) -> AppResult<()> {
+    let path = sync_settings_path(local_dir);
     match fs::remove_file(&path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -127,860 +64,41 @@ pub fn remove_marker(local_dir: &Path) -> AppResult<()> {
     }
 }
 
-/// Self-heal launch step: if a previous `sync_enable` left binaries
-/// stranded in `<local>/books` or `<local>/covers` (move failed
-/// mid-flight, marker + data_dir already committed), move them into
-/// the matching `<ubiquity>` subdir now so the app stops resolving
-/// blobs against an iCloud directory that doesn't have them.
-///
-/// Idempotent — empty source dirs (the common case post-enable) make
-/// the call a no-op. Placeholder-aware: a `<dst>/.<name>.icloud`
-/// stub means iCloud already has the file (just evicted), so we skip
-/// rather than move on top of the placeholder and lose the local
-/// real copy. Failures per-file are logged but don't abort the whole
-/// launch — the next reconcile pass picks up what's left.
-///
-/// Triggered from `lib.rs::setup` whenever `is_migration_complete &&
-/// ubiquity_dir.exists()`. Without it, a failed `sync_enable` whose
-/// marker write succeeded but whose binary move failed would strand
-/// books permanently — PR #190's sixth review pass caught the path.
-pub fn reconcile_local_blobs_to_ubiquity(
-    local_dir: &Path,
-    ubiquity_dir: &Path,
-) -> AppResult<()> {
-    for sub in ["books", "covers"] {
-        let src = local_dir.join(sub);
-        if !src.exists() {
-            continue;
-        }
-        let dst = ubiquity_dir.join(sub);
-        fs::create_dir_all(&dst)?;
-        for entry in fs::read_dir(&src)? {
-            let entry = entry?;
-            let target = dst.join(entry.file_name());
-            // Real file already at dst → skip.
-            if target.exists() {
-                continue;
-            }
-            // iCloud-evicted placeholder for the same logical file →
-            // skip (file logically present, just not downloaded).
-            // Same trick as `commands::sync::move_dir_contents`.
-            if let Some(name) = target.file_name().and_then(|n| n.to_str()) {
-                let placeholder = dst.join(format!(".{name}.icloud"));
-                if placeholder.exists() {
-                    continue;
-                }
-            }
-            // Try a same-fs rename first; fall back to copy + remove
-            // for cross-volume paths. Per-entry failures are logged
-            // and skipped so one bad file doesn't strand the rest.
-            if let Err(rename_err) = fs::rename(entry.path(), &target) {
-                match fs::copy(entry.path(), &target).and_then(|_| fs::remove_file(entry.path())) {
-                    Ok(()) => {}
-                    Err(copy_err) => {
-                        log::warn!(
-                            "sync: failed to reconcile {} to ubiquity: rename={rename_err}, copy={copy_err}",
-                            entry.path().display()
-                        );
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Resolve the iCloud Documents directory at launch time. `Some(path)`
-/// when the launch flow should treat this install as having iCloud
-/// sync "on" in some form (either legacy file-sync pending migration,
-/// or post-migration / new-UI-enabled); `None` when sync is cleanly
-/// off. Prefers the path recorded in the migration marker (stable
-/// across launches) over the deterministic location (fallback for
-/// legacy markers from pre-PR #192 builds or the untouched
-/// `.icloud_enabled`-only case).
-///
-/// Taking the legacy-marker presence as a parameter keeps this helper
-/// testable without pulling in macOS-only `icloud::is_icloud_enabled`.
-pub fn resolve_ubiquity_dir(
-    local_dir: &Path,
-    legacy_marker_present: bool,
-) -> Option<PathBuf> {
-    let migration_done = is_migration_complete(local_dir);
-    if !legacy_marker_present && !migration_done {
-        return None;
-    }
-    recorded_data_dir(local_dir).or_else(crate::icloud::icloud_data_dir_deterministic)
-}
-
-/// Migrate from legacy file-sync to per-device event log.
-///
-/// `local_dir` is the always-local app data directory (`<app_data>` in
-/// the spec). `ubiquity_dir` is the iCloud Documents container. After a
-/// successful run:
-///
-/// - `<local>/quill.db` is the new home of the DB (bit-exact copy of
-///   the source, then auto-migrated to v11 by `Db::init`).
-/// - `<ubiquity>/logs/<device>.snapshot.json` holds the bootstrap snapshot.
-/// - `<ubiquity>/logs/<device>.jsonl` exists but is empty.
-/// - `<local>/.migration_complete` exists.
-/// - `<ubiquity>/quill.db*` are renamed to `quill.db.migrated-<iso>`.
-///
-/// On any failure the error is returned and no marker is written; the
-/// next launch will retry. Partial state (e.g. snapshot written but
-/// marker missing) is harmless because peers ignore unfamiliar
-/// snapshots until they're advertised by an active log, and the next
-/// run overwrites the snapshot anyway.
-pub fn run_migration(
-    local_dir: &Path,
-    ubiquity_dir: &Path,
-    device_id: &str,
-) -> AppResult<MigrationOutcome> {
-    let mut outcome = MigrationOutcome::default();
-
-    // 0. Sanity: nothing to migrate if the marker is already there. This
-    //    arm makes the function safe to call without the caller checking
-    //    first; callers that DO check still benefit because we double-
-    //    check before doing any IO.
-    if is_migration_complete(local_dir) {
-        // Self-healing retire — if a previous run wrote the marker but
-        // crashed before retire, finish the job now.
-        outcome.retired_files = retire_ubiquity_db(ubiquity_dir)?;
-        return Ok(outcome);
-    }
-
-    let ubiquity_db = ubiquity_dir.join("quill.db");
-    let local_db = local_dir.join("quill.db");
-
-    // 1a. ubiquity_dir itself is missing → iCloud container hasn't
-    //     materialized yet (cold boot, signed-out account, daemon
-    //     race). Defer without writing the marker. Critical: we MUST
-    //     NOT mark complete here — if we did, the launch flow would
-    //     create a fresh empty local DB on this launch, and the next
-    //     launch (iCloud back) would see `local/quill.db` exists,
-    //     skip the copy step, snapshot the empty file, and retire
-    //     the real legacy DB. The user's library would be gone.
-    //     (Reviewed in PR #192.)
-    if !ubiquity_dir.exists() {
-        outcome.deferred_for_download = true;
-        return Ok(outcome);
-    }
-
-    // 1b. Resolve the source DB. Three cases:
-    //
-    //    a. `quill.db` is on disk → copy → migrate.
-    //    b. `quill.db` is missing AND `.quill.db.icloud` placeholder is
-    //       present → file is iCloud-evicted. Trigger a download and
-    //       BAIL WITHOUT WRITING THE MARKER so the next launch retries.
-    //       Users who haven't opened the app in months commonly land
-    //       here — the iCloud daemon evicts cold files. Without this
-    //       arm we'd silently skip migration forever (the next launch
-    //       would see the marker and never retry), and the
-    //       self-healing retire path in lib.rs would later rename the
-    //       freshly-downloaded `quill.db` away as a "stray".
-    //    c. Neither file present → no legacy data exists. Mark complete.
-    if !ubiquity_db.exists() {
-        let placeholder = match crate::icloud::icloud_placeholder_path(&ubiquity_db) {
-            Some(p) => p,
-            None => {
-                // Pathological case (root path with no parent). Treat
-                // as "nothing to migrate".
-                fs::create_dir_all(local_dir)?;
-                write_marker(local_dir, None)?;
-                return Ok(outcome);
-            }
-        };
-        if placeholder.exists() {
-            // Ask the iCloud daemon to download. No-op on non-macOS;
-            // best-effort on macOS (failures are logged in
-            // `trigger_download_file`). Either way we return without a
-            // marker so next launch tries again.
-            crate::icloud::trigger_download_file(&ubiquity_db);
-            outcome.deferred_for_download = true;
-            return Ok(outcome);
-        }
-        // No legacy data to migrate. Mark complete with no recorded
-        // path so the launch flow falls back to the deterministic
-        // iCloud path (or local on non-macOS).
-        fs::create_dir_all(local_dir)?;
-        write_marker(local_dir, None)?;
-        return Ok(outcome);
-    }
-
-    // ALWAYS copy ubiquity → local — never skip just because local_db
-    // already exists. A leftover local DB might be:
-    //   - A partially-migrated file from a crashed prior run.
-    //   - A "tentative" DB created by a prior launch that opened
-    //     local while migration was deferred (iCloud unreachable at
-    //     boot). Any session writes against that DB are sacrificed
-    //     to preserve the legacy library — the alternative would be
-    //     snapshotting the empty/tentative local file and retiring
-    //     the real legacy DB, which is unrecoverable data loss.
-    //   - A stale file from a past failed migration where the marker
-    //     was never written.
-    // In all three cases, copying ubiquity → local is the right move:
-    // ubiquity holds the source-of-truth library, and we're about to
-    // retire it anyway.
-    fs::create_dir_all(local_dir)?;
-    fs::copy(&ubiquity_db, &local_db)?;
-    outcome.copied_db = true;
-
-    // 2. Open the local DB — Db::init applies migrations 1-11, so a
-    //    legacy v8 / v9 / v10 file is brought to the current schema
-    //    before we read it.
-    let db = Db::init(local_dir)?;
-
-    // 3. Build the snapshot from the now-migrated local DB.
-    let snap = {
-        let conn = db
-            .conn
-            .lock()
-            .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
-        Snapshot::from_legacy_db(&conn, device_id)?
-    };
-
-    // 4. Write snapshot + empty log into the ubiquity logs dir.
-    let logs_dir = ubiquity_dir.join("logs");
-    fs::create_dir_all(&logs_dir)?;
-    let snap_path = logs_dir.join(format!("{device_id}.snapshot.json"));
-    snap.write_atomic(&snap_path)?;
-    outcome.wrote_snapshot = true;
-
-    let log_path = logs_dir.join(format!("{device_id}.jsonl"));
-    if !log_path.exists() {
-        // EventLog::open creates the file if missing. We don't write any
-        // events; the file exists so peers and `discover_peers` can find
-        // us as a participant.
-        let _ = EventLog::open(&log_path, device_id, false)?;
-        outcome.created_log = true;
-    }
-
-    // 5. Mark complete BEFORE retiring the ubiquity DB. If retire fails
-    //    we still want the next launch to skip the migration body and
-    //    just retry retire (the self-healing arm above).
-    //
-    //    The marker stores the absolute ubiquity path so the launch
-    //    flow always resolves blob paths against the same dir, even if
-    //    iCloud is offline at next launch (path resolution is decoupled
-    //    from path availability — IO will fail visibly instead of
-    //    silently flipping data_dir).
-    write_marker(local_dir, Some(ubiquity_dir))?;
-
-    // 6. Retire ubiquity quill.db*.
-    let report = retire_ubiquity_db_with_report(ubiquity_dir)?;
-    outcome.retired_files = report.renamed;
-    outcome.conflict_copies_discarded = report.conflict_copies_discarded;
-
-    Ok(outcome)
-}
-
-/// What `retire_ubiquity_db` did. Pulled out as a struct so the
-/// migration outcome can flag conflict-copy discards without changing
-/// the simpler `retire_ubiquity_db` callers.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct RetireReport {
-    pub renamed: usize,
-    pub conflict_copies_discarded: usize,
-}
-
-/// Rename `<ubiquity>/quill.db*` → `quill.db.migrated-<iso>`. Globs over
-/// `quill.db`, `quill.db-wal`, `quill.db-shm`, and conflict copies like
-/// `quill (1).db`. Idempotent — already-migrated files are skipped.
-/// Returns the number of files renamed.
-///
-/// Called from `run_migration` step 6 and from the launch self-healing
-/// arm. Safe to call on every launch.
-pub fn retire_ubiquity_db(ubiquity_dir: &Path) -> AppResult<usize> {
-    Ok(retire_ubiquity_db_with_report(ubiquity_dir)?.renamed)
-}
-
-/// Same as `retire_ubiquity_db` but surfaces the conflict-copy count
-/// separately so `run_migration` can flag the data-loss risk. See the
-/// module docstring for why we deliberately discard conflict copies in
-/// v1 instead of merging them.
-pub fn retire_ubiquity_db_with_report(ubiquity_dir: &Path) -> AppResult<RetireReport> {
-    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
-    let mut report = RetireReport::default();
-    let entries = match fs::read_dir(ubiquity_dir) {
-        Ok(e) => e,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(report),
-        Err(e) => return Err(AppError::Io(e)),
-    };
-    for entry in entries {
-        let entry = entry?;
-        let path = entry.path();
-        let name = match path.file_name().and_then(|n| n.to_str()) {
-            Some(n) => n.to_string(),
-            None => continue,
-        };
-        if !is_legacy_db_file(&name) {
-            continue;
-        }
-        let is_conflict = is_conflict_copy(&name);
-        let new_name = format!("{name}.migrated-{ts}");
-        let new_path = ubiquity_dir.join(&new_name);
-        // Best-effort rename; iCloud can transiently fail with EXDEV /
-        // permission errors. Log and move on rather than fail the whole
-        // migration.
-        match fs::rename(&path, &new_path) {
-            Ok(()) => {
-                report.renamed += 1;
-                if is_conflict {
-                    report.conflict_copies_discarded += 1;
-                    // Loud warning so a migrating user sees something
-                    // concrete in the console — conflict copies are
-                    // deliberately discarded in v1 (see module doc).
-                    log::warn!(
-                        "sync: WARNING — discarding legacy conflict copy {name:?} \
-                         without merging. Any rows unique to this file are lost. \
-                         The retired file remains at {new_name:?} for manual recovery."
-                    );
-                }
-            }
-            Err(e) => log::warn!(
-                "sync: failed to retire ubiquity file {name:?}: {e}; will retry next launch"
-            ),
-        }
-    }
-    Ok(report)
-}
-
-/// Subset of `is_legacy_db_file` — true only for `quill (N).db*`.
-/// `quill.db` / `quill.db-wal` / `quill.db-shm` are NOT conflict copies.
-fn is_conflict_copy(name: &str) -> bool {
-    if !name.starts_with("quill (") {
-        return false;
-    }
-    is_legacy_db_file(name)
-}
-
-/// True if `name` looks like a legacy file-sync DB artifact that should
-/// be retired by the migration. Matches:
-/// - `quill.db`, `quill.db-wal`, `quill.db-shm`
-/// - conflict copies: `quill (1).db`, `quill (2).db-wal`, etc.
-///
-/// Already-retired files (`quill.db.migrated-*`) are intentionally NOT
-/// matched — that's what makes retire idempotent.
-fn is_legacy_db_file(name: &str) -> bool {
-    if !name.starts_with("quill") {
-        return false;
-    }
-    if name.contains(".migrated-") {
-        return false;
-    }
-    let after_quill = &name["quill".len()..];
-    if after_quill == ".db" || after_quill == ".db-wal" || after_quill == ".db-shm" {
-        return true;
-    }
-    // Conflict-copy form: `quill (N).db`, `quill (N).db-wal`, etc.
-    if let Some(stripped) = after_quill.strip_prefix(" (") {
-        if let Some(close_paren) = stripped.find(')') {
-            let n = &stripped[..close_paren];
-            if !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()) {
-                let suffix = &stripped[close_paren + 1..];
-                return suffix == ".db" || suffix == ".db-wal" || suffix == ".db-shm";
-            }
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rusqlite::Connection;
     use tempfile::TempDir;
 
-    fn seed_legacy_db(path: &Path) {
-        let conn = Connection::open(path).unwrap();
-        conn.execute_batch("PRAGMA journal_mode=DELETE;").unwrap();
-        // Pretend this is a v11-shaped file-sync DB (matches what the
-        // user has after upgrading through migrations 1-11 normally).
-        Db::run_migrations_on(&conn).unwrap();
-        conn.execute(
-            "INSERT INTO books
-             (id, title, author, file_path, format, status, progress, created_at, updated_at, updated_by_device)
-             VALUES ('b1', 'War and Peace', 'Tolstoy', 'books/wp.epub', 'epub', 'reading', 42, 1000, 1500, 'migration')",
-            [],
-        ).unwrap();
-        conn.execute(
-            "INSERT INTO highlights
-             (id, book_id, cfi_range, color, created_at, updated_at, updated_by_device)
-             VALUES ('h1', 'b1', 'cfi', 'yellow', 1100, 1100, 'migration')",
-            [],
-        ).unwrap();
-    }
-
-    fn count(db_path: &Path, table: &str) -> i64 {
-        let conn = Connection::open(db_path).unwrap();
-        conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
-            .unwrap()
-    }
-
-    // -----------------------------------------------------------------
-    // resolve_ubiquity_dir — launch-flow gate. Regression for the
-    // umbrella PR review finding #1: new-UI enablers never get
-    // `.icloud_enabled` written, so the gate must accept
-    // `.migration_complete` on its own or sync dies on restart.
-    // -----------------------------------------------------------------
-
     #[test]
-    fn resolve_ubiquity_dir_none_when_no_markers() {
+    fn not_enabled_by_default() {
         let local = TempDir::new().unwrap();
-        assert_eq!(resolve_ubiquity_dir(local.path(), false), None);
-    }
-
-    #[test]
-    fn resolve_ubiquity_dir_returns_recorded_path_for_new_ui_enabler() {
-        let local = TempDir::new().unwrap();
-        // Simulate `sync_enable` having written the marker with an
-        // explicit ubiquity path. `.icloud_enabled` is deliberately
-        // absent — the bug was that legacy-only gating left these
-        // users with None.
-        let recorded = TempDir::new().unwrap();
-        write_marker(local.path(), Some(recorded.path())).unwrap();
-
-        let resolved = resolve_ubiquity_dir(local.path(), false).expect("must resolve");
-        assert_eq!(resolved, recorded.path());
-    }
-
-    #[test]
-    fn resolve_ubiquity_dir_returns_recorded_path_for_legacy_only_user() {
-        let local = TempDir::new().unwrap();
-        // Legacy user: only `.icloud_enabled` is present (no marker).
-        // On macOS the deterministic fallback resolves to the real
-        // container path; on other platforms it's None — either way
-        // the gate itself opens because the legacy marker is true.
-        let resolved = resolve_ubiquity_dir(local.path(), true);
-        #[cfg(target_os = "macos")]
-        assert!(resolved.is_some(), "legacy marker on macOS should resolve");
-        #[cfg(not(target_os = "macos"))]
-        assert!(resolved.is_none(), "no deterministic fallback off macOS");
-    }
-
-    #[test]
-    fn resolve_ubiquity_dir_prefers_recorded_over_legacy_fallback() {
-        let local = TempDir::new().unwrap();
-        let recorded = TempDir::new().unwrap();
-        write_marker(local.path(), Some(recorded.path())).unwrap();
-
-        // Legacy marker also present — still prefer the recorded
-        // path, not the deterministic iCloud fallback.
-        let resolved = resolve_ubiquity_dir(local.path(), true).unwrap();
-        assert_eq!(resolved, recorded.path());
-    }
-
-    // -----------------------------------------------------------------
-    // reconcile_local_blobs_to_ubiquity — launch self-heal for failed
-    // `sync_enable` moves. Regression for PR #190's sixth review pass.
-    // -----------------------------------------------------------------
-
-    #[test]
-    fn reconcile_no_local_subdir_is_noop() {
-        let local = TempDir::new().unwrap();
-        let ub = TempDir::new().unwrap();
-        // Neither books/ nor covers/ exists in local.
-        reconcile_local_blobs_to_ubiquity(local.path(), ub.path()).unwrap();
-        // No iCloud writes either.
-        assert!(!ub.path().join("books").exists() || ub.path().join("books").read_dir().unwrap().next().is_none());
-    }
-
-    #[test]
-    fn reconcile_moves_leftover_local_books_into_ubiquity() {
-        let local = TempDir::new().unwrap();
-        let ub = TempDir::new().unwrap();
-        fs::create_dir_all(local.path().join("books")).unwrap();
-        fs::create_dir_all(ub.path().join("books")).unwrap();
-        fs::write(local.path().join("books/orphan.epub"), b"content").unwrap();
-
-        reconcile_local_blobs_to_ubiquity(local.path(), ub.path()).unwrap();
-
-        assert!(ub.path().join("books/orphan.epub").exists(), "moved to ubiquity");
-        assert!(!local.path().join("books/orphan.epub").exists(), "removed from local");
-    }
-
-    #[test]
-    fn reconcile_skips_when_target_already_present_in_ubiquity() {
-        let local = TempDir::new().unwrap();
-        let ub = TempDir::new().unwrap();
-        fs::create_dir_all(local.path().join("books")).unwrap();
-        fs::create_dir_all(ub.path().join("books")).unwrap();
-        fs::write(local.path().join("books/dup.epub"), b"local-version").unwrap();
-        fs::write(ub.path().join("books/dup.epub"), b"ubiquity-version").unwrap();
-
-        reconcile_local_blobs_to_ubiquity(local.path(), ub.path()).unwrap();
-
-        // ubiquity copy is the authoritative one; local is preserved
-        // (we don't delete what we didn't move).
-        assert_eq!(fs::read(ub.path().join("books/dup.epub")).unwrap(), b"ubiquity-version");
-        assert!(local.path().join("books/dup.epub").exists(), "untouched local stays");
-    }
-
-    #[test]
-    fn reconcile_skips_when_only_icloud_placeholder_at_target() {
-        let local = TempDir::new().unwrap();
-        let ub = TempDir::new().unwrap();
-        fs::create_dir_all(local.path().join("books")).unwrap();
-        fs::create_dir_all(ub.path().join("books")).unwrap();
-        fs::write(local.path().join("books/foo.epub"), b"local-real").unwrap();
-        // iCloud has only an evicted-placeholder stub for foo.epub.
-        fs::write(ub.path().join("books/.foo.epub.icloud"), b"stub").unwrap();
-
-        reconcile_local_blobs_to_ubiquity(local.path(), ub.path()).unwrap();
-
-        assert!(local.path().join("books/foo.epub").exists(),
-            "must NOT move on top of an iCloud placeholder — local keeps the real file");
-        assert!(!ub.path().join("books/foo.epub").exists(),
-            "ubiquity stays placeholder-only; iCloud daemon will materialise on demand");
-        assert!(ub.path().join("books/.foo.epub.icloud").exists(), "placeholder preserved");
-    }
-
-    #[test]
-    fn reconcile_handles_books_and_covers_independently() {
-        let local = TempDir::new().unwrap();
-        let ub = TempDir::new().unwrap();
-        fs::create_dir_all(local.path().join("books")).unwrap();
-        fs::create_dir_all(local.path().join("covers")).unwrap();
-        fs::create_dir_all(ub.path().join("books")).unwrap();
-        fs::create_dir_all(ub.path().join("covers")).unwrap();
-        fs::write(local.path().join("books/b.epub"), b"b").unwrap();
-        fs::write(local.path().join("covers/c.jpg"), b"c").unwrap();
-
-        reconcile_local_blobs_to_ubiquity(local.path(), ub.path()).unwrap();
-
-        assert!(ub.path().join("books/b.epub").exists());
-        assert!(ub.path().join("covers/c.jpg").exists());
-        assert!(!local.path().join("books/b.epub").exists());
-        assert!(!local.path().join("covers/c.jpg").exists());
-    }
-
-    #[test]
-    fn run_migration_first_run_writes_artifacts_and_retires_db() {
-        let local = TempDir::new().unwrap();
-        let ubiquity = TempDir::new().unwrap();
-        let dev = "dev-MIGRATING";
-
-        seed_legacy_db(&ubiquity.path().join("quill.db"));
-        // WAL/SHM siblings the iCloud daemon may have left behind.
-        fs::write(ubiquity.path().join("quill.db-wal"), b"wal").unwrap();
-        fs::write(ubiquity.path().join("quill.db-shm"), b"shm").unwrap();
-
-        let outcome = run_migration(local.path(), ubiquity.path(), dev).unwrap();
-
-        assert!(outcome.copied_db);
-        assert!(outcome.wrote_snapshot);
-        assert!(outcome.created_log);
-        assert!(outcome.retired_files >= 1);
-
-        // Local DB exists and carries the seeded rows.
-        assert!(local.path().join("quill.db").exists());
-        assert_eq!(count(&local.path().join("quill.db"), "books"), 1);
-
-        // Snapshot + log artifacts.
-        assert!(ubiquity
-            .path()
-            .join("logs")
-            .join(format!("{dev}.snapshot.json"))
-            .exists());
-        assert!(ubiquity
-            .path()
-            .join("logs")
-            .join(format!("{dev}.jsonl"))
-            .exists());
-
-        // Marker present AND records the ubiquity path so the next
-        // launch resolves binaries against the same directory even if
-        // iCloud is offline at boot.
-        assert!(is_migration_complete(local.path()));
-        assert_eq!(
-            recorded_data_dir(local.path()).as_deref(),
-            Some(ubiquity.path()),
-            "marker must record the absolute ubiquity path for stable resolution"
-        );
-
-        // Ubiquity DB retired (renamed, not in place).
-        assert!(!ubiquity.path().join("quill.db").exists());
-        let mut migrated = 0;
-        for entry in fs::read_dir(ubiquity.path()).unwrap() {
-            let name = entry.unwrap().file_name().into_string().unwrap();
-            if name.contains(".migrated-") {
-                migrated += 1;
-            }
-        }
-        assert!(migrated >= 1, "at least one retired file expected");
-    }
-
-    #[test]
-    fn run_migration_is_idempotent_after_marker_set() {
-        let local = TempDir::new().unwrap();
-        let ubiquity = TempDir::new().unwrap();
-        let dev = "dev-MIGRATING";
-
-        seed_legacy_db(&ubiquity.path().join("quill.db"));
-        run_migration(local.path(), ubiquity.path(), dev).unwrap();
-
-        // Re-add a fake stray ubiquity DB to simulate a peer reverting
-        // (not realistic in production, but proves the self-healing
-        // retire arm runs on every call).
-        fs::write(ubiquity.path().join("quill.db"), b"stray").unwrap();
-
-        let outcome = run_migration(local.path(), ubiquity.path(), dev).unwrap();
-        // Marker arm short-circuits → didn't copy/snapshot/create_log,
-        // but DID retire the stray.
-        assert!(!outcome.copied_db);
-        assert!(!outcome.wrote_snapshot);
-        assert!(!outcome.created_log);
-        assert!(outcome.retired_files >= 1);
-        assert!(!ubiquity.path().join("quill.db").exists());
-    }
-
-    #[test]
-    fn run_migration_with_empty_ubiquity_dir_writes_marker_and_skips() {
-        let local = TempDir::new().unwrap();
-        let ubiquity = TempDir::new().unwrap();
-        // ubiquity dir EXISTS (TempDir created it) but contains no
-        // legacy DB and no placeholder → genuinely no data to migrate.
-        let outcome = run_migration(local.path(), ubiquity.path(), "dev-X").unwrap();
-        assert!(!outcome.copied_db);
-        assert!(!outcome.deferred_for_download);
-        assert!(is_migration_complete(local.path()));
-    }
-
-    /// Regression for the first-launch-without-iCloud finding (PR #192
-    /// 4th-round review): if `ubiquity_dir` itself doesn't exist
-    /// (iCloud container hasn't materialized yet — cold boot, signed-
-    /// out account, daemon race), `run_migration` MUST defer without
-    /// writing the marker. Writing the marker would let the next
-    /// launch open a fresh empty local DB which the *next* migration
-    /// would then snapshot and use to retire the real legacy DB —
-    /// permanent data loss.
-    #[test]
-    fn run_migration_defers_when_ubiquity_dir_missing() {
-        let local = TempDir::new().unwrap();
-        let tmp = TempDir::new().unwrap();
-        let ubiquity = tmp.path().join("not-yet-materialized");
-        // Don't create the directory.
-        assert!(!ubiquity.exists());
-
-        let outcome = run_migration(local.path(), &ubiquity, "dev-X").unwrap();
-        assert!(outcome.deferred_for_download);
-        assert!(!outcome.copied_db);
-        assert!(
-            !is_migration_complete(local.path()),
-            "marker MUST NOT be written when ubiquity is unreachable — \
-             otherwise next launch would open a fresh local DB and the \
-             migration after that would retire the real legacy DB"
-        );
-    }
-
-    /// Regression for the same finding's second arm: if a tentative
-    /// local DB exists from a prior deferred-migration launch (or a
-    /// crashed previous attempt), `run_migration` must clobber it
-    /// with the real ubiquity DB — never snapshot the local file and
-    /// retire ubiquity. The legacy library is the source of truth.
-    #[test]
-    fn run_migration_clobbers_tentative_local_db_with_ubiquity() {
-        let local = TempDir::new().unwrap();
-        let ubiquity = TempDir::new().unwrap();
-        let dev = "dev-MIGRATING";
-
-        // Seed legacy ubiquity DB with one book.
-        seed_legacy_db(&ubiquity.path().join("quill.db"));
-
-        // Simulate a tentative local DB created during a previous
-        // launch where iCloud was unreachable. Different content from
-        // the legacy DB so the test can tell which one survived.
-        let conn = Connection::open(local.path().join("quill.db")).unwrap();
-        Db::run_migrations_on(&conn).unwrap();
-        conn.execute(
-            "INSERT INTO books
-             (id, title, author, file_path, format, status, progress, created_at, updated_at, updated_by_device)
-             VALUES ('tentative', 'Imported during wedge', 'X', 'books/x.epub', 'epub', 'reading', 0, 1, 1, 'wedge')",
-            [],
-        ).unwrap();
-        drop(conn);
-
-        run_migration(local.path(), ubiquity.path(), dev).unwrap();
-
-        // Local now mirrors the legacy library — the tentative row is
-        // gone, the legacy `b1` row is present.
-        let local_conn = Connection::open(local.path().join("quill.db")).unwrap();
-        let has_legacy: bool = local_conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM books WHERE id = 'b1')",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        let has_tentative: bool = local_conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM books WHERE id = 'tentative')",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert!(has_legacy, "real legacy book must survive the migration");
-        assert!(
-            !has_tentative,
-            "tentative wedge-session writes are deliberately sacrificed \
-             so the legacy library wins the conflict"
-        );
-    }
-
-    /// Regression for the data_dir-stability follow-up on PR #192.
-    /// Markers from the first Chunk 6 build are empty files; loading
-    /// them must NOT spuriously return `Some(<empty path>)`. Returning
-    /// `None` lets the launch flow fall back to the deterministic
-    /// iCloud path instead of resolving against `""`.
-    #[test]
-    fn recorded_data_dir_is_none_for_legacy_empty_marker() {
-        let local = TempDir::new().unwrap();
-        // Simulate the legacy marker: empty file at .migration_complete.
-        fs::write(migration_complete_path(local.path()), b"").unwrap();
-        assert!(is_migration_complete(local.path()));
+        assert!(!is_sync_enabled(local.path()));
         assert_eq!(recorded_data_dir(local.path()), None);
     }
 
-    /// Round-trip: the path written by `write_marker` is what
-    /// `recorded_data_dir` reads back. This is the contract the launch
-    /// flow relies on for stable post-migration data_dir resolution.
     #[test]
-    fn recorded_data_dir_round_trips_through_marker() {
+    fn write_then_read_round_trips() {
         let local = TempDir::new().unwrap();
-        let data_dir = std::path::Path::new("/tmp/some/icloud/path");
-        write_marker(local.path(), Some(data_dir)).unwrap();
-        assert_eq!(
-            recorded_data_dir(local.path()).as_deref(),
-            Some(data_dir),
-        );
+        let data_dir = Path::new("/tmp/some/icloud/path");
+        write_sync_settings(local.path(), Some(data_dir)).unwrap();
+        assert!(is_sync_enabled(local.path()));
+        assert_eq!(recorded_data_dir(local.path()).as_deref(), Some(data_dir));
     }
 
-    /// Regression for review finding #2: a `.quill.db.icloud` placeholder
-    /// (file is iCloud-evicted, not yet downloaded) must NOT cause the
-    /// migration to short-circuit with the marker. We bail without the
-    /// marker so the next launch retries after iCloud finishes pulling
-    /// the real file down.
     #[test]
-    fn run_migration_with_icloud_placeholder_defers_and_skips_marker() {
+    fn remove_clears_settings() {
         let local = TempDir::new().unwrap();
-        let ubiquity = TempDir::new().unwrap();
-        // No quill.db, but a placeholder marking it as evicted.
-        fs::write(ubiquity.path().join(".quill.db.icloud"), b"placeholder").unwrap();
-
-        let outcome = run_migration(local.path(), ubiquity.path(), "dev-X").unwrap();
-        assert!(outcome.deferred_for_download);
-        assert!(!outcome.copied_db);
-        assert!(!outcome.wrote_snapshot);
-        assert!(
-            !is_migration_complete(local.path()),
-            "marker must NOT be written when the source is evicted — \
-             we need next launch to retry"
-        );
+        write_sync_settings(local.path(), Some(Path::new("/tmp"))).unwrap();
+        assert!(is_sync_enabled(local.path()));
+        remove_sync_settings(local.path()).unwrap();
+        assert!(!is_sync_enabled(local.path()));
     }
 
-    /// Regression for review finding #3: conflict copies are
-    /// deliberately retired without merging in v1. The migration
-    /// outcome surfaces the count so the launch-flow log can flag it.
-    /// This test pins both sides of the contract: detection and
-    /// counting.
     #[test]
-    fn run_migration_counts_discarded_conflict_copies() {
+    fn none_data_dir_still_enabled() {
         let local = TempDir::new().unwrap();
-        let ubiquity = TempDir::new().unwrap();
-        let dev = "dev-MIGRATING";
-
-        seed_legacy_db(&ubiquity.path().join("quill.db"));
-        // Two conflict copies with their own seeded DBs (data we
-        // intentionally drop on the floor).
-        seed_legacy_db(&ubiquity.path().join("quill (1).db"));
-        seed_legacy_db(&ubiquity.path().join("quill (2).db"));
-
-        let outcome = run_migration(local.path(), ubiquity.path(), dev).unwrap();
-        assert_eq!(
-            outcome.conflict_copies_discarded, 2,
-            "both quill (N).db files should be counted as discarded"
-        );
-        // Both files should have been retired (renamed) — none left in
-        // place.
-        assert!(!ubiquity.path().join("quill (1).db").exists());
-        assert!(!ubiquity.path().join("quill (2).db").exists());
-    }
-
-    #[test]
-    fn retire_ubiquity_db_renames_main_wal_shm_and_conflict_copies() {
-        let dir = TempDir::new().unwrap();
-        for name in [
-            "quill.db",
-            "quill.db-wal",
-            "quill.db-shm",
-            "quill (1).db",
-            "quill (2).db-wal",
-            "secrets.db",
-            "covers",
-        ] {
-            // `covers/` is a directory — it shouldn't be renamed. Files
-            // get a single byte each.
-            let p = dir.path().join(name);
-            if name == "covers" {
-                fs::create_dir(&p).unwrap();
-            } else {
-                fs::write(&p, b"x").unwrap();
-            }
-        }
-
-        let renamed = retire_ubiquity_db(dir.path()).unwrap();
-        assert_eq!(
-            renamed, 5,
-            "only quill.db family + conflict copies should retire"
-        );
-        assert!(!dir.path().join("quill.db").exists());
-        assert!(!dir.path().join("quill.db-wal").exists());
-        assert!(!dir.path().join("quill.db-shm").exists());
-        assert!(!dir.path().join("quill (1).db").exists());
-        assert!(!dir.path().join("quill (2).db-wal").exists());
-        // Unrelated files are untouched.
-        assert!(dir.path().join("secrets.db").exists());
-        assert!(dir.path().join("covers").is_dir());
-    }
-
-    #[test]
-    fn retire_ubiquity_db_skips_already_retired_files() {
-        let dir = TempDir::new().unwrap();
-        fs::write(
-            dir.path().join("quill.db.migrated-20260101T000000Z"),
-            b"x",
-        )
-        .unwrap();
-        let renamed = retire_ubiquity_db(dir.path()).unwrap();
-        assert_eq!(renamed, 0);
-        assert!(dir
-            .path()
-            .join("quill.db.migrated-20260101T000000Z")
-            .exists());
-    }
-
-    #[test]
-    fn retire_ubiquity_db_missing_dir_is_a_noop() {
-        let dir = TempDir::new().unwrap();
-        let missing = dir.path().join("nope");
-        let renamed = retire_ubiquity_db(&missing).unwrap();
-        assert_eq!(renamed, 0);
-    }
-
-    #[test]
-    fn is_legacy_db_file_matches_expected_set() {
-        assert!(is_legacy_db_file("quill.db"));
-        assert!(is_legacy_db_file("quill.db-wal"));
-        assert!(is_legacy_db_file("quill.db-shm"));
-        assert!(is_legacy_db_file("quill (1).db"));
-        assert!(is_legacy_db_file("quill (12).db-wal"));
-
-        assert!(!is_legacy_db_file("quill.db.migrated-20260101T000000Z"));
-        assert!(!is_legacy_db_file("secrets.db"));
-        assert!(!is_legacy_db_file("books"));
-        assert!(!is_legacy_db_file("quill"));
-        assert!(
-            !is_legacy_db_file("quill ().db"),
-            "empty parens isn't a real conflict copy"
-        );
+        write_sync_settings(local.path(), None).unwrap();
+        assert!(is_sync_enabled(local.path()));
+        assert_eq!(recorded_data_dir(local.path()), None);
     }
 }

--- a/src-tauri/src/sync/writer.rs
+++ b/src-tauri/src/sync/writer.rs
@@ -140,7 +140,7 @@ impl SyncWriter {
 
     /// Toggle whether `with_tx` writes its events vec into
     /// `_pending_publish`. `true` is set by lib.rs whenever
-    /// `.migration_complete` exists, regardless of whether the iCloud
+    /// `.icloud_setting` exists, regardless of whether the iCloud
     /// container is reachable this launch. The decoupling from `log` is
     /// what enables the queue-only mode: events accumulate durably in
     /// SQL even when the engine can't boot, and the next reachable

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Library, BookOpen, CheckCircle2, FolderClosed, BookA, Plus, MessageSquare, Globe, Pencil, Trash2, GripVertical, Cloud, RefreshCw } from "lucide-react";
+import { Library, BookOpen, CheckCircle2, FolderClosed, BookA, Plus, MessageSquare, Globe, Pencil, Trash2, GripVertical, RefreshCw } from "lucide-react";
 import Button from "./ui/Button";
 import QuillLogo from "./QuillLogo";
 import type { Book } from "../hooks/useBooks";
@@ -19,7 +19,6 @@ interface SidebarProps {
   };
   userName?: string;
   onOpenSettings?: () => void;
-  icloudSyncing?: boolean;
   syncProgress?: { applied: number; total: number } | null;
 }
 
@@ -37,7 +36,7 @@ function getStoredWidth(): number {
   return SIDEBAR_DEFAULT;
 }
 
-export default function Sidebar({ activeFilter, onFilterChange, books, collections: collectionsHook, userName, onOpenSettings, icloudSyncing, syncProgress }: SidebarProps) {
+export default function Sidebar({ activeFilter, onFilterChange, books, collections: collectionsHook, userName, onOpenSettings, syncProgress }: SidebarProps) {
   const { t } = useTranslation();
   const [sidebarWidth, setSidebarWidth] = useState(getStoredWidth);
   const resizingRef = useRef(false);
@@ -188,10 +187,6 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
                 {syncProgress.applied}/{syncProgress.total}
               </span>
             )}
-          </span>
-        ) : icloudSyncing ? (
-          <span title={t("sidebar.icloudSyncing")} className="ml-auto shrink-0">
-            <Cloud size={14} className="text-text-muted animate-pulse" />
           </span>
         ) : null}
       </div>

--- a/src/components/settings/LibrarySyncSettings.tsx
+++ b/src/components/settings/LibrarySyncSettings.tsx
@@ -19,7 +19,7 @@ interface PeerInfo {
 interface SyncStatus {
   enabled: boolean;
   available: boolean;
-  migration_complete: boolean;
+  sync_enabled: boolean;
   shared_dir: string | null;
   device_uuid: string;
   device_name: string;
@@ -69,7 +69,7 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
   // Tracks the toggle action that returned an error so the Retry
   // button can re-invoke it. Without this, after a failed enable
   // that committed the marker, the next toggle click would open the
-  // Disable flow (because `migration_complete` is now true), leaving
+  // Disable flow (because `sync_enabled` is now true), leaving
   // the user with no UI path to finish the half-completed enable.
   const [lastFailedAction, setLastFailedAction] = useState<"enable" | "disable" | null>(null);
   // Peer the user clicked the trash icon on; opens a confirmation
@@ -107,10 +107,10 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
   const onToggleClick = () => {
     if (!status) return;
     // Action mirrors the rendered toggle, which reflects persisted
-    // intent (`migration_complete`) not runtime state (`enabled`).
+    // intent (`sync_enabled`) not runtime state (`enabled`).
     // Using `enabled` here meant a queue-only/offline session showed
     // the toggle as on but opened the Enable flow on click.
-    setConfirm(status.migration_complete ? "disable" : "enable");
+    setConfirm(status.sync_enabled ? "disable" : "enable");
   };
 
   const runToggle = async (action: "enable" | "disable") => {
@@ -205,7 +205,7 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
   };
 
   // Two orthogonal states surfaced by the backend:
-  //  - `migration_complete` is the user's durable intent ("sync is on
+  //  - `sync_enabled` is the user's durable intent ("sync is on
   //    for this install"). This drives the Toggle and the visibility
   //    of the "Other devices" / actions sections — if the user said
   //    they want sync, those affordances should stay put even when
@@ -217,7 +217,7 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
   // Splitting the two keeps a user with sync on but iCloud temporarily
   // offline from seeing the toggle flip itself off — and from being
   // re-offered `sync_enable` as if they never turned it on.
-  const syncOn = status?.migration_complete ?? false;
+  const syncOn = status?.sync_enabled ?? false;
   const engineRunning = status?.enabled ?? false;
   const available = status?.available ?? false;
   const peers = status?.peers ?? [];

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,6 @@ export default function Home() {
   const [importing, setImporting] = useState(false);
   const [importSlow, setImportSlow] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
-  const [icloudSyncing, setIcloudSyncing] = useState(false);
   const [syncProgress, setSyncProgress] = useState<{ applied: number; total: number } | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<"general" | "reading" | "ai" | "lookup" | "librarySync" | "about">("general");
@@ -137,14 +136,7 @@ export default function Home() {
     return () => clearTimeout(timer);
   }, [importing]);
 
-  // iCloud background sync indicator + refresh books when sync finishes
   useEffect(() => {
-    const unlistenStart = listen("icloud-sync-start", () => setIcloudSyncing(true));
-    const unlistenDone = listen("icloud-sync-done", () => {
-      setIcloudSyncing(false);
-      refreshRef.current();
-      allBooksRefreshRef.current();
-    });
     const unlistenTick = listen("sync-initial-tick-done", () => {
       setSyncProgress(null);
       refreshRef.current();
@@ -155,8 +147,6 @@ export default function Home() {
       setSyncProgress(e.payload);
     });
     return () => {
-      unlistenStart.then((fn) => fn());
-      unlistenDone.then((fn) => fn());
       unlistenTick.then((fn) => fn());
       unlistenProgress.then((fn) => fn());
     };
@@ -300,7 +290,6 @@ export default function Home() {
         collections={collections}
         userName={userName}
         onOpenSettings={() => setSettingsOpen(true)}
-        icloudSyncing={icloudSyncing}
         syncProgress={syncProgress}
       />
 


### PR DESCRIPTION
## Summary

- Remove the entire legacy file-sync migration path (~1,200 lines): `run_migration`, `retire_ubiquity_db`, `reconcile_local_blobs_to_ubiquity`, `.icloud_enabled` marker, `ensure_downloaded`, `sync_revert_to_legacy`, `app_ready` iCloud download trigger, `icloudSyncing` frontend state
- Rename `.migration_complete` → `.icloud_setting` with JSON format for extensibility:
  ```json
  { "enabled": true, "data_dir": "/path/to/iCloud/Documents" }
  ```
- Rename all APIs: `is_migration_complete` → `is_sync_enabled`, `write_marker` → `write_sync_settings`, `remove_marker` → `remove_sync_settings`, `migration_complete` field → `sync_enabled`

**Breaking change**: existing users with `.migration_complete` will need to re-enable sync in settings after updating.

## Test plan

- [x] 229 tests pass (227 unit + 2 integration)
- [x] TypeScript compiles clean
- [ ] Fresh install → enable sync → verify `.icloud_setting` written with correct JSON
- [ ] Disable sync → verify `.icloud_setting` removed
- [ ] Relaunch → verify sync stays off (no stale marker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)