### PR TITLE
feat: backend cursor pagination for book list

### DIFF
--- a/docs/impls/247-covers-in-db.md
+++ b/docs/impls/247-covers-in-db.md
@@ -1,0 +1,78 @@
+# 247 — Store Covers in SQLite
+
+PR: https://github.com/yicheng47/quill/pull/248
+
+## Problem
+
+When iCloud sync is enabled, cover images resolve to iCloud paths. On a freshly synced device, all covers are evicted placeholders. The frontend tries to load them via Tauri's asset protocol, which blocks the main thread → app hangs ("not responding").
+
+## Solution
+
+Store cover image bytes directly in SQLite as a BLOB column. Covers are small (~50KB each, ~16MB total for 329 books). The frontend renders them as `data:image/...;base64,...` URLs. No iCloud paths, no file management, no eviction.
+
+## Schema Change
+
+Migration 013:
+
+```sql
+ALTER TABLE books ADD COLUMN cover_data BLOB;
+```
+
+Backfill on first launch: read existing cover files from disk, write bytes into the DB, set `cover_path = NULL`.
+
+## Backend Changes
+
+### `Book` struct
+
+Add `cover_data: Option<String>` — base64-encoded image. Returned inline by `list_books` and `get_book`.
+
+### `list_books` / `get_book`
+
+SELECT includes `cover_data`. The base64 string is included in the JSON response. ~16MB for 329 books with covers — one IPC call, fast from local SQLite.
+
+### `save_book_cover`
+
+Write bytes to `cover_data` column instead of disk.
+
+### Import (EPUB / PDF)
+
+`extract_metadata` returns cover bytes instead of writing to `covers_dir`. Stored in DB during insert.
+
+### Sync
+
+- Snapshots include `cover_data` per book (full state dump)
+- Events do NOT carry cover bytes — too large per-event. `book.import` events carry `cover_path` for backwards compat. Peers get covers via snapshot apply.
+
+## Frontend Changes
+
+### `Book` type
+
+```typescript
+interface Book {
+  // ... existing fields
+  cover_data: string | null;  // base64-encoded image
+}
+```
+
+### `CoverImage` / `BookGrid` / `BookList`
+
+Replace `convertFileSrc(book.cover_path)` with:
+
+```typescript
+const src = book.cover_data
+  ? `data:image/png;base64,${book.cover_data}`
+  : null;
+```
+
+## Migration
+
+1. Migration 013 adds `cover_data BLOB` column
+2. Backfill routine on startup reads existing cover files, writes bytes into DB
+3. Cover files on disk are NOT deleted (iCloud peers may still reference them)
+
+## Verification
+
+- Fresh device syncs 329 books → app renders immediately, covers show from DB
+- Import a book → cover stored in DB, shows instantly
+- Existing library → migration backfills from disk → no visible change
+- Snapshot sync includes cover_data → peer gets covers on snapshot apply

--- a/docs/impls/248-backend-pagination.md
+++ b/docs/impls/248-backend-pagination.md
@@ -1,0 +1,110 @@
+# 248 — Backend Pagination for Book List
+
+PR: https://github.com/yicheng47/quill/pull/248
+
+## Problem
+
+`list_books` returns all books at once. With 329+ books, this means:
+- Large IPC payload on every filter/search change
+- 329 cover images hit Tauri's asset protocol simultaneously
+- On synced devices with iCloud covers, this hangs the app
+
+## Solution
+
+Cursor-based pagination. The backend returns one page at a time (default 20 books). The frontend renders the first page immediately and loads more on scroll.
+
+## Backend Changes
+
+### `list_books` command
+
+Current signature:
+```rust
+fn list_books(filter: Option<String>, search: Option<String>, db: State<Db>) -> AppResult<Vec<Book>>
+```
+
+New signature:
+```rust
+fn list_books(
+    filter: Option<String>,
+    search: Option<String>,
+    cursor: Option<String>,  // opaque cursor (book id from last page)
+    limit: Option<usize>,    // default 20
+    db: State<Db>,
+) -> AppResult<BookPage>
+```
+
+Response:
+```rust
+#[derive(Serialize)]
+struct BookPage {
+    books: Vec<Book>,
+    next_cursor: Option<String>,  // null = no more pages
+    total: usize,                 // total count for the filter (for "All Books (329)")
+}
+```
+
+### SQL query
+
+```sql
+SELECT ... FROM books
+WHERE (filter conditions)
+  AND (search conditions)
+  AND updated_at < ?cursor_updated_at   -- cursor position
+ORDER BY updated_at DESC
+LIMIT ?limit + 1                        -- fetch one extra to know if there's a next page
+```
+
+The cursor encodes the `updated_at` + `id` of the last book in the previous page (for stable pagination when timestamps collide). Using `updated_at DESC` matches the current default sort order.
+
+The +1 trick: fetch 21 rows, return 20. If 21 came back, there's a next page — set `next_cursor` to the 20th book's position. If ≤20 came back, `next_cursor = null`.
+
+### Total count
+
+A separate `SELECT COUNT(*)` with the same filter/search conditions. Cached per filter change, not per page fetch.
+
+## Frontend Changes
+
+### `useBooks` hook
+
+```typescript
+interface UseBooks {
+  books: Book[];
+  total: number;
+  loading: boolean;
+  loadMore: () => void;
+  hasMore: boolean;
+  refresh: () => void;
+}
+```
+
+- `books` accumulates across pages (page 1 + page 2 + ...)
+- `loadMore()` fetches the next page using the cursor
+- `refresh()` resets to page 1 (filter/search change)
+- `hasMore` is true when `next_cursor` is not null
+
+### BookGrid / BookList
+
+Add a "load more" trigger at the bottom — either:
+- IntersectionObserver on a sentinel element (loads automatically on scroll)
+- Or a simple "Load more" button
+
+### Filter / search changes
+
+When filter or search changes, reset to page 1 (clear accumulated books, fetch fresh).
+
+### Sidebar counts
+
+The `total` field from the first page response drives the count badges ("All Books 329", "Currently Reading 4"). No separate query needed.
+
+## Migration
+
+None — this is a query-level change, no schema modification.
+
+## Verification
+
+- Library with 329 books → first 20 render immediately
+- Scroll down → next 20 load seamlessly
+- Switch filter → resets to page 1 of new filter
+- Search → resets to page 1 with search results
+- Sidebar counts still accurate
+- Synced device with iCloud covers → only 20 asset loads at a time, no hang

--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -317,26 +317,48 @@ pub async fn import_book(
 /// absolute paths for the frontend; the MCP `list_books` tool returns
 /// them as-is so the response doesn't leak this user's home directory
 /// layout to AI clients.
+/// Paginated response for `list_books`.
+#[derive(Debug, serde::Serialize)]
+pub struct BookPage {
+    pub books: Vec<Book>,
+    pub next_cursor: Option<String>,
+    pub total: usize,
+}
+
 pub(crate) fn query_books(
     db: &Db,
     filter: Option<&str>,
     search: Option<&str>,
-) -> AppResult<Vec<Book>> {
+    collection_id: Option<&str>,
+    cursor: Option<&str>,
+    limit: usize,
+) -> AppResult<BookPage> {
     let conn = db.reader();
 
-    let mut sql = "SELECT id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at FROM books".to_string();
+    let use_collection = collection_id.is_some();
+    let from_clause = if use_collection {
+        "books INNER JOIN collection_books cb ON cb.book_id = books.id"
+    } else {
+        "books"
+    };
+
     let mut conditions: Vec<String> = Vec::new();
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+    if let Some(cid) = collection_id {
+        conditions.push("cb.collection_id = ?".to_string());
+        param_values.push(Box::new(cid.to_string()));
+    }
 
     if let Some(f) = filter {
         match f {
             "reading" | "finished" | "unread" => {
-                conditions.push("status = ?".to_string());
+                conditions.push("books.status = ?".to_string());
                 param_values.push(Box::new(f.to_string()));
             }
             "all" => {}
             genre => {
-                conditions.push("genre = ?".to_string());
+                conditions.push("books.genre = ?".to_string());
                 param_values.push(Box::new(genre.to_string()));
             }
         }
@@ -344,24 +366,85 @@ pub(crate) fn query_books(
 
     if let Some(q) = search {
         if !q.is_empty() {
-            conditions.push("(LOWER(title) LIKE ? OR LOWER(author) LIKE ?)".to_string());
+            conditions.push("(LOWER(books.title) LIKE ? OR LOWER(books.author) LIKE ?)".to_string());
             let pattern = format!("%{}%", q.to_lowercase());
             param_values.push(Box::new(pattern.clone()));
             param_values.push(Box::new(pattern));
         }
     }
 
-    if !conditions.is_empty() {
-        sql.push_str(" WHERE ");
-        sql.push_str(&conditions.join(" AND "));
+    // Cursor: "updated_at:id" — books older than cursor position.
+    if let Some(c) = cursor {
+        if let Some((ts_str, cid)) = c.split_once(':') {
+            if let Ok(ts) = ts_str.parse::<i64>() {
+                conditions.push(
+                    "(books.updated_at < ? OR (books.updated_at = ? AND books.id > ?))".to_string(),
+                );
+                param_values.push(Box::new(ts));
+                param_values.push(Box::new(ts));
+                param_values.push(Box::new(cid.to_string()));
+            }
+        }
     }
 
-    sql.push_str(" ORDER BY updated_at DESC");
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!(" WHERE {}", conditions.join(" AND "))
+    };
+
+    // Count conditions = same as main conditions but without cursor.
+    let count_where = {
+        let mut cc: Vec<String> = Vec::new();
+        if let Some(cid) = collection_id {
+            cc.push("cb.collection_id = ?".to_string());
+            let _ = cid;
+        }
+        if let Some(f) = filter {
+            match f {
+                "reading" | "finished" | "unread" => cc.push("books.status = ?".to_string()),
+                "all" => {}
+                _ => cc.push("books.genre = ?".to_string()),
+            }
+        }
+        if search.is_some_and(|q| !q.is_empty()) {
+            cc.push("(LOWER(books.title) LIKE ? OR LOWER(books.author) LIKE ?)".to_string());
+        }
+        if cc.is_empty() { String::new() } else { format!(" WHERE {}", cc.join(" AND ")) }
+    };
+    let count_sql = format!("SELECT COUNT(*) FROM {from_clause}{count_where}");
+    let mut count_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    if let Some(cid) = collection_id {
+        count_params.push(Box::new(cid.to_string()));
+    }
+    if let Some(f) = filter {
+        match f {
+            "reading" | "finished" | "unread" | "all" => {
+                if f != "all" { count_params.push(Box::new(f.to_string())); }
+            }
+            _ => { count_params.push(Box::new(f.to_string())); }
+        }
+    }
+    if let Some(q) = search {
+        if !q.is_empty() {
+            let pattern = format!("%{}%", q.to_lowercase());
+            count_params.push(Box::new(pattern.clone()));
+            count_params.push(Box::new(pattern));
+        }
+    }
+    let count_refs: Vec<&dyn rusqlite::types::ToSql> = count_params.iter().map(|p| p.as_ref()).collect();
+    let total: usize = conn.query_row(&count_sql, count_refs.as_slice(), |r| r.get(0))?;
+
+    // Main query with cursor + limit.
+    let sql = format!(
+        "SELECT books.id, books.title, books.author, books.description, books.cover_path, books.file_path, books.format, books.genre, books.pages, books.status, books.progress, books.current_cfi, books.created_at, books.updated_at FROM {from_clause}{where_clause} ORDER BY books.updated_at DESC, books.id ASC LIMIT ?",
+    );
+    param_values.push(Box::new((limit + 1) as i64));
 
     let params_refs: Vec<&dyn rusqlite::types::ToSql> = param_values.iter().map(|p| p.as_ref()).collect();
 
     let mut stmt = conn.prepare(&sql)?;
-    let books = stmt.query_map(params_refs.as_slice(), |row| {
+    let mut books: Vec<Book> = stmt.query_map(params_refs.as_slice(), |row| {
         Ok(Book {
             id: row.get(0)?,
             title: row.get(1)?,
@@ -377,12 +460,20 @@ pub(crate) fn query_books(
             current_cfi: row.get(11)?,
             created_at: row.get(12)?,
             updated_at: row.get(13)?,
-            available: true, // raw shape — Tauri wrapper resolves availability
+            available: true,
         })
     })?
     .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(books)
+    let next_cursor = if books.len() > limit {
+        books.truncate(limit);
+        let last = &books[limit - 1];
+        Some(format!("{}:{}", last.updated_at, last.id))
+    } else {
+        None
+    };
+
+    Ok(BookPage { books, next_cursor, total })
 }
 
 /// Shared query helper for the single-book lookup. Same relative-path
@@ -415,17 +506,50 @@ pub(crate) fn query_book(db: &Db, id: &str) -> AppResult<Book> {
     Ok(book)
 }
 
+const DEFAULT_PAGE_SIZE: usize = 20;
+
 #[tauri::command]
 pub fn list_books(
     filter: Option<String>,
     search: Option<String>,
+    collection_id: Option<String>,
+    cursor: Option<String>,
+    limit: Option<usize>,
     db: State<'_, Db>,
-) -> AppResult<Vec<Book>> {
-    let mut books = query_books(&db, filter.as_deref(), search.as_deref())?;
-    for book in &mut books {
+) -> AppResult<BookPage> {
+    let page_size = limit.unwrap_or(DEFAULT_PAGE_SIZE);
+    let mut page = query_books(
+        &db,
+        filter.as_deref(),
+        search.as_deref(),
+        collection_id.as_deref(),
+        cursor.as_deref(),
+        page_size,
+    )?;
+    for book in &mut page.books {
         resolve_book_paths(book, &db);
     }
-    Ok(books)
+    Ok(page)
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct BookCounts {
+    pub all: usize,
+    pub reading: usize,
+    pub finished: usize,
+}
+
+#[tauri::command]
+pub fn get_book_counts(db: State<'_, Db>) -> AppResult<BookCounts> {
+    let conn = db.reader();
+    let all: usize = conn.query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))?;
+    let reading: usize = conn.query_row(
+        "SELECT COUNT(*) FROM books WHERE status = 'reading'", [], |r| r.get(0),
+    )?;
+    let finished: usize = conn.query_row(
+        "SELECT COUNT(*) FROM books WHERE status = 'finished'", [], |r| r.get(0),
+    )?;
+    Ok(BookCounts { all, reading, finished })
 }
 
 #[tauri::command]
@@ -1262,5 +1386,134 @@ mod tests {
 
         assert_eq!(book.format, "pdf");
         assert_eq!(book.id, "b1");
+    }
+
+    // -----------------------------------------------------------------------
+    // Pagination
+    // -----------------------------------------------------------------------
+
+    fn insert_book_with_ts(db: &Db, id: &str, status: &str, updated_at: i64) {
+        let conn = db.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO books (id, title, author, file_path, format, status, progress, created_at, updated_at)
+             VALUES (?1, ?2, 'Author', 'books/test.epub', 'epub', ?3, 0, ?4, ?4)",
+            params![id, format!("Book {id}"), status, updated_at],
+        ).unwrap();
+    }
+
+    #[test]
+    fn pagination_returns_first_page() {
+        let (_dir, db) = setup();
+        for i in 0..5 {
+            insert_book_with_ts(&db, &format!("b{i}"), "reading", 1000 + i);
+        }
+        let page = query_books(&db, None, None, None, None, 3).unwrap();
+        assert_eq!(page.books.len(), 3);
+        assert_eq!(page.total, 5);
+        assert!(page.next_cursor.is_some());
+    }
+
+    #[test]
+    fn pagination_cursor_returns_next_page() {
+        let (_dir, db) = setup();
+        for i in 0..5 {
+            insert_book_with_ts(&db, &format!("b{i}"), "reading", 1000 + i);
+        }
+        let page1 = query_books(&db, None, None, None, None, 3).unwrap();
+        let page2 = query_books(&db, None, None, None, page1.next_cursor.as_deref(), 3).unwrap();
+        assert_eq!(page2.books.len(), 2);
+        assert_eq!(page2.total, 5);
+        assert!(page2.next_cursor.is_none());
+    }
+
+    #[test]
+    fn pagination_no_more_pages() {
+        let (_dir, db) = setup();
+        for i in 0..3 {
+            insert_book_with_ts(&db, &format!("b{i}"), "reading", 1000 + i);
+        }
+        let page = query_books(&db, None, None, None, None, 5).unwrap();
+        assert_eq!(page.books.len(), 3);
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[test]
+    fn pagination_filter_by_status() {
+        let (_dir, db) = setup();
+        insert_book_with_ts(&db, "b1", "reading", 1000);
+        insert_book_with_ts(&db, "b2", "finished", 1001);
+        insert_book_with_ts(&db, "b3", "reading", 1002);
+        let page = query_books(&db, Some("reading"), None, None, None, 10).unwrap();
+        assert_eq!(page.books.len(), 2);
+        assert_eq!(page.total, 2);
+    }
+
+    #[test]
+    fn pagination_search() {
+        let (_dir, db) = setup();
+        insert_book_with_ts(&db, "b1", "reading", 1000);
+        insert_book_with_ts(&db, "b2", "reading", 1001);
+        let page = query_books(&db, None, Some("Book b1"), None, None, 10).unwrap();
+        assert_eq!(page.books.len(), 1);
+        assert_eq!(page.books[0].id, "b1");
+    }
+
+    #[test]
+    fn pagination_collection_filter() {
+        let (_dir, db) = setup();
+        insert_book_with_ts(&db, "b1", "reading", 1000);
+        insert_book_with_ts(&db, "b2", "reading", 1001);
+        insert_book_with_ts(&db, "b3", "reading", 1002);
+        let conn = db.conn.lock().unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        conn.execute(
+            "INSERT INTO collections (id, name, sort_order, created_at, updated_at, updated_by_device)
+             VALUES ('c1', 'Fiction', 0, ?1, ?1, 'dev')",
+            params![now],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO collection_books (collection_id, book_id, created_at, updated_at, updated_by_device)
+             VALUES ('c1', 'b1', ?1, ?1, 'dev')",
+            params![now],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO collection_books (collection_id, book_id, created_at, updated_at, updated_by_device)
+             VALUES ('c1', 'b3', ?1, ?1, 'dev')",
+            params![now],
+        ).unwrap();
+        drop(conn);
+        let page = query_books(&db, None, None, Some("c1"), None, 10).unwrap();
+        assert_eq!(page.books.len(), 2);
+        assert_eq!(page.total, 2);
+    }
+
+    #[test]
+    fn pagination_collection_with_cursor() {
+        let (_dir, db) = setup();
+        for i in 0..5 {
+            insert_book_with_ts(&db, &format!("b{i}"), "reading", 1000 + i);
+        }
+        let conn = db.conn.lock().unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        conn.execute(
+            "INSERT INTO collections (id, name, sort_order, created_at, updated_at, updated_by_device)
+             VALUES ('c1', 'All Five', 0, ?1, ?1, 'dev')",
+            params![now],
+        ).unwrap();
+        for i in 0..5 {
+            conn.execute(
+                "INSERT INTO collection_books (collection_id, book_id, created_at, updated_at, updated_by_device)
+                 VALUES ('c1', ?1, ?2, ?2, 'dev')",
+                params![format!("b{i}"), now],
+            ).unwrap();
+        }
+        drop(conn);
+        let page1 = query_books(&db, None, None, Some("c1"), None, 3).unwrap();
+        assert_eq!(page1.books.len(), 3);
+        assert_eq!(page1.total, 5);
+        assert!(page1.next_cursor.is_some());
+        let page2 = query_books(&db, None, None, Some("c1"), page1.next_cursor.as_deref(), 3).unwrap();
+        assert_eq!(page2.books.len(), 2);
+        assert!(page2.next_cursor.is_none());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -580,6 +580,7 @@ pub fn run() {
             commands::books::cancel_pdf_import,
             commands::books::list_books,
             commands::books::get_book,
+            commands::books::get_book_counts,
             commands::books::delete_book,
             commands::books::update_reading_progress,
             commands::books::mark_finished,

--- a/src-tauri/src/mcp/tools/library.rs
+++ b/src-tauri/src/mcp/tools/library.rs
@@ -92,12 +92,10 @@ impl QuillMcpHandler {
         &self,
         Parameters(ListBooksArgs { filter, search }): Parameters<ListBooksArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let books: Vec<McpBook> =
-            books::query_books(&self.state.db, filter.as_deref(), search.as_deref())
-                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?
-                .into_iter()
-                .map(McpBook::from)
-                .collect();
+        let page =
+            books::query_books(&self.state.db, filter.as_deref(), search.as_deref(), None, None, 1000)
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let books: Vec<McpBook> = page.books.into_iter().map(McpBook::from).collect();
         Ok(CallToolResult::success(vec![Content::json(&books)?]))
     }
 

--- a/src/components/BookGrid.tsx
+++ b/src/components/BookGrid.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
+import { Loader2 } from "lucide-react";
 import type { Book } from "../hooks/useBooks";
 import { openReaderWindow } from "../utils/openReaderWindow";
 import { deleteBook, markFinished, updateBookStatus } from "../hooks/useBooks";
@@ -29,11 +30,14 @@ function CoverImage({ src, alt, title }: { src: string; alt: string; title: stri
 
 interface BookGridProps {
   books: Book[];
+  hasMore?: boolean;
+  loadMore?: () => void;
+  loadingMore?: boolean;
   activeCollectionId?: string;
   onBooksChanged?: () => void;
 }
 
-export default function BookGrid({ books, activeCollectionId, onBooksChanged }: BookGridProps) {
+export default function BookGrid({ books, hasMore, loadMore, loadingMore, activeCollectionId, onBooksChanged }: BookGridProps) {
   const { t } = useTranslation();
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -134,6 +138,28 @@ export default function BookGrid({ books, activeCollectionId, onBooksChanged }: 
           }}
         />
       )}
+
+      {hasMore && <LoadMoreSentinel loadMore={loadMore} loadingMore={loadingMore} />}
     </>
+  );
+}
+
+function LoadMoreSentinel({ loadMore, loadingMore }: { loadMore?: () => void; loadingMore?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !loadMore) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) loadMore(); },
+      { rootMargin: "200px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  return (
+    <div ref={ref} className="flex justify-center py-4">
+      {loadingMore && <Loader2 size={20} className="text-text-muted animate-spin" />}
+    </div>
   );
 }

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { openReaderWindow } from "../utils/openReaderWindow";
-import { Check, CloudDownload } from "lucide-react";
+import { Check, CloudDownload, Loader2 } from "lucide-react";
 import type { Book } from "../hooks/useBooks";
 import { deleteBook, markFinished, updateBookStatus } from "../hooks/useBooks";
 import BookContextMenu from "./BookContextMenu";
@@ -28,11 +28,14 @@ function CoverImage({ src, alt, title }: { src: string; alt: string; title: stri
 
 interface BookListProps {
   books: Book[];
+  hasMore?: boolean;
+  loadMore?: () => void;
+  loadingMore?: boolean;
   activeCollectionId?: string;
   onBooksChanged?: () => void;
 }
 
-export default function BookList({ books, activeCollectionId, onBooksChanged }: BookListProps) {
+export default function BookList({ books, hasMore, loadMore, loadingMore, activeCollectionId, onBooksChanged }: BookListProps) {
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -169,6 +172,28 @@ export default function BookList({ books, activeCollectionId, onBooksChanged }: 
           }}
         />
       )}
+
+      {hasMore && <LoadMoreSentinel loadMore={loadMore} loadingMore={loadingMore} />}
     </>
+  );
+}
+
+function LoadMoreSentinel({ loadMore, loadingMore }: { loadMore?: () => void; loadingMore?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !loadMore) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) loadMore(); },
+      { rootMargin: "200px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  return (
+    <div ref={ref} className="flex justify-center py-4">
+      {loadingMore && <Loader2 size={20} className="text-text-muted animate-spin" />}
+    </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,13 +3,18 @@ import { useTranslation } from "react-i18next";
 import { Library, BookOpen, CheckCircle2, FolderClosed, BookA, Plus, MessageSquare, Globe, Pencil, Trash2, GripVertical, RefreshCw } from "lucide-react";
 import Button from "./ui/Button";
 import QuillLogo from "./QuillLogo";
-import type { Book } from "../hooks/useBooks";
 import type { Collection } from "../hooks/useCollections";
+
+interface BookCounts {
+  all: number;
+  reading: number;
+  finished: number;
+}
 
 interface SidebarProps {
   activeFilter: string;
   onFilterChange: (filter: string) => void;
-  books: Book[];
+  bookCounts: BookCounts;
   collections: {
     collections: Collection[];
     create: (name: string) => Promise<Collection>;
@@ -36,7 +41,7 @@ function getStoredWidth(): number {
   return SIDEBAR_DEFAULT;
 }
 
-export default function Sidebar({ activeFilter, onFilterChange, books, collections: collectionsHook, userName, onOpenSettings, syncProgress }: SidebarProps) {
+export default function Sidebar({ activeFilter, onFilterChange, bookCounts, collections: collectionsHook, userName, onOpenSettings, syncProgress }: SidebarProps) {
   const { t } = useTranslation();
   const [sidebarWidth, setSidebarWidth] = useState(getStoredWidth);
   const resizingRef = useRef(false);
@@ -104,9 +109,9 @@ export default function Sidebar({ activeFilter, onFilterChange, books, collectio
   const displayCollections = dragId ? dragOrder.map((id) => collections.find((c) => c.id === id)!).filter(Boolean) : collections;
 
   const getCount = (filterId: string) => {
-    if (filterId === "all") return books.length;
-    if (filterId === "reading") return books.filter((b) => b.status === "reading").length;
-    if (filterId === "finished") return books.filter((b) => b.status === "finished").length;
+    if (filterId === "all") return bookCounts.all;
+    if (filterId === "reading") return bookCounts.reading;
+    if (filterId === "finished") return bookCounts.finished;
     return 0;
   };
 

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -20,33 +20,76 @@ export interface Book {
   available: boolean;
 }
 
-export function useBooks(filter?: string, search?: string) {
+interface BookPage {
+  books: Book[];
+  next_cursor: string | null;
+  total: number;
+}
+
+export function useBooks(filter?: string, search?: string, collectionId?: string) {
   const [books, setBooks] = useState<Book[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      const result = await invoke<Book[]>("list_books", {
+      const page = await invoke<BookPage>("list_books", {
         filter: filter || null,
         search: search || null,
+        collectionId: collectionId || null,
+        cursor: null,
+        limit: null,
       });
-      setBooks(result.map((b) => ({
+      setBooks(page.books.map((b) => ({
         ...b,
         cover_path: b.cover_path === "none" ? null : b.cover_path,
       })));
+      setTotal(page.total);
+      setCursor(page.next_cursor);
+      setHasMore(page.next_cursor !== null);
     } catch (err) {
       console.error("Failed to load books:", err);
     } finally {
       setLoading(false);
     }
-  }, [filter, search]);
+  }, [filter, search, collectionId]);
+
+  const loadMore = useCallback(async () => {
+    if (!cursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const page = await invoke<BookPage>("list_books", {
+        filter: filter || null,
+        search: search || null,
+        collectionId: collectionId || null,
+        cursor,
+        limit: null,
+      });
+      setBooks((prev) => [
+        ...prev,
+        ...page.books.map((b) => ({
+          ...b,
+          cover_path: b.cover_path === "none" ? null : b.cover_path,
+        })),
+      ]);
+      setCursor(page.next_cursor);
+      setHasMore(page.next_cursor !== null);
+    } catch (err) {
+      console.error("Failed to load more books:", err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [cursor, filter, search, collectionId, loadingMore]);
 
   useEffect(() => {
     refresh();
   }, [refresh]);
 
-  return { books, loading, refresh };
+  return { books, total, loading, loadingMore, hasMore, loadMore, refresh };
 }
 
 async function pickFile(): Promise<string | null> {
@@ -101,8 +144,8 @@ export async function backfillMissingCovers(): Promise<void> {
   if (backfillRunning) return;
   backfillRunning = true;
   try {
-    const books = await invoke<Book[]>("list_books", { filter: null, search: null });
-    const missing = books.filter(needsCover);
+    const page = await invoke<BookPage>("list_books", { filter: null, search: null, cursor: null, limit: 1000 });
+    const missing = page.books.filter(needsCover);
     if (missing.length === 0) {
       backfillRunning = false;
       return;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -81,39 +81,31 @@ export default function Home() {
     return () => document.removeEventListener("keydown", handler);
   }, []);
 
-  // For collection filters, we need to fetch the book IDs in the collection
-  // then filter client-side
   const isCollectionFilter = activeFilter.startsWith("collection:");
   const statusFilter = !isCollectionFilter && activeFilter !== "all" ? activeFilter : undefined;
+  const collectionId = isCollectionFilter ? activeFilter.replace("collection:", "") : undefined;
   const searchParam = searchQuery || undefined;
 
-  const { books, loading, refresh } = useBooks(statusFilter, searchParam);
-  const allBooks = useBooks();
+  const { books, loading, hasMore, loadMore, loadingMore, refresh } = useBooks(statusFilter, searchParam, collectionId);
 
-  // Collection-filtered books
-  const [collectionBookIds, setCollectionBookIds] = useState<string[]>([]);
-  const refreshCollectionBooks = useCallback(() => {
-    if (!isCollectionFilter) return;
-    const collectionId = activeFilter.replace("collection:", "");
-    invoke<string[]>("list_books_in_collection", { collectionId })
-      .then(setCollectionBookIds)
-      .catch(() => setCollectionBookIds([]));
-  }, [activeFilter, isCollectionFilter]);
-
-  useEffect(() => {
-    if (!isCollectionFilter) {
-      setCollectionBookIds([]);
-      return;
+  // Book counts for sidebar badges — lightweight, no book data loaded.
+  const [bookCounts, setBookCounts] = useState({ all: 0, reading: 0, finished: 0 });
+  const refreshCounts = useCallback(async () => {
+    try {
+      const counts = await invoke<{ all: number; reading: number; finished: number }>("get_book_counts");
+      setBookCounts(counts);
+    } catch (err) {
+      console.error("Failed to load book counts:", err);
     }
-    refreshCollectionBooks();
-  }, [activeFilter, isCollectionFilter, refreshCollectionBooks]);
+  }, []);
+  useEffect(() => { refreshCounts(); }, [refreshCounts]);
 
   // Keep stable refs for refresh functions so the drag-drop effect doesn't re-register
   const refreshRef = useRef(refresh);
-  const allBooksRefreshRef = useRef(allBooks.refresh);
+  const countsRefreshRef = useRef(refreshCounts);
   const collectionsRefreshRef = useRef(collections.refresh);
   useEffect(() => { refreshRef.current = refresh; }, [refresh]);
-  useEffect(() => { allBooksRefreshRef.current = allBooks.refresh; }, [allBooks.refresh]);
+  useEffect(() => { countsRefreshRef.current = refreshCounts; }, [refreshCounts]);
   useEffect(() => { collectionsRefreshRef.current = collections.refresh; }, [collections.refresh]);
 
   // Auto-dismiss import error after 10s
@@ -140,7 +132,7 @@ export default function Home() {
     const unlistenTick = listen("sync-initial-tick-done", () => {
       setSyncProgress(null);
       refreshRef.current();
-      allBooksRefreshRef.current();
+      countsRefreshRef.current();
       collectionsRefreshRef.current();
     });
     const unlistenProgress = listen<{ applied: number; total: number }>("sync-progress", (e) => {
@@ -162,17 +154,17 @@ export default function Home() {
       if (mcpDebounce) clearTimeout(mcpDebounce);
       mcpDebounce = setTimeout(async () => {
         refreshRef.current();
-        allBooksRefreshRef.current();
+        countsRefreshRef.current();
         collectionsRefreshRef.current();
         await backfillMissingCovers();
         refreshRef.current();
-        allBooksRefreshRef.current();
+        countsRefreshRef.current();
       }, 500);
     });
     const unlistenCollections = listen("mcp:collections-changed", () => {
       collectionsRefreshRef.current();
       refreshRef.current();
-      allBooksRefreshRef.current();
+      countsRefreshRef.current();
     });
     return () => {
       if (mcpDebounce) clearTimeout(mcpDebounce);
@@ -205,7 +197,7 @@ export default function Home() {
               }
             }
             refreshRef.current();
-            allBooksRefreshRef.current();
+            countsRefreshRef.current();
           } finally {
             setImporting(false);
           }
@@ -236,7 +228,7 @@ export default function Home() {
           }
         }
         refreshRef.current();
-        allBooksRefreshRef.current();
+        countsRefreshRef.current();
       } finally {
         setImporting(false);
       }
@@ -244,9 +236,7 @@ export default function Home() {
     return () => { unlisten.then((fn) => fn()); };
   }, []);
 
-  const displayBooks = isCollectionFilter
-    ? allBooks.books.filter((b) => collectionBookIds.includes(b.id))
-    : books;
+  const displayBooks = books;
 
   const handleImport = async () => {
     let selected: string | null = null;
@@ -258,7 +248,7 @@ export default function Home() {
         const book = await importBookDialog.importFile(selected);
         if (book) {
           refresh();
-          allBooks.refresh();
+          refreshCounts();
         }
       } finally {
         setImporting(false);
@@ -286,7 +276,7 @@ export default function Home() {
       <Sidebar
         activeFilter={activeFilter}
         onFilterChange={setActiveFilter}
-        books={allBooks.books}
+        bookCounts={bookCounts}
         collections={collections}
         userName={userName}
         onOpenSettings={() => setSettingsOpen(true)}
@@ -358,9 +348,9 @@ export default function Home() {
                 )}
               </div>
             ) : viewMode === "grid" ? (
-              <BookGrid books={displayBooks} activeCollectionId={isCollectionFilter ? activeFilter.replace("collection:", "") : undefined} onBooksChanged={() => { refresh(); allBooks.refresh(); collections.refresh(); refreshCollectionBooks(); }} />
+              <BookGrid books={displayBooks} hasMore={hasMore} loadMore={loadMore} loadingMore={loadingMore} activeCollectionId={isCollectionFilter ? activeFilter.replace("collection:", "") : undefined} onBooksChanged={() => { refresh(); refreshCounts(); collections.refresh();}} />
             ) : (
-              <BookList books={displayBooks} activeCollectionId={isCollectionFilter ? activeFilter.replace("collection:", "") : undefined} onBooksChanged={() => { refresh(); allBooks.refresh(); collections.refresh(); refreshCollectionBooks(); }} />
+              <BookList books={displayBooks} hasMore={hasMore} loadMore={loadMore} loadingMore={loadingMore} activeCollectionId={isCollectionFilter ? activeFilter.replace("collection:", "") : undefined} onBooksChanged={() => { refresh(); refreshCounts(); collections.refresh();}} />
             )}
           </div>
 


### PR DESCRIPTION
## Summary

Replaces the all-at-once `list_books` with cursor-based pagination (20 books per page). Fixes the app hang on freshly synced devices where 329 cover images overwhelmed the webview.

- **`list_books`** accepts `cursor`/`limit` params, returns `BookPage { books, next_cursor, total }`
- **`get_book_counts`** returns `{ all, reading, finished }` for sidebar badges — no book data loaded
- **Sidebar** uses `get_book_counts` instead of loading all books
- **BookGrid/BookList** have IntersectionObserver sentinels for infinite scroll
- **Removed `allBooks = useBooks()`** — no more full library load

See `docs/impls/248-backend-pagination.md` for the full plan.

## Test plan

- [x] 224 unit + 2 integration tests pass
- [x] `pnpm run lint` — 0 errors
- [x] Smoke test — grid loads first 20 books, scroll loads more
- [ ] Test on other Mac with 329 books — app should render immediately
- [ ] Collection filtering (TODO — needs `collection_id` param in `list_books`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)