### PR TITLE
feat: store covers as BLOBs in SQLite

### DIFF
--- a/docs/impls/251-cover-sync-via-files.md
+++ b/docs/impls/251-cover-sync-via-files.md
@@ -1,0 +1,157 @@
+# 251 — Cover Sync via iCloud Files
+
+Issue: https://github.com/yicheng47/quill/issues/250
+PR: https://github.com/yicheng47/quill/pull/251
+
+## Problem
+
+Covers stored as BLOBs in SQLite don't propagate to peers through the event log (too large per-event). They only travel via snapshot compaction, which is threshold-gated (2MB / 5000 events / 30 days). A newly imported book's cover may take days to reach a synced peer.
+
+## Solution
+
+Dual-storage: covers live as files in the iCloud `covers/` directory for sync transport, and as BLOBs in local SQLite for fast rendering. iCloud replicates the file natively; the replay tick picks up new peer cover files and writes them into the local DB.
+
+```
+Import → write covers/<id>.ext to shared_dir + cover_data BLOB locally
+                    │
+                    ▼
+         iCloud replicates file to peer
+                    │
+                    ▼
+Peer replay tick → scan covers/ for new files → read bytes → store in local cover_data BLOB
+                    │
+                    ▼
+         Frontend renders from cover_data (never from file)
+```
+
+The frontend always renders from `cover_data` BLOB — no file I/O in the hot path. The `covers/` directory is a sync transport only.
+
+## Directory Layout
+
+```
+<shared_dir>/            # ubiquity_dir (iCloud Documents)
+  logs/                  # event logs + snapshots (existing)
+  devices/               # peer manifests (existing)
+  books/                 # book files (existing)
+  covers/                # cover image files (NEW sync transport)
+    <book_id>.img        # raw image bytes, .img extension (format-agnostic)
+```
+
+Use `.img` as a generic extension — the actual format (PNG/JPEG/etc.) is sniffed from magic bytes when encoding to data URI. This avoids needing to track MIME separately.
+
+## Backend Changes
+
+### 1. Cover file write on import/save
+
+**Files:** `src-tauri/src/commands/books.rs`
+
+When cover bytes are available (EPUB import, PDF commit, PDF backfill), write them to `<data_dir>/covers/<book_id>.img` in addition to storing in `cover_data` BLOB. **Only when sync is enabled** — local-only users don't need the file copy. The file write is best-effort — if it fails (disk full), the local BLOB still works.
+
+A dedicated `cover-writer` thread processes file writes off the import path. Avoids spawning a thread per import and keeps iCloud I/O off the main thread.
+
+**SyncWriter gets a channel sender:**
+
+```rust
+// In SyncWriter
+cover_tx: Mutex<Option<mpsc::Sender<(PathBuf, Vec<u8>)>>>,
+```
+
+**Thread created once during `boot_sync_engine`:**
+
+```rust
+let (tx, rx) = mpsc::channel::<(PathBuf, Vec<u8>)>();
+std::thread::Builder::new()
+    .name("cover-writer".into())
+    .spawn(move || {
+        for (path, bytes) in rx {
+            let _ = fs::create_dir_all(path.parent().unwrap());
+            let _ = fs::write(&path, &bytes);
+        }
+    });
+sync_writer.set_cover_tx(Some(tx));
+```
+
+**Helper on SyncWriter:**
+
+```rust
+impl SyncWriter {
+    pub fn queue_cover_write(&self, db: &Db, book_id: &str, bytes: &[u8]) {
+        if !self.should_queue() { return; }
+        let Ok(data_dir) = db.data_dir.lock() else { return };
+        let path = data_dir.join("covers").join(format!("{book_id}.img"));
+        if let Some(tx) = self.cover_tx.lock().ok().and_then(|g| g.clone()) {
+            let _ = tx.send((path, bytes.to_vec()));
+        }
+    }
+}
+```
+
+Call sites just call `sync.queue_cover_write(db, &book_id, bytes)`:
+- `do_insert_book` — after INSERT, if `cover_bytes.is_some()`
+- `save_book_cover` — after UPDATE
+- `commit_pdf_import` — after INSERT, if `cover_data.is_some()`
+
+When sync is disabled, `cover_tx` is `None` — writes silently skipped. When sync is enabled, writes queue into the channel and the `cover-writer` thread drains them sequentially. The channel is unbounded (`mpsc::channel`) so the sender never blocks.
+
+### 2. Ingest peer cover files during replay tick
+
+**File:** `src-tauri/src/sync/replay.rs`
+
+Add a new phase between the existing outbox flush and peer discovery (or after peer apply):
+
+```rust
+fn ingest_peer_covers(shared_dir: &Path, db: &Db) {
+    let covers_dir = shared_dir.join("covers");
+    // list all .img files
+    // for each: parse book_id from filename
+    // check if local cover_data IS NULL for that book_id
+    // if so: read file bytes, UPDATE books SET cover_data = ? WHERE id = ?
+}
+```
+
+This runs on every tick. It's cheap: one `read_dir` + one SELECT per new file. Files already ingested are skipped (`cover_data IS NOT NULL`). No timeout needed — cover files are small (50-500KB).
+
+### 3. Snapshot changes
+
+**File:** `src-tauri/src/sync/snapshot.rs`
+
+Remove the cover_data overlay from `compact_own_log` — it's no longer needed since covers propagate via files. The snapshot still includes `cover_data` in `BookRow` for the initial bootstrap case (peer has no cover files yet but gets a full snapshot).
+
+`upsert_book` keeps `COALESCE(excluded.cover_data, books.cover_data)` — still correct.
+
+### 4. Delete cover file on book delete
+
+**File:** `src-tauri/src/commands/books.rs`
+
+In `do_delete_book`, after removing the book file, also remove the cover file:
+
+```rust
+let cover_file = db.resolve_path(&format!("covers/{id}.img"));
+let _ = fs::remove_file(&cover_file);
+```
+
+### 5. Restore `covers/` directory creation
+
+**File:** `src-tauri/src/db.rs`
+
+Re-add `fs::create_dir_all(data_dir.join("covers"))` in `init_split` since covers are files again (for sync transport).
+
+## Frontend Changes
+
+None. The frontend already renders from `cover_data` BLOB via data URI. The file layer is invisible to it.
+
+## Migration
+
+No schema changes. The `cover_data` BLOB column (migration 013) stays. The background backfill from the previous commit handles upgrading users — it reads legacy `covers/<id>.png` files into the DB.
+
+For the new `.img` files: they're written going forward on new imports. Existing covers in the DB don't need corresponding `.img` files unless a peer needs them — the snapshot carries `cover_data` for the bootstrap case.
+
+## Verification
+
+1. Import an EPUB with cover → `cover_data` BLOB set + `covers/<id>.img` written to data_dir
+2. MCP imports a PDF → `backfillMissingCovers` fires → `save_book_cover` dual-writes BLOB + file
+3. Sync enabled, two devices: import on A → cover file replicates via iCloud → B's next tick picks it up → B has cover in DB
+4. Delete book → cover file removed
+5. Fresh peer with snapshot only (no cover files yet) → gets cover via snapshot `cover_data`
+6. `cargo test` passes
+7. MCP `list_books` still uses lightweight query (no cover BLOB loading)

--- a/src-tauri/migrations/013_covers_in_db.sql
+++ b/src-tauri/migrations/013_covers_in_db.sql
@@ -1,0 +1,1 @@
+ALTER TABLE books ADD COLUMN cover_data BLOB;

--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -13,6 +13,22 @@ use crate::icloud;
 use crate::sync::events::{BookImportPayload, EventBody};
 use crate::sync::writer::SyncWriter;
 
+fn cover_blob_to_data_uri(bytes: &[u8]) -> String {
+    let mime = if bytes.starts_with(b"\x89PNG") {
+        "image/png"
+    } else if bytes.starts_with(b"\xFF\xD8\xFF") {
+        "image/jpeg"
+    } else if bytes.starts_with(b"GIF8") {
+        "image/gif"
+    } else if bytes.len() > 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        "image/webp"
+    } else {
+        "image/png"
+    };
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("data:{mime};base64,{b64}")
+}
+
 fn pdf_obj_to_string(obj: &lopdf::Object) -> Option<String> {
     let bytes = obj.as_str().ok().or_else(|| obj.as_name().ok())?;
     let s = String::from_utf8_lossy(bytes).to_string();
@@ -181,7 +197,7 @@ pub(crate) fn do_import_epub(
     let now = chrono::Utc::now().timestamp_millis();
     let rel_file_path = format!("books/{}", filename);
     let cover_data_b64 = metadata.cover_data.as_deref().map(|b| {
-        base64::engine::general_purpose::STANDARD.encode(b)
+        cover_blob_to_data_uri(b)
     });
 
     let book = Book {
@@ -471,7 +487,7 @@ pub(crate) fn query_books(
             created_at: row.get(12)?,
             updated_at: row.get(13)?,
             available: true,
-            cover_data: cover_blob.map(|b| base64::engine::general_purpose::STANDARD.encode(&b)),
+            cover_data: cover_blob.filter(|b| !b.is_empty()).map(|b| cover_blob_to_data_uri(&b)),
         })
     })?
     .collect::<Result<Vec<_>, _>>()?;
@@ -512,7 +528,7 @@ pub(crate) fn query_book(db: &Db, id: &str) -> AppResult<Book> {
                 created_at: row.get(12)?,
                 updated_at: row.get(13)?,
                 available: true,
-                cover_data: cover_blob.map(|b| base64::engine::general_purpose::STANDARD.encode(&b)),
+                cover_data: cover_blob.filter(|b| !b.is_empty()).map(|b| cover_blob_to_data_uri(&b)),
             })
         },
     )?;
@@ -617,19 +633,48 @@ pub fn mark_cover_unavailable(
 ) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     conn.execute(
-        "UPDATE books SET cover_path = 'none' WHERE id = ?1 AND cover_path IS NULL",
+        "UPDATE books SET cover_data = X'' WHERE id = ?1 AND cover_data IS NULL",
         params![book_id],
     )?;
     Ok(())
 }
 
+#[derive(Debug, Serialize)]
+pub struct CoverBackfillEntry {
+    pub id: String,
+    pub file_path: String,
+}
+
+#[tauri::command]
+pub fn list_books_needing_covers(db: State<'_, Db>) -> AppResult<Vec<CoverBackfillEntry>> {
+    let conn = db.reader();
+    let mut stmt = conn.prepare(
+        "SELECT id, file_path FROM books WHERE format = 'pdf' AND cover_data IS NULL",
+    )?;
+    let entries: Vec<CoverBackfillEntry> = stmt
+        .query_map([], |row| {
+            Ok(CoverBackfillEntry {
+                id: row.get(0)?,
+                file_path: row.get(1)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(entries
+        .into_iter()
+        .map(|mut e| {
+            e.file_path = db.resolve_path(&e.file_path).to_string_lossy().to_string();
+            e
+        })
+        .collect())
+}
+
 pub(crate) fn do_delete_book(id: &str, db: &Db, sync: &SyncWriter) -> AppResult<()> {
-    let (file_path, cover_path): (String, Option<String>) = {
+    let file_path: String = {
         let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
         conn.query_row(
-            "SELECT file_path, cover_path FROM books WHERE id = ?1",
+            "SELECT file_path FROM books WHERE id = ?1",
             params![id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| row.get(0),
         )?
     };
 
@@ -655,12 +700,6 @@ pub(crate) fn do_delete_book(id: &str, db: &Db, sync: &SyncWriter) -> AppResult<
 
     let abs_file = db.resolve_path(&file_path);
     let _ = fs::remove_file(&abs_file);
-    if let Some(cover) = cover_path {
-        if cover != "none" {
-            let abs_cover = db.resolve_path(&cover);
-            let _ = fs::remove_file(&abs_cover);
-        }
-    }
 
     Ok(())
 }
@@ -925,7 +964,7 @@ pub async fn commit_pdf_import(
     let now = chrono::Utc::now().timestamp_millis();
     let rel_file_path = format!("books/{}", filename);
     let cover_data_b64 = cover_data.as_ref().map(|d| {
-        base64::engine::general_purpose::STANDARD.encode(d)
+        cover_blob_to_data_uri(d)
     });
 
     let book = Book {

--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -535,6 +535,80 @@ pub(crate) fn query_book(db: &Db, id: &str) -> AppResult<Book> {
     Ok(book)
 }
 
+/// Lightweight book query for MCP — computes `has_cover` from the BLOB
+/// without actually loading/encoding cover bytes. Prevents hundreds of
+/// MB of wasted DB reads + base64 allocations when MCP lists 1000 books.
+pub(crate) fn query_books_lite(
+    db: &Db,
+    filter: Option<&str>,
+    search: Option<&str>,
+    limit: usize,
+) -> AppResult<Vec<Book>> {
+    let conn = db.reader();
+    let mut conditions: Vec<String> = Vec::new();
+    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+    if let Some(f) = filter {
+        match f {
+            "reading" | "finished" | "unread" => {
+                conditions.push("status = ?".to_string());
+                param_values.push(Box::new(f.to_string()));
+            }
+            "all" => {}
+            genre => {
+                conditions.push("genre = ?".to_string());
+                param_values.push(Box::new(genre.to_string()));
+            }
+        }
+    }
+    if let Some(q) = search {
+        if !q.is_empty() {
+            conditions.push("(LOWER(title) LIKE ? OR LOWER(author) LIKE ?)".to_string());
+            let pattern = format!("%{}%", q.to_lowercase());
+            param_values.push(Box::new(pattern.clone()));
+            param_values.push(Box::new(pattern));
+        }
+    }
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!(" WHERE {}", conditions.join(" AND "))
+    };
+
+    let sql = format!(
+        "SELECT id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at, (cover_data IS NOT NULL AND LENGTH(cover_data) > 0) AS has_cover FROM books{where_clause} ORDER BY updated_at DESC LIMIT ?",
+    );
+    param_values.push(Box::new(limit as i64));
+    let params_refs: Vec<&dyn rusqlite::types::ToSql> = param_values.iter().map(|p| p.as_ref()).collect();
+
+    let mut stmt = conn.prepare(&sql)?;
+    let books = stmt
+        .query_map(params_refs.as_slice(), |row| {
+            let has_cover: bool = row.get(14)?;
+            Ok(Book {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                author: row.get(2)?,
+                description: row.get(3)?,
+                cover_path: row.get(4)?,
+                file_path: row.get(5)?,
+                format: row.get(6)?,
+                genre: row.get(7)?,
+                pages: row.get(8)?,
+                status: row.get(9)?,
+                progress: row.get(10)?,
+                current_cfi: row.get(11)?,
+                created_at: row.get(12)?,
+                updated_at: row.get(13)?,
+                available: true,
+                cover_data: if has_cover { Some("has_cover".to_string()) } else { None },
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(books)
+}
+
 const DEFAULT_PAGE_SIZE: usize = 20;
 
 #[tauri::command]
@@ -613,17 +687,13 @@ pub fn save_book_cover(
     book_id: String,
     cover_data: Vec<u8>,
     db: State<'_, Db>,
-    sync: State<'_, SyncWriter>,
 ) -> AppResult<()> {
-    let now = chrono::Utc::now().timestamp_millis();
-    let device = sync.self_device().to_string();
-    sync.with_tx(&db, now, |tx, _events| {
-        tx.execute(
-            "UPDATE books SET cover_data = ?1, updated_at = ?2, updated_by_device = ?3 WHERE id = ?4",
-            params![cover_data, now, device, book_id],
-        )?;
-        Ok(())
-    })
+    let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
+    conn.execute(
+        "UPDATE books SET cover_data = ?1 WHERE id = ?2",
+        params![cover_data, book_id],
+    )?;
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -1244,31 +1244,26 @@ mod tests {
 
     #[test]
     fn test_import_pdf_with_cover() {
-        let (dir, db) = setup();
+        let (_dir, db) = setup();
         let book_id = "cover-test";
-        let cover_data = b"fake png data";
-
-        let cover_file = dir.path().join("covers").join(format!("{}.png", book_id));
-        fs::write(&cover_file, cover_data).unwrap();
+        let cover_bytes = b"\x89PNG fake png data";
 
         let conn = db.conn.lock().unwrap();
         let now = chrono::Utc::now().timestamp_millis();
-        let cover_path = format!("covers/{}.png", book_id);
 
         conn.execute(
-            "INSERT INTO books (id, title, author, file_path, format, cover_path, status, progress, created_at, updated_at)
+            "INSERT INTO books (id, title, author, file_path, format, cover_data, status, progress, created_at, updated_at)
              VALUES (?1, 'PDF With Cover', 'Author', 'books/test.pdf', 'pdf', ?2, 'unread', 0, ?3, ?3)",
-            params![book_id, cover_path, now],
+            params![book_id, cover_bytes.as_slice(), now],
         ).unwrap();
 
-        let db_cover: Option<String> = conn.query_row(
-            "SELECT cover_path FROM books WHERE id = ?1",
+        let db_cover: Option<Vec<u8>> = conn.query_row(
+            "SELECT cover_data FROM books WHERE id = ?1",
             params![book_id],
             |r| r.get(0),
         ).unwrap();
 
-        assert_eq!(db_cover, Some(cover_path));
-        assert!(cover_file.exists());
+        assert_eq!(db_cover.as_deref(), Some(cover_bytes.as_slice()));
     }
 
     #[test]
@@ -1337,50 +1332,37 @@ mod tests {
     fn test_import_pdf_with_all_metadata() {
         let (dir, db) = setup();
 
-        // Create source PDF
         let src = dir.path().join("academic-paper.pdf");
         fs::write(&src, b"%PDF-1.7 fake").unwrap();
 
         let book_id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now().timestamp_millis();
         let rel_path = format!("books/{}.pdf", book_id);
-        let cover_rel = format!("covers/{}.png", book_id);
+        let cover_bytes = b"\x89PNG fake cover";
 
-        // Copy file
         let dest = dir.path().join("books").join(format!("{}.pdf", book_id));
         fs::copy(&src, &dest).unwrap();
 
-        // Write cover
-        let cover_file = dir.path().join("covers").join(format!("{}.png", book_id));
-        fs::write(&cover_file, b"PNG fake").unwrap();
-
         let conn = db.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO books (id, title, author, description, cover_path, file_path, format, pages, status, progress, created_at, updated_at)
-             VALUES (?1, 'Deep Learning', 'Ian Goodfellow, Yoshua Bengio', 'A comprehensive textbook', ?2, ?3, 'pdf', 800, 'unread', 0, ?4, ?4)",
-            params![book_id, cover_rel, rel_path, now],
+            "INSERT INTO books (id, title, author, description, file_path, format, pages, status, progress, created_at, updated_at, cover_data)
+             VALUES (?1, 'Deep Learning', 'Ian Goodfellow, Yoshua Bengio', 'A comprehensive textbook', ?2, 'pdf', 800, 'unread', 0, ?3, ?3, ?4)",
+            params![book_id, rel_path, now, cover_bytes.as_slice()],
         ).unwrap();
 
-        let book: Book = conn.query_row(
-            "SELECT id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at FROM books WHERE id = ?1",
+        let (title, author, desc, format, pages, has_cover): (String, String, Option<String>, String, Option<i32>, bool) = conn.query_row(
+            "SELECT title, author, description, format, pages, (cover_data IS NOT NULL) FROM books WHERE id = ?1",
             params![book_id],
-            |row| Ok(Book {
-                id: row.get(0)?, title: row.get(1)?, author: row.get(2)?,
-                description: row.get(3)?, cover_path: row.get(4)?, file_path: row.get(5)?,
-                format: row.get(6)?, genre: row.get(7)?, pages: row.get(8)?,
-                status: row.get(9)?, progress: row.get(10)?, current_cfi: row.get(11)?,
-                created_at: row.get(12)?, updated_at: row.get(13)?, available: true, cover_data: None,
-            }),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?)),
         ).unwrap();
 
-        assert_eq!(book.title, "Deep Learning");
-        assert_eq!(book.author, "Ian Goodfellow, Yoshua Bengio");
-        assert_eq!(book.description, Some("A comprehensive textbook".to_string()));
-        assert_eq!(book.format, "pdf");
-        assert_eq!(book.pages, Some(800));
-        assert!(book.cover_path.is_some());
+        assert_eq!(title, "Deep Learning");
+        assert_eq!(author, "Ian Goodfellow, Yoshua Bengio");
+        assert_eq!(desc, Some("A comprehensive textbook".to_string()));
+        assert_eq!(format, "pdf");
+        assert_eq!(pages, Some(800));
+        assert!(has_cover);
         assert!(dest.exists());
-        assert!(cover_file.exists());
     }
 
     #[test]

--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -312,7 +312,11 @@ fn do_insert_book(book: &Book, cover_bytes: Option<&[u8]>, db: &Db, sync: &SyncW
             pages: book.pages,
         }));
         Ok(())
-    })
+    })?;
+    if let Some(bytes) = cover_bytes {
+        sync.queue_cover_write(db, &book.id, bytes);
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -687,12 +691,15 @@ pub fn save_book_cover(
     book_id: String,
     cover_data: Vec<u8>,
     db: State<'_, Db>,
+    sync: State<'_, SyncWriter>,
 ) -> AppResult<()> {
     let conn = db.conn.lock().map_err(|e| AppError::Other(e.to_string()))?;
     conn.execute(
         "UPDATE books SET cover_data = ?1 WHERE id = ?2",
         params![cover_data, book_id],
     )?;
+    drop(conn);
+    sync.queue_cover_write(&db, &book_id, &cover_data);
     Ok(())
 }
 
@@ -770,6 +777,8 @@ pub(crate) fn do_delete_book(id: &str, db: &Db, sync: &SyncWriter) -> AppResult<
 
     let abs_file = db.resolve_path(&file_path);
     let _ = fs::remove_file(&abs_file);
+    let cover_file = db.resolve_path(&format!("covers/{id}.img"));
+    let _ = fs::remove_file(&cover_file);
 
     Ok(())
 }
@@ -1093,6 +1102,10 @@ pub async fn commit_pdf_import(
         }));
         Ok(())
     })?;
+
+    if let Some(ref bytes) = cover_data {
+        sync.queue_cover_write(&db, &book.id, bytes);
+    }
 
     log::info!("import_book: complete id={} title={:?} format=pdf", book.id, book.title);
 

--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use base64::Engine;
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
 use tauri::State;
@@ -123,6 +124,9 @@ pub struct Book {
     /// Whether the book file is locally available (not an iCloud placeholder).
     #[serde(default = "default_true")]
     pub available: bool,
+    /// Base64-encoded cover image bytes. Rendered as data URI on the frontend.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cover_data: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -161,12 +165,11 @@ pub(crate) fn do_import_epub(
         .map_err(|e| AppError::Other(e.to_string()))?
         .clone();
     let books_dir = data_dir.join("books");
-    let covers_dir = data_dir.join("covers");
 
     let book_id = uuid::Uuid::new_v4().to_string();
     let src = std::path::Path::new(file_path);
 
-    let metadata = epub::extract_metadata(src, &covers_dir, &book_id)
+    let metadata = epub::extract_metadata(src)
         .inspect_err(|e| log::error!("import_book: extract_metadata failed for {file_path}: {e}"))?;
     let pages = epub::count_chapters(src)
         .inspect_err(|e| log::error!("import_book: count_chapters failed for {file_path}: {e}"))? as i32;
@@ -177,13 +180,16 @@ pub(crate) fn do_import_epub(
 
     let now = chrono::Utc::now().timestamp_millis();
     let rel_file_path = format!("books/{}", filename);
+    let cover_data_b64 = metadata.cover_data.as_deref().map(|b| {
+        base64::engine::general_purpose::STANDARD.encode(b)
+    });
 
     let book = Book {
         id: book_id,
         title: metadata.title,
         author: metadata.author,
         description: metadata.description,
-        cover_path: metadata.cover_path,
+        cover_path: None,
         file_path: rel_file_path,
         format: "epub".to_string(),
         genre: None,
@@ -194,9 +200,10 @@ pub(crate) fn do_import_epub(
         created_at: now,
         updated_at: now,
         available: true,
+        cover_data: cover_data_b64,
     };
 
-    do_insert_book(&book, db, sync, now)?;
+    do_insert_book(&book, metadata.cover_data.as_deref(), db, sync, now)?;
 
     log::info!("import_book: complete id={} title={:?}", book.id, book.title);
     Ok(book)
@@ -243,20 +250,21 @@ pub(crate) fn do_import_pdf(
         created_at: now,
         updated_at: now,
         available: true,
+        cover_data: None,
     };
 
-    do_insert_book(&book, db, sync, now)?;
+    do_insert_book(&book, None, db, sync, now)?;
 
     log::info!("import_book: complete id={} title={:?} format=pdf", book.id, book.title);
     Ok(book)
 }
 
-fn do_insert_book(book: &Book, db: &Db, sync: &SyncWriter, now: i64) -> AppResult<()> {
+fn do_insert_book(book: &Book, cover_bytes: Option<&[u8]>, db: &Db, sync: &SyncWriter, now: i64) -> AppResult<()> {
     let device = sync.self_device().to_string();
     sync.with_tx(db, now, |tx, events| {
         tx.execute(
-            "INSERT INTO books (id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at, updated_by_device)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+            "INSERT INTO books (id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at, updated_by_device, cover_data)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
             params![
                 book.id,
                 book.title,
@@ -273,6 +281,7 @@ fn do_insert_book(book: &Book, db: &Db, sync: &SyncWriter, now: i64) -> AppResul
                 book.created_at,
                 book.updated_at,
                 device,
+                cover_bytes,
             ],
         )?;
         events.push(EventBody::BookImport(BookImportPayload {
@@ -437,7 +446,7 @@ pub(crate) fn query_books(
 
     // Main query with cursor + limit.
     let sql = format!(
-        "SELECT books.id, books.title, books.author, books.description, books.cover_path, books.file_path, books.format, books.genre, books.pages, books.status, books.progress, books.current_cfi, books.created_at, books.updated_at FROM {from_clause}{where_clause} ORDER BY books.updated_at DESC, books.id ASC LIMIT ?",
+        "SELECT books.id, books.title, books.author, books.description, books.cover_path, books.file_path, books.format, books.genre, books.pages, books.status, books.progress, books.current_cfi, books.created_at, books.updated_at, books.cover_data FROM {from_clause}{where_clause} ORDER BY books.updated_at DESC, books.id ASC LIMIT ?",
     );
     param_values.push(Box::new((limit + 1) as i64));
 
@@ -445,6 +454,7 @@ pub(crate) fn query_books(
 
     let mut stmt = conn.prepare(&sql)?;
     let mut books: Vec<Book> = stmt.query_map(params_refs.as_slice(), |row| {
+        let cover_blob: Option<Vec<u8>> = row.get(14)?;
         Ok(Book {
             id: row.get(0)?,
             title: row.get(1)?,
@@ -461,6 +471,7 @@ pub(crate) fn query_books(
             created_at: row.get(12)?,
             updated_at: row.get(13)?,
             available: true,
+            cover_data: cover_blob.map(|b| base64::engine::general_purpose::STANDARD.encode(&b)),
         })
     })?
     .collect::<Result<Vec<_>, _>>()?;
@@ -481,9 +492,10 @@ pub(crate) fn query_books(
 pub(crate) fn query_book(db: &Db, id: &str) -> AppResult<Book> {
     let conn = db.reader();
     let book = conn.query_row(
-        "SELECT id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at FROM books WHERE id = ?1",
+        "SELECT id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at, cover_data FROM books WHERE id = ?1",
         params![id],
         |row| {
+            let cover_blob: Option<Vec<u8>> = row.get(14)?;
             Ok(Book {
                 id: row.get(0)?,
                 title: row.get(1)?,
@@ -500,6 +512,7 @@ pub(crate) fn query_book(db: &Db, id: &str) -> AppResult<Book> {
                 created_at: row.get(12)?,
                 updated_at: row.get(13)?,
                 available: true,
+                cover_data: cover_blob.map(|b| base64::engine::general_purpose::STANDARD.encode(&b)),
             })
         },
     )?;
@@ -563,10 +576,10 @@ pub fn get_book(id: String, db: State<'_, Db>) -> AppResult<Book> {
 #[tauri::command]
 pub fn check_book_available(id: String, db: State<'_, Db>) -> AppResult<bool> {
     let conn = db.reader();
-    let (file_path, cover_path): (String, Option<String>) = conn.query_row(
-        "SELECT file_path, cover_path FROM books WHERE id = ?1",
+    let file_path: String = conn.query_row(
+        "SELECT file_path FROM books WHERE id = ?1",
         params![id],
-        |row| Ok((row.get(0)?, row.get(1)?)),
+        |row| row.get(0),
     )?;
 
     let abs_path = db.resolve_path(&file_path);
@@ -574,12 +587,6 @@ pub fn check_book_available(id: String, db: State<'_, Db>) -> AppResult<bool> {
 
     if !available {
         icloud::trigger_download_file(&abs_path);
-    }
-    if let Some(cover) = cover_path {
-        let cover_abs = db.resolve_path(&cover);
-        if !icloud::is_file_downloaded(&cover_abs) {
-            icloud::trigger_download_file(&cover_abs);
-        }
     }
 
     Ok(available)
@@ -592,30 +599,13 @@ pub fn save_book_cover(
     db: State<'_, Db>,
     sync: State<'_, SyncWriter>,
 ) -> AppResult<()> {
-    let data_dir = db
-        .data_dir
-        .lock()
-        .map_err(|e| AppError::Other(e.to_string()))?
-        .clone();
-    let covers_dir = data_dir.join("covers");
-    fs::create_dir_all(&covers_dir)?;
-
-    let cover_file = covers_dir.join(format!("{book_id}.png"));
-    fs::write(&cover_file, &cover_data)?;
-
-    let rel_cover = format!("covers/{book_id}.png");
     let now = chrono::Utc::now().timestamp_millis();
     let device = sync.self_device().to_string();
-    sync.with_tx(&db, now, |tx, events| {
+    sync.with_tx(&db, now, |tx, _events| {
         tx.execute(
-            "UPDATE books SET cover_path = ?1, updated_at = ?2, updated_by_device = ?3 WHERE id = ?4",
-            params![rel_cover, now, device, book_id],
+            "UPDATE books SET cover_data = ?1, updated_at = ?2, updated_by_device = ?3 WHERE id = ?4",
+            params![cover_data, now, device, book_id],
         )?;
-        events.push(EventBody::BookMetadataSet {
-            book: book_id.clone(),
-            field: "cover_path".into(),
-            value: serde_json::Value::String(rel_cover.clone()),
-        });
         Ok(())
     })
 }
@@ -916,7 +906,6 @@ pub async fn commit_pdf_import(
         .map_err(|e| AppError::Other(e.to_string()))?
         .clone();
     let books_dir = data_dir.join("books");
-    let covers_dir = data_dir.join("covers");
 
     let staged = books_dir.join(format!("{}.pdf", book_id));
     if !staged.exists() {
@@ -933,25 +922,18 @@ pub async fn commit_pdf_import(
         fs::rename(&staged, &dest)?;
     }
 
-    // Save cover image if provided
-    let cover_path = if let Some(ref data) = cover_data {
-        fs::create_dir_all(&covers_dir)?;
-        let cover_file = covers_dir.join(format!("{}.png", book_id));
-        fs::write(&cover_file, data)?;
-        Some(format!("covers/{}.png", book_id))
-    } else {
-        None
-    };
-
     let now = chrono::Utc::now().timestamp_millis();
     let rel_file_path = format!("books/{}", filename);
+    let cover_data_b64 = cover_data.as_ref().map(|d| {
+        base64::engine::general_purpose::STANDARD.encode(d)
+    });
 
     let book = Book {
         id: book_id,
         title,
         author: author.unwrap_or_else(|| "Unknown Author".to_string()),
         description,
-        cover_path,
+        cover_path: None,
         file_path: rel_file_path,
         format: "pdf".to_string(),
         genre: None,
@@ -962,13 +944,14 @@ pub async fn commit_pdf_import(
         created_at: now,
         updated_at: now,
         available: true,
+        cover_data: cover_data_b64,
     };
 
     let device = sync.self_device().to_string();
     sync.with_tx(&db, now, |tx, events| {
         tx.execute(
-            "INSERT INTO books (id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at, updated_by_device)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+            "INSERT INTO books (id, title, author, description, cover_path, file_path, format, genre, pages, status, progress, current_cfi, created_at, updated_at, updated_by_device, cover_data)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
             params![
                 book.id,
                 book.title,
@@ -985,6 +968,7 @@ pub async fn commit_pdf_import(
                 book.created_at,
                 book.updated_at,
                 device,
+                cover_data,
             ],
         )?;
         events.push(EventBody::BookImport(BookImportPayload {
@@ -1031,9 +1015,6 @@ pub async fn cancel_pdf_import(book_id: String, db: State<'_, Db>) -> AppResult<
             }
         }
     }
-    // Remove cover if it was written before the failure.
-    let cover = data_dir.join("covers").join(format!("{}.png", book_id));
-    let _ = fs::remove_file(&cover);
     Ok(())
 }
 
@@ -1208,6 +1189,7 @@ mod tests {
                 created_at: row.get(12)?,
                 updated_at: row.get(13)?,
                 available: true,
+                cover_data: None,
             })
         }).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
 
@@ -1278,7 +1260,7 @@ mod tests {
                 description: row.get(3)?, cover_path: row.get(4)?, file_path: row.get(5)?,
                 format: row.get(6)?, genre: row.get(7)?, pages: row.get(8)?,
                 status: row.get(9)?, progress: row.get(10)?, current_cfi: row.get(11)?,
-                created_at: row.get(12)?, updated_at: row.get(13)?, available: true,
+                created_at: row.get(12)?, updated_at: row.get(13)?, available: true, cover_data: None,
             }),
         ).unwrap();
 
@@ -1380,7 +1362,7 @@ mod tests {
                 description: row.get(3)?, cover_path: row.get(4)?, file_path: row.get(5)?,
                 format: row.get(6)?, genre: row.get(7)?, pages: row.get(8)?,
                 status: row.get(9)?, progress: row.get(10)?, current_cfi: row.get(11)?,
-                created_at: row.get(12)?, updated_at: row.get(13)?, available: true,
+                created_at: row.get(12)?, updated_at: row.get(13)?, available: true, cover_data: None,
             }),
         ).unwrap();
 

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -513,11 +513,11 @@ pub fn sync_now(
 /// Returns an error when sync isn't enabled in this process — the
 /// settings UI surfaces it as a toast.
 #[tauri::command]
-pub fn sync_compact(sync_state: State<'_, SyncState>, db: State<'_, Db>) -> AppResult<SyncCompactResult> {
+pub fn sync_compact(sync_state: State<'_, SyncState>) -> AppResult<SyncCompactResult> {
     let engine = sync_state
         .engine_snapshot()?
         .ok_or_else(|| AppError::Other("sync is not enabled on this device".into()))?;
-    let report = snapshot::compact_own_log(&engine.shared_dir, &engine.own_log, Some(&db))?;
+    let report = snapshot::compact_own_log(&engine.shared_dir, &engine.own_log)?;
     Ok(report.into())
 }
 

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -317,6 +317,7 @@ pub fn sync_enable(
     // peers, and store the engine + watcher in app state so the rest
     // of the app sees sync as on.
     sync_writer.set_log(Some(Arc::clone(&log)));
+    sync_writer.spawn_cover_writer();
     {
         let mut g = sync_state
             .engine
@@ -436,6 +437,7 @@ pub fn sync_disable(
     // `_pending_publish` nor try to drain it.
     sync_writer.set_log(None);
     sync_writer.set_should_queue(false);
+    sync_writer.set_cover_tx(None);
 
     // Repoint data_dir at local now that the binary copy-back has
     // finished. Mid-flight reads during phase 1 still resolved

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -318,6 +318,7 @@ pub fn sync_enable(
     // of the app sees sync as on.
     sync_writer.set_log(Some(Arc::clone(&log)));
     sync_writer.spawn_cover_writer();
+    sync_writer.backfill_cover_files(&db);
     {
         let mut g = sync_state
             .engine

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -513,11 +513,11 @@ pub fn sync_now(
 /// Returns an error when sync isn't enabled in this process — the
 /// settings UI surfaces it as a toast.
 #[tauri::command]
-pub fn sync_compact(sync_state: State<'_, SyncState>) -> AppResult<SyncCompactResult> {
+pub fn sync_compact(sync_state: State<'_, SyncState>, db: State<'_, Db>) -> AppResult<SyncCompactResult> {
     let engine = sync_state
         .engine_snapshot()?
         .ok_or_else(|| AppError::Other("sync is not enabled on this device".into()))?;
-    let report = snapshot::compact_own_log(&engine.shared_dir, &engine.own_log)?;
+    let report = snapshot::compact_own_log(&engine.shared_dir, &engine.own_log, Some(&db))?;
     Ok(report.into())
 }
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -159,13 +159,18 @@ impl Db {
         // read access without blocking the Tauri app's writes.
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=OFF;")?;
 
-        let version_before = Self::current_schema_version(&conn);
         Self::run_migrations(&conn)?;
 
         // One-time migration: convert absolute paths to relative
         Self::migrate_to_relative_paths(&conn, data_dir)?;
 
-        let needs_cover_backfill = version_before < 13;
+        let needs_cover_backfill: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM books WHERE cover_path IS NOT NULL AND cover_path != 'none' AND cover_data IS NULL)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(false);
 
         // Separate read connection so frontend queries never contend
         // with sync engine writes. WAL mode allows concurrent readers
@@ -183,15 +188,6 @@ impl Db {
             read_conn: Arc::new(Mutex::new(read_conn)),
             data_dir: Arc::new(Mutex::new(data_dir.to_path_buf())),
         }, needs_cover_backfill))
-    }
-
-    fn current_schema_version(conn: &Connection) -> i64 {
-        conn.query_row(
-            "SELECT COALESCE(MAX(version), 0) FROM schema_version",
-            [],
-            |r| r.get(0),
-        )
-        .unwrap_or(0)
     }
 
     fn run_migrations(conn: &Connection) -> AppResult<()> {
@@ -302,45 +298,69 @@ impl Db {
     }
 
     /// One-time backfill: read existing cover files from disk into the
-    /// `cover_data` BLOB column. Only needed when upgrading from schema <13.
-    /// Rows that already have `cover_data` or whose `cover_path` is NULL /
-    /// `'none'` are skipped.
-    pub fn backfill_cover_data(conn: &Connection, data_dir: &Path) -> AppResult<()> {
-        let mut stmt = conn.prepare(
-            "SELECT id, cover_path FROM books
-             WHERE cover_data IS NULL
-               AND cover_path IS NOT NULL
-               AND cover_path != 'none'",
-        )?;
-        let rows: Vec<(String, String)> = stmt
-            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
-            .collect::<Result<Vec<_>, _>>()?;
-        drop(stmt);
+    /// `cover_data` BLOB column. Three-phase to avoid holding the DB
+    /// lock during file I/O:
+    /// 1. Quick read-conn query to find candidates
+    /// 2. Read files from disk (no lock held)
+    /// 3. Brief write-conn lock to store each cover
+    pub fn backfill_cover_data(&self) {
+        let data_dir = match self.data_dir.lock() {
+            Ok(d) => d.clone(),
+            Err(_) => return,
+        };
+
+        // Phase 1: find candidates via read conn
+        let rows: Vec<(String, String)> = {
+            let Ok(conn) = self.read_conn.lock() else { return };
+            let Ok(mut stmt) = conn.prepare(
+                "SELECT id, cover_path FROM books
+                 WHERE cover_data IS NULL
+                   AND cover_path IS NOT NULL
+                   AND cover_path != 'none'",
+            ) else { return };
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+                .into_iter()
+                .flatten()
+                .flatten()
+                .collect()
+        };
 
         if rows.is_empty() {
-            return Ok(());
+            return;
         }
 
         log::info!("db: backfilling cover_data for {} books", rows.len());
-        for (id, cover_path) in &rows {
-            let abs = if Path::new(cover_path).is_absolute() {
-                PathBuf::from(cover_path)
-            } else {
-                data_dir.join(cover_path)
-            };
-            match fs::read(&abs) {
-                Ok(bytes) => {
-                    conn.execute(
-                        "UPDATE books SET cover_data = ?1 WHERE id = ?2",
-                        params![bytes, id],
-                    )?;
+
+        // Phase 2: read files (no lock held)
+        let loaded: Vec<(String, Vec<u8>)> = rows
+            .into_iter()
+            .filter_map(|(id, cover_path)| {
+                let abs = if Path::new(&cover_path).is_absolute() {
+                    PathBuf::from(&cover_path)
+                } else {
+                    data_dir.join(&cover_path)
+                };
+                match fs::read(&abs) {
+                    Ok(bytes) => Some((id, bytes)),
+                    Err(e) => {
+                        log::warn!("db: backfill cover_data failed for {id}: {e}");
+                        None
+                    }
                 }
-                Err(e) => {
-                    log::warn!("db: backfill cover_data failed for {id}: {e}");
-                }
+            })
+            .collect();
+
+        // Phase 3: brief write lock per cover
+        for (id, bytes) in &loaded {
+            if let Ok(conn) = self.conn.lock() {
+                let _ = conn.execute(
+                    "UPDATE books SET cover_data = ?1 WHERE id = ?2",
+                    params![bytes, id],
+                );
             }
         }
-        Ok(())
+
+        log::info!("db: backfilled {} cover(s)", loaded.len());
     }
 
     /// Migrate existing absolute paths in the books table to relative paths.

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -70,7 +70,8 @@ impl Db {
     /// `app_data_dir`. Used by tests, fresh installs, and any caller
     /// where the materialized view and the binary blobs live together.
     pub fn init(app_data_dir: &Path) -> AppResult<Self> {
-        Self::init_split(app_data_dir, app_data_dir)
+        let (db, _needs_backfill) = Self::init_split(app_data_dir, app_data_dir)?;
+        Ok(db)
     }
 
     /// Open the SQLite file read-only without running migrations. Used
@@ -138,7 +139,9 @@ impl Db {
     /// Resolving `books/<id>.epub` then walks into the iCloud folder
     /// instead of an empty local one. Without this split, the reader
     /// silently breaks for every existing iCloud user post-migration.
-    pub fn init_split(db_dir: &Path, data_dir: &Path) -> AppResult<Self> {
+    /// Returns `(db, needs_cover_backfill)`. The caller should run
+    /// `backfill_cover_data` on a background thread when the flag is true.
+    pub fn init_split(db_dir: &Path, data_dir: &Path) -> AppResult<(Self, bool)> {
         fs::create_dir_all(db_dir)?;
         fs::create_dir_all(data_dir)?;
         fs::create_dir_all(data_dir.join("books"))?;
@@ -156,13 +159,13 @@ impl Db {
         // read access without blocking the Tauri app's writes.
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=OFF;")?;
 
+        let version_before = Self::current_schema_version(&conn);
         Self::run_migrations(&conn)?;
 
         // One-time migration: convert absolute paths to relative
         Self::migrate_to_relative_paths(&conn, data_dir)?;
 
-        // One-time backfill: read existing cover files into cover_data BLOB
-        Self::backfill_cover_data(&conn, data_dir)?;
+        let needs_cover_backfill = version_before < 13;
 
         // Separate read connection so frontend queries never contend
         // with sync engine writes. WAL mode allows concurrent readers
@@ -175,11 +178,20 @@ impl Db {
                 | rusqlite::OpenFlags::SQLITE_OPEN_URI,
         )?;
 
-        Ok(Self {
+        Ok((Self {
             conn: Arc::new(Mutex::new(conn)),
             read_conn: Arc::new(Mutex::new(read_conn)),
             data_dir: Arc::new(Mutex::new(data_dir.to_path_buf())),
-        })
+        }, needs_cover_backfill))
+    }
+
+    fn current_schema_version(conn: &Connection) -> i64 {
+        conn.query_row(
+            "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0)
     }
 
     fn run_migrations(conn: &Connection) -> AppResult<()> {
@@ -290,10 +302,10 @@ impl Db {
     }
 
     /// One-time backfill: read existing cover files from disk into the
-    /// `cover_data` BLOB column. Runs after migration 013 adds the column.
+    /// `cover_data` BLOB column. Only needed when upgrading from schema <13.
     /// Rows that already have `cover_data` or whose `cover_path` is NULL /
     /// `'none'` are skipped.
-    fn backfill_cover_data(conn: &Connection, data_dir: &Path) -> AppResult<()> {
+    pub fn backfill_cover_data(conn: &Connection, data_dir: &Path) -> AppResult<()> {
         let mut stmt = conn.prepare(
             "SELECT id, cover_path FROM books
              WHERE cover_data IS NULL
@@ -380,7 +392,7 @@ mod tests {
     fn init_split_opens_db_in_db_dir_resolves_blobs_in_data_dir() {
         let db_dir = TempDir::new().unwrap();
         let data_dir = TempDir::new().unwrap();
-        let db = Db::init_split(db_dir.path(), data_dir.path()).unwrap();
+        let (db, _) = Db::init_split(db_dir.path(), data_dir.path()).unwrap();
 
         // SQLite file landed in db_dir (NOT data_dir).
         assert!(db_dir.path().join("quill.db").exists());

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -145,7 +145,6 @@ impl Db {
         fs::create_dir_all(db_dir)?;
         fs::create_dir_all(data_dir)?;
         fs::create_dir_all(data_dir.join("books"))?;
-        fs::create_dir_all(data_dir.join("covers"))?;
 
         let db_path = db_dir.join("quill.db");
         let conn = Connection::open(&db_path)?;
@@ -398,9 +397,8 @@ mod tests {
         assert!(db_dir.path().join("quill.db").exists());
         assert!(!data_dir.path().join("quill.db").exists());
 
-        // books/ + covers/ subdirs were created in data_dir (NOT db_dir).
+        // books/ subdir was created in data_dir (NOT db_dir).
         assert!(data_dir.path().join("books").exists());
-        assert!(data_dir.path().join("covers").exists());
         assert!(!db_dir.path().join("books").exists());
 
         // resolve_path uses data_dir as the base.

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -145,6 +145,7 @@ impl Db {
         fs::create_dir_all(db_dir)?;
         fs::create_dir_all(data_dir)?;
         fs::create_dir_all(data_dir.join("books"))?;
+        fs::create_dir_all(data_dir.join("covers"))?;
 
         let db_path = db_dir.join("quill.db");
         let conn = Connection::open(&db_path)?;

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -18,6 +18,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (10, include_str!("../migrations/010_replay_state.sql")),
     (11, include_str!("../migrations/011_lww_tiebreak_and_outbox.sql")),
     (12, include_str!("../migrations/012_vocab_context_explanation.sql")),
+    (13, include_str!("../migrations/013_covers_in_db.sql")),
 ];
 
 /// SQLite handle for the local materialized view.
@@ -160,6 +161,9 @@ impl Db {
         // One-time migration: convert absolute paths to relative
         Self::migrate_to_relative_paths(&conn, data_dir)?;
 
+        // One-time backfill: read existing cover files into cover_data BLOB
+        Self::backfill_cover_data(&conn, data_dir)?;
+
         // Separate read connection so frontend queries never contend
         // with sync engine writes. WAL mode allows concurrent readers
         // alongside one writer at the SQLite level; the two Rust
@@ -193,7 +197,7 @@ impl Db {
             if version > current {
                 log::info!("db: applying migration {version}");
                 // ALTER TABLE migrations may fail if column already exists
-                if version == 4 || version == 5 {
+                if version == 4 || version == 5 || version == 13 {
                     let _ = conn.execute_batch(sql);
                 } else if let Err(e) = conn.execute_batch(sql) {
                     log::error!("db: migration {version} failed: {e}");
@@ -268,7 +272,7 @@ impl Db {
                 break;
             }
             if version > current {
-                if version == 4 || version == 5 {
+                if version == 4 || version == 5 || version == 13 {
                     let _ = conn.execute_batch(sql);
                 } else {
                     conn.execute_batch(sql)?;
@@ -282,6 +286,48 @@ impl Db {
             }
         }
 
+        Ok(())
+    }
+
+    /// One-time backfill: read existing cover files from disk into the
+    /// `cover_data` BLOB column. Runs after migration 013 adds the column.
+    /// Rows that already have `cover_data` or whose `cover_path` is NULL /
+    /// `'none'` are skipped.
+    fn backfill_cover_data(conn: &Connection, data_dir: &Path) -> AppResult<()> {
+        let mut stmt = conn.prepare(
+            "SELECT id, cover_path FROM books
+             WHERE cover_data IS NULL
+               AND cover_path IS NOT NULL
+               AND cover_path != 'none'",
+        )?;
+        let rows: Vec<(String, String)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?;
+        drop(stmt);
+
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        log::info!("db: backfilling cover_data for {} books", rows.len());
+        for (id, cover_path) in &rows {
+            let abs = if Path::new(cover_path).is_absolute() {
+                PathBuf::from(cover_path)
+            } else {
+                data_dir.join(cover_path)
+            };
+            match fs::read(&abs) {
+                Ok(bytes) => {
+                    conn.execute(
+                        "UPDATE books SET cover_data = ?1 WHERE id = ?2",
+                        params![bytes, id],
+                    )?;
+                }
+                Err(e) => {
+                    log::warn!("db: backfill cover_data failed for {id}: {e}");
+                }
+            }
+        }
         Ok(())
     }
 
@@ -362,7 +408,7 @@ mod tests {
         let conn = db.conn.lock().unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 12);
+        assert_eq!(version, 13);
     }
 
     #[test]
@@ -398,7 +444,7 @@ mod tests {
         Db::run_migrations_on(&conn).unwrap();
         let version: i64 =
             conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
-        assert_eq!(version, 12);
+        assert_eq!(version, 13);
     }
 
     #[test]

--- a/src-tauri/src/epub.rs
+++ b/src-tauri/src/epub.rs
@@ -1,5 +1,4 @@
 use epub::doc::EpubDoc;
-use std::fs;
 use std::path::Path;
 
 use crate::error::{AppError, AppResult};
@@ -8,10 +7,10 @@ pub struct EpubMetadata {
     pub title: String,
     pub author: String,
     pub description: Option<String>,
-    pub cover_path: Option<String>,
+    pub cover_data: Option<Vec<u8>>,
 }
 
-pub fn extract_metadata(epub_path: &Path, covers_dir: &Path, book_id: &str) -> AppResult<EpubMetadata> {
+pub fn extract_metadata(epub_path: &Path) -> AppResult<EpubMetadata> {
     let mut doc = EpubDoc::new(epub_path).map_err(|e| AppError::Epub(e.to_string()))?;
 
     let title = doc
@@ -26,32 +25,19 @@ pub fn extract_metadata(epub_path: &Path, covers_dir: &Path, book_id: &str) -> A
 
     let description = doc.mdata("description").map(|m| m.value.clone());
 
-    let cover_path = extract_cover(&mut doc, covers_dir, book_id);
+    let cover_data = extract_cover(&mut doc);
 
     Ok(EpubMetadata {
         title,
         author,
         description,
-        cover_path,
+        cover_data,
     })
 }
 
-fn extract_cover(doc: &mut EpubDoc<std::io::BufReader<std::fs::File>>, covers_dir: &Path, book_id: &str) -> Option<String> {
-    let (data, mime) = resolve_cover_resource(doc)?;
-
-    let ext = match mime.as_str() {
-        "image/png" => "png",
-        "image/gif" => "gif",
-        _ => "jpg",
-    };
-
-    let cover_filename = format!("{}.{}", book_id, ext);
-    let cover_path = covers_dir.join(&cover_filename);
-
-    fs::write(&cover_path, &data).ok()?;
-
-    // Return relative path for DB storage
-    Some(format!("covers/{}", cover_filename))
+fn extract_cover(doc: &mut EpubDoc<std::io::BufReader<std::fs::File>>) -> Option<Vec<u8>> {
+    let (data, _mime) = resolve_cover_resource(doc)?;
+    Some(data)
 }
 
 /// Resolve the cover image bytes + mime, walking through fallback

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -282,20 +282,7 @@ fn boot_sync_engine(
         *engine_guard = Some(Arc::clone(&engine));
         *watcher_guard = Some(watcher);
         sync_writer.set_log(Some(log));
-
-        let (cover_tx, cover_rx) = std::sync::mpsc::channel::<(std::path::PathBuf, Vec<u8>)>();
-        std::thread::Builder::new()
-            .name("cover-writer".into())
-            .spawn(move || {
-                for (path, bytes) in cover_rx {
-                    if let Some(parent) = path.parent() {
-                        let _ = std::fs::create_dir_all(parent);
-                    }
-                    let _ = std::fs::write(&path, &bytes);
-                }
-            })
-            .ok();
-        sync_writer.set_cover_tx(Some(cover_tx));
+        sync_writer.spawn_cover_writer();
     }
 
     let bg_engine = Arc::clone(&engine);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -188,6 +188,7 @@ pub fn mcp_stdio_main() {
         let sw = SyncWriter::new(device.device_uuid);
         if sync::migration::is_sync_enabled(&local_dir) {
             sw.set_should_queue(true);
+            sw.spawn_cover_writer();
         }
         (db, Some(sw))
     } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -451,8 +451,22 @@ pub fn run() {
             // When sync is on, blobs (books/, covers/) live in iCloud;
             // otherwise they're local.
             let data_dir = ubiquity_dir.clone().unwrap_or_else(|| local_dir.clone());
-            let db = Db::init_split(&local_dir, &data_dir)
+            let (db, needs_cover_backfill) = Db::init_split(&local_dir, &data_dir)
                 .expect("failed to initialize database");
+
+            if needs_cover_backfill {
+                let backfill_conn = db.conn.clone();
+                let backfill_dir = data_dir.clone();
+                std::thread::Builder::new()
+                    .name("cover-backfill".into())
+                    .spawn(move || {
+                        let conn = backfill_conn.lock().expect("backfill conn mutex");
+                        if let Err(e) = Db::backfill_cover_data(&conn, &backfill_dir) {
+                            log::warn!("cover backfill failed: {e}");
+                        }
+                    })
+                    .ok();
+            }
 
             log::info!(
                 "quill start v{version} os={os} arch={arch} data_dir={data_dir} schema_v={schema}",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -287,9 +287,6 @@ fn boot_sync_engine(
     let bg_engine = Arc::clone(&engine);
     let bg_db = db.clone();
     let bg_handle = app_handle.clone();
-    let bg_data_dir = db.data_dir.lock()
-        .map(|d| d.clone())
-        .unwrap_or_default();
     std::thread::Builder::new()
         .name("sync-initial-tick".into())
         .spawn(move || {
@@ -297,38 +294,11 @@ fn boot_sync_engine(
             if let Err(e) = result {
                 log::warn!("sync: initial replay tick failed: {e}");
             }
-            trigger_cover_downloads(&bg_data_dir);
             let _ = bg_handle.emit("sync-initial-tick-done", ());
         })
         .ok();
 
     Ok(())
-}
-
-/// Trigger iCloud downloads for all evicted cover images so the
-/// library grid renders cover art immediately after sync. Covers
-/// are small (few KB each) — downloading eagerly is fine. Book
-/// EPUBs stay lazy (downloaded on access).
-fn trigger_cover_downloads(data_dir: &Path) {
-    let covers_dir = data_dir.join("covers");
-    let entries = match std::fs::read_dir(&covers_dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-    let mut triggered = 0usize;
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str.starts_with('.') && name_str.ends_with(".icloud") {
-            let real_name = &name_str[1..name_str.len() - 7];
-            let real_path = covers_dir.join(real_name);
-            icloud::trigger_download_file(&real_path);
-            triggered += 1;
-        }
-    }
-    if triggered > 0 {
-        log::info!("sync: triggered download for {triggered} evicted cover(s)");
-    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -297,6 +297,12 @@ fn boot_sync_engine(
             if let Err(e) = result {
                 log::warn!("sync: initial replay tick failed: {e}");
             }
+            // Chained: DB backfill first (cover files → BLOBs), then
+            // file backfill (BLOBs → .img). Sequential so .img writes
+            // always see the full set of cover_data.
+            if needs_cover_backfill {
+                bg_db.backfill_cover_data();
+            }
             let bg_writer: tauri::State<SyncWriter> = bg_handle.state();
             bg_writer.backfill_cover_files(&bg_db);
             let _ = bg_handle.emit("sync-initial-tick-done", ());
@@ -459,7 +465,11 @@ pub fn run() {
             let (db, needs_cover_backfill) = Db::init_split(&local_dir, &data_dir)
                 .expect("failed to initialize database");
 
-            if needs_cover_backfill {
+            // DB cover backfill for non-sync users. When sync boots, the
+            // initial-tick thread handles both DB and .img backfill sequentially.
+            let sync_will_boot = sync::migration::is_sync_enabled(&local_dir)
+                && ubiquity_dir.as_ref().is_some_and(|p| p.exists());
+            if needs_cover_backfill && !sync_will_boot {
                 let backfill_db = db.clone();
                 std::thread::Builder::new()
                     .name("cover-backfill".into())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -282,6 +282,20 @@ fn boot_sync_engine(
         *engine_guard = Some(Arc::clone(&engine));
         *watcher_guard = Some(watcher);
         sync_writer.set_log(Some(log));
+
+        let (cover_tx, cover_rx) = std::sync::mpsc::channel::<(std::path::PathBuf, Vec<u8>)>();
+        std::thread::Builder::new()
+            .name("cover-writer".into())
+            .spawn(move || {
+                for (path, bytes) in cover_rx {
+                    if let Some(parent) = path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
+                    let _ = std::fs::write(&path, &bytes);
+                }
+            })
+            .ok();
+        sync_writer.set_cover_tx(Some(cover_tx));
     }
 
     let bg_engine = Arc::clone(&engine);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -560,6 +560,7 @@ pub fn run() {
             commands::books::update_book_metadata,
             commands::books::save_book_cover,
             commands::books::mark_cover_unavailable,
+            commands::books::list_books_needing_covers,
             // Settings
             commands::settings::get_all_settings,
             commands::settings::get_setting,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -297,10 +297,8 @@ fn boot_sync_engine(
             if let Err(e) = result {
                 log::warn!("sync: initial replay tick failed: {e}");
             }
-            if needs_cover_backfill {
-                let bg_writer: tauri::State<SyncWriter> = bg_handle.state();
-                bg_writer.backfill_cover_files(&bg_db);
-            }
+            let bg_writer: tauri::State<SyncWriter> = bg_handle.state();
+            bg_writer.backfill_cover_files(&bg_db);
             let _ = bg_handle.emit("sync-initial-tick-done", ());
         })
         .ok();
@@ -462,15 +460,11 @@ pub fn run() {
                 .expect("failed to initialize database");
 
             if needs_cover_backfill {
-                let backfill_conn = db.conn.clone();
-                let backfill_dir = data_dir.clone();
+                let backfill_db = db.clone();
                 std::thread::Builder::new()
                     .name("cover-backfill".into())
                     .spawn(move || {
-                        let conn = backfill_conn.lock().expect("backfill conn mutex");
-                        if let Err(e) = Db::backfill_cover_data(&conn, &backfill_dir) {
-                            log::warn!("cover backfill failed: {e}");
-                        }
+                        backfill_db.backfill_cover_data();
                     })
                     .ok();
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -249,6 +249,7 @@ fn boot_sync_engine(
     sync_writer: &SyncWriter,
     sync_state: &SyncState,
     app_handle: &tauri::AppHandle,
+    needs_cover_backfill: bool,
 ) -> error::AppResult<()> {
     let log_path = shared_dir.join("logs").join(format!("{device_uuid}.jsonl"));
     let log = Arc::new(EventLog::open(&log_path, device_uuid, true)?);
@@ -295,6 +296,10 @@ fn boot_sync_engine(
             let result = bg_engine.tick_with_progress(&bg_db, Some(&bg_handle));
             if let Err(e) = result {
                 log::warn!("sync: initial replay tick failed: {e}");
+            }
+            if needs_cover_backfill {
+                let bg_writer: tauri::State<SyncWriter> = bg_handle.state();
+                bg_writer.backfill_cover_files(&bg_db);
             }
             let _ = bg_handle.emit("sync-initial-tick-done", ());
         })
@@ -526,6 +531,7 @@ pub fn run() {
                 .flatten();
             if let Some(ub) = should_boot {
                 let bg_handle = app.handle().clone();
+                let bg_needs_backfill = needs_cover_backfill;
                 std::thread::Builder::new()
                     .name("sync-boot".into())
                     .spawn(move || {
@@ -534,7 +540,7 @@ pub fn run() {
                         let bg_device: tauri::State<DeviceIdentity> = bg_handle.state();
                         let bg_sync: tauri::State<SyncState> = bg_handle.state();
                         match boot_sync_engine(
-                            ub, &bg_device.device_uuid, &bg_db, &bg_writer, &bg_sync, &bg_handle,
+                            ub, &bg_device.device_uuid, &bg_db, &bg_writer, &bg_sync, &bg_handle, bg_needs_backfill,
                         ) {
                             Ok(()) => {
                                 log::info!("sync: engine booted (replay + watcher active)");

--- a/src-tauri/src/mcp/tools/library.rs
+++ b/src-tauri/src/mcp/tools/library.rs
@@ -38,19 +38,17 @@ pub struct GetBookArgs {
     pub book_id: String,
 }
 
-/// MCP-facing projection of `books::Book`. Drops the `available`
-/// field because the stdio subprocess doesn't know the iCloud
-/// `data_dir` (only the Tauri app does), so it can't honestly compute
-/// availability; and iCloud-evicted state is a frontend rendering
-/// concern (greyed-out tile in the library view) — MCP clients have
-/// no use for it. Returning a hardcoded `true` would mislead callers.
+/// MCP-facing projection of `books::Book`. Drops `available` (the
+/// stdio subprocess can't compute iCloud eviction state) and
+/// `cover_data` (multi-hundred-KB base64 BLOBs are too large for
+/// MCP JSON responses — MCP clients that need covers should fetch
+/// them via a dedicated tool in the future).
 #[derive(Debug, Serialize)]
 struct McpBook {
     id: String,
     title: String,
     author: String,
     description: Option<String>,
-    cover_path: Option<String>,
     file_path: String,
     format: String,
     genre: Option<String>,
@@ -60,16 +58,17 @@ struct McpBook {
     current_cfi: Option<String>,
     created_at: i64,
     updated_at: i64,
+    has_cover: bool,
 }
 
 impl From<books::Book> for McpBook {
     fn from(b: books::Book) -> Self {
+        let has_cover = b.cover_data.as_ref().is_some_and(|d| !d.is_empty());
         Self {
             id: b.id,
             title: b.title,
             author: b.author,
             description: b.description,
-            cover_path: b.cover_path.filter(|c| c != "none"),
             file_path: b.file_path,
             format: b.format,
             genre: b.genre,
@@ -79,6 +78,7 @@ impl From<books::Book> for McpBook {
             current_cfi: b.current_cfi,
             created_at: b.created_at,
             updated_at: b.updated_at,
+            has_cover,
         }
     }
 }
@@ -86,7 +86,7 @@ impl From<books::Book> for McpBook {
 #[tool_router(router = library_router, vis = "pub(crate)")]
 impl QuillMcpHandler {
     #[tool(
-        description = "List books in the local library. Optionally filter by status or genre and search title/author. Returns relative file/cover paths (under the app data directory)."
+        description = "List books in the local library. Optionally filter by status or genre and search title/author. Returns relative file paths (under the app data directory). Covers are stored as BLOBs in the DB — use `has_cover` to check availability."
     )]
     pub async fn list_books(
         &self,

--- a/src-tauri/src/mcp/tools/library.rs
+++ b/src-tauri/src/mcp/tools/library.rs
@@ -92,10 +92,14 @@ impl QuillMcpHandler {
         &self,
         Parameters(ListBooksArgs { filter, search }): Parameters<ListBooksArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let page =
-            books::query_books(&self.state.db, filter.as_deref(), search.as_deref(), None, None, 1000)
-                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
-        let books: Vec<McpBook> = page.books.into_iter().map(McpBook::from).collect();
+        let raw = books::query_books_lite(
+            &self.state.db,
+            filter.as_deref(),
+            search.as_deref(),
+            1000,
+        )
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let books: Vec<McpBook> = raw.into_iter().map(McpBook::from).collect();
         Ok(CallToolResult::success(vec![Content::json(&books)?]))
     }
 

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -230,7 +230,9 @@ impl ReplayEngine {
                 ::log::error!("sync: batch apply failed: {e}");
             })?;
 
-        if events_applied > 0 || snapshots_applied > 0 || outbox_flushed > 0 {
+        let covers_ingested = ingest_peer_covers(&self.shared_dir, db);
+
+        if events_applied > 0 || snapshots_applied > 0 || outbox_flushed > 0 || covers_ingested > 0 {
             ::log::info!(
                 "sync: batch applied events={events_applied} snapshots={snapshots_applied} outbox_flushed={outbox_flushed} elapsed_ms={}",
                 started.elapsed().as_millis(),
@@ -278,7 +280,7 @@ impl ReplayEngine {
         // Failures are non-fatal — the next tick will retry and the log
         // simply grows in the meantime.
         if snapshot::should_compact(&self.shared_dir, &self.self_device) {
-            match snapshot::compact_own_log(&self.shared_dir, &self.own_log, Some(db)) {
+            match snapshot::compact_own_log(&self.shared_dir, &self.own_log) {
                 Ok(report) if report.snapshot_written => ::log::info!(
                     "sync: compacted own log — {} events folded, {} bytes freed",
                     report.events_folded, report.bytes_freed,
@@ -668,6 +670,55 @@ fn read_outbox(conn: &Connection) -> AppResult<Vec<OutboxRow>> {
         })?
         .collect::<Result<_, _>>()?;
     Ok(collected)
+}
+
+fn ingest_peer_covers(shared_dir: &Path, db: &Db) -> usize {
+    let covers_dir = shared_dir.join("covers");
+    let entries = match std::fs::read_dir(&covers_dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+
+    let conn = match db.conn.lock() {
+        Ok(c) => c,
+        Err(_) => return 0,
+    };
+
+    let mut ingested = 0usize;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        let Some(book_id) = name_str.strip_suffix(".img") else { continue };
+
+        let has_cover: bool = conn
+            .query_row(
+                "SELECT cover_data IS NOT NULL AND LENGTH(cover_data) > 0 FROM books WHERE id = ?1",
+                rusqlite::params![book_id],
+                |r| r.get(0),
+            )
+            .unwrap_or(true);
+
+        if has_cover {
+            continue;
+        }
+
+        match std::fs::read(entry.path()) {
+            Ok(bytes) if !bytes.is_empty() => {
+                if conn
+                    .execute(
+                        "UPDATE books SET cover_data = ?1 WHERE id = ?2 AND (cover_data IS NULL OR LENGTH(cover_data) = 0)",
+                        rusqlite::params![bytes, book_id],
+                    )
+                    .is_ok()
+                {
+                    ingested += 1;
+                    ::log::info!("sync: ingested cover for book {book_id}");
+                }
+            }
+            _ => {}
+        }
+    }
+    ingested
 }
 
 #[cfg(test)]

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -278,7 +278,7 @@ impl ReplayEngine {
         // Failures are non-fatal — the next tick will retry and the log
         // simply grows in the meantime.
         if snapshot::should_compact(&self.shared_dir, &self.self_device) {
-            match snapshot::compact_own_log(&self.shared_dir, &self.own_log) {
+            match snapshot::compact_own_log(&self.shared_dir, &self.own_log, Some(db)) {
                 Ok(report) if report.snapshot_written => ::log::info!(
                     "sync: compacted own log — {} events folded, {} bytes freed",
                     report.events_folded, report.bytes_freed,

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -679,43 +679,56 @@ fn ingest_peer_covers(shared_dir: &Path, db: &Db) -> usize {
         Err(_) => return 0,
     };
 
-    let conn = match db.conn.lock() {
-        Ok(c) => c,
-        Err(_) => return 0,
+    // Phase 1: collect candidates — quick SQL check per file, no file I/O.
+    let candidates: Vec<(String, std::path::PathBuf)> = {
+        let Ok(conn) = db.read_conn.lock() else { return 0 };
+        entries
+            .flatten()
+            .filter_map(|entry| {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                let book_id = name_str.strip_suffix(".img")?.to_string();
+                let has_cover: bool = conn
+                    .query_row(
+                        "SELECT cover_data IS NOT NULL AND LENGTH(cover_data) > 0 FROM books WHERE id = ?1",
+                        rusqlite::params![&book_id],
+                        |r| r.get(0),
+                    )
+                    .unwrap_or(true);
+                if has_cover { None } else { Some((book_id, entry.path())) }
+            })
+            .collect()
     };
 
+    if candidates.is_empty() {
+        return 0;
+    }
+
+    // Phase 2: read files (no DB lock held — safe if iCloud stalls).
+    let loaded: Vec<(String, Vec<u8>)> = candidates
+        .into_iter()
+        .filter_map(|(id, path)| {
+            std::fs::read(&path).ok().filter(|b| !b.is_empty()).map(|b| (id, b))
+        })
+        .collect();
+
+    if loaded.is_empty() {
+        return 0;
+    }
+
+    // Phase 3: brief write lock to store covers.
+    let Ok(conn) = db.conn.lock() else { return 0 };
     let mut ingested = 0usize;
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        let Some(book_id) = name_str.strip_suffix(".img") else { continue };
-
-        let has_cover: bool = conn
-            .query_row(
-                "SELECT cover_data IS NOT NULL AND LENGTH(cover_data) > 0 FROM books WHERE id = ?1",
-                rusqlite::params![book_id],
-                |r| r.get(0),
+    for (book_id, bytes) in &loaded {
+        if conn
+            .execute(
+                "UPDATE books SET cover_data = ?1 WHERE id = ?2 AND (cover_data IS NULL OR LENGTH(cover_data) = 0)",
+                rusqlite::params![bytes, book_id],
             )
-            .unwrap_or(true);
-
-        if has_cover {
-            continue;
-        }
-
-        match std::fs::read(entry.path()) {
-            Ok(bytes) if !bytes.is_empty() => {
-                if conn
-                    .execute(
-                        "UPDATE books SET cover_data = ?1 WHERE id = ?2 AND (cover_data IS NULL OR LENGTH(cover_data) = 0)",
-                        rusqlite::params![bytes, book_id],
-                    )
-                    .is_ok()
-                {
-                    ingested += 1;
-                    ::log::info!("sync: ingested cover for book {book_id}");
-                }
-            }
-            _ => {}
+            .is_ok_and(|n| n > 0)
+        {
+            ingested += 1;
+            ::log::info!("sync: ingested cover for book {book_id}");
         }
     }
     ingested

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -680,6 +680,7 @@ fn ingest_peer_covers(shared_dir: &Path, db: &Db) -> usize {
     };
 
     // Phase 1: collect candidates — quick SQL check per file, no file I/O.
+    // Recognizes both real files (foo.img) and iCloud placeholders (.foo.img.icloud).
     let candidates: Vec<(String, std::path::PathBuf)> = {
         let Ok(conn) = db.read_conn.lock() else { return 0 };
         entries
@@ -687,7 +688,17 @@ fn ingest_peer_covers(shared_dir: &Path, db: &Db) -> usize {
             .filter_map(|entry| {
                 let name = entry.file_name();
                 let name_str = name.to_string_lossy();
-                let book_id = name_str.strip_suffix(".img")?.to_string();
+                let (book_id, path) = if let Some(id) = name_str.strip_suffix(".img") {
+                    (id.to_string(), entry.path())
+                } else if name_str.starts_with('.') && name_str.ends_with(".img.icloud") {
+                    let inner = &name_str[1..name_str.len() - 7]; // strip leading '.' and trailing '.icloud'
+                    let id = inner.strip_suffix(".img")?.to_string();
+                    let real_path = covers_dir.join(format!("{id}.img"));
+                    crate::icloud::trigger_download_file(&real_path);
+                    return None; // skip this tick, file will be available next tick
+                } else {
+                    return None;
+                };
                 let has_cover: bool = conn
                     .query_row(
                         "SELECT cover_data IS NOT NULL AND LENGTH(cover_data) > 0 FROM books WHERE id = ?1",
@@ -695,7 +706,7 @@ fn ingest_peer_covers(shared_dir: &Path, db: &Db) -> usize {
                         |r| r.get(0),
                     )
                     .unwrap_or(true);
-                if has_cover { None } else { Some((book_id, entry.path())) }
+                if has_cover { None } else { Some((book_id, path)) }
             })
             .collect()
     };

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -26,6 +26,7 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
+use base64::Engine;
 use rusqlite::{params, Connection, Transaction};
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
@@ -107,6 +108,8 @@ pub struct BookRow {
     pub created_at: i64,
     pub updated_at: i64,
     pub updated_by_device: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cover_data: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -708,11 +711,14 @@ pub fn compact_own_log(
 // ---------------------------------------------------------------------------
 
 fn upsert_book(tx: &Transaction, id: &str, r: &BookRow) -> AppResult<()> {
+    let cover_bytes: Option<Vec<u8>> = r.cover_data.as_ref().and_then(|b64| {
+        base64::engine::general_purpose::STANDARD.decode(b64).ok()
+    });
     tx.execute(
         "INSERT INTO books
          (id, title, author, description, cover_path, file_path, genre, pages,
-          format, status, progress, current_cfi, created_at, updated_at, updated_by_device)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+          format, status, progress, current_cfi, created_at, updated_at, updated_by_device, cover_data)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
          ON CONFLICT(id) DO UPDATE SET
            title=excluded.title,
            author=excluded.author,
@@ -725,6 +731,7 @@ fn upsert_book(tx: &Transaction, id: &str, r: &BookRow) -> AppResult<()> {
            status=excluded.status,
            progress=excluded.progress,
            current_cfi=excluded.current_cfi,
+           cover_data=excluded.cover_data,
            updated_at=excluded.updated_at,
            updated_by_device=excluded.updated_by_device
          WHERE (books.updated_at, books.updated_by_device)
@@ -732,9 +739,16 @@ fn upsert_book(tx: &Transaction, id: &str, r: &BookRow) -> AppResult<()> {
         params![
             id, r.title, r.author, r.description, r.cover_path, r.file_path,
             r.genre, r.pages, r.format, r.status, r.progress, r.current_cfi,
-            r.created_at, r.updated_at, r.updated_by_device,
+            r.created_at, r.updated_at, r.updated_by_device, cover_bytes,
         ],
     )?;
+    // Fill cover_data from snapshot even when LWW doesn't update (same timestamp)
+    if let Some(ref bytes) = cover_bytes {
+        tx.execute(
+            "UPDATE books SET cover_data = ?1 WHERE id = ?2 AND cover_data IS NULL",
+            params![bytes, id],
+        )?;
+    }
     Ok(())
 }
 
@@ -903,10 +917,11 @@ fn dump_state(conn: &Connection) -> AppResult<SnapshotState> {
     let mut stmt = conn.prepare(
         "SELECT id, title, author, description, cover_path, file_path, genre, pages,
                 format, status, progress, current_cfi,
-                created_at, updated_at, updated_by_device
+                created_at, updated_at, updated_by_device, cover_data
          FROM books",
     )?;
     let rows = stmt.query_map([], |r| {
+        let cover_blob: Option<Vec<u8>> = r.get(15)?;
         Ok((
             r.get::<_, String>(0)?,
             BookRow {
@@ -924,6 +939,9 @@ fn dump_state(conn: &Connection) -> AppResult<SnapshotState> {
                 created_at: r.get(12)?,
                 updated_at: r.get(13)?,
                 updated_by_device: r.get(14)?,
+                cover_data: cover_blob.map(|b| {
+                    base64::engine::general_purpose::STANDARD.encode(&b)
+                }),
             },
         ))
     })?;

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -601,7 +601,6 @@ pub fn should_compact(shared_dir: &Path, device: &str) -> bool {
 pub fn compact_own_log(
     shared_dir: &Path,
     log_handle: &EventLog,
-    live_db: Option<&Db>,
 ) -> AppResult<CompactReport> {
     let device = log_handle.device().to_string();
     let snap_path = shared_dir
@@ -638,35 +637,7 @@ pub fn compact_own_log(
             }
             tx.commit()?;
         }
-        let mut state = dump_state(&conn)?;
-
-        // cover_data is written directly to SQLite (not through events),
-        // so the event replay above misses it. Overlay from the live DB
-        // so the compacted snapshot carries covers to peers.
-        if let Some(db) = live_db {
-            if let Ok(live_conn) = db.read_conn.lock() {
-                let mut stmt = live_conn.prepare(
-                    "SELECT id, cover_data FROM books WHERE cover_data IS NOT NULL AND LENGTH(cover_data) > 0",
-                ).ok();
-                if let Some(ref mut s) = stmt {
-                    let rows: Vec<(String, Vec<u8>)> = s
-                        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
-                        .into_iter()
-                        .flatten()
-                        .flatten()
-                        .collect();
-                    for (id, bytes) in rows {
-                        if let Some(book) = state.books.get_mut(&id) {
-                            if book.cover_data.is_none() {
-                                book.cover_data = Some(
-                                    base64::engine::general_purpose::STANDARD.encode(&bytes),
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        let state = dump_state(&conn)?;
 
         // The new snapshot's watermark is the highest event id we
         // just folded. After truncation the log is empty, so any
@@ -1923,7 +1894,7 @@ mod tests {
             vec![import("b1"), import("b2"), import("b3")],
         );
 
-        let report = compact_own_log(shared, &log, None).unwrap();
+        let report = compact_own_log(shared, &log).unwrap();
         assert_eq!(report.events_folded, 3);
         assert!(report.snapshot_written);
 
@@ -1946,7 +1917,7 @@ mod tests {
         let log_path = shared.join("logs/dev-A.jsonl");
         let log = EventLog::open(&log_path, "dev-A", false).unwrap();
 
-        let report = compact_own_log(shared, &log, None).unwrap();
+        let report = compact_own_log(shared, &log).unwrap();
         assert_eq!(report.events_folded, 0);
         assert!(!report.snapshot_written);
         assert!(!shared.join("logs/dev-A.snapshot.json").exists());
@@ -1959,11 +1930,11 @@ mod tests {
         std::fs::create_dir_all(shared.join("logs")).unwrap();
         let log = seed_log(shared, "dev-A", vec![import("b1"), import("b2")]);
 
-        let r1 = compact_own_log(shared, &log, None).unwrap();
+        let r1 = compact_own_log(shared, &log).unwrap();
         assert_eq!(r1.events_folded, 2);
 
         // Second run sees an empty log → no snapshot rewrite.
-        let r2 = compact_own_log(shared, &log, None).unwrap();
+        let r2 = compact_own_log(shared, &log).unwrap();
         assert_eq!(r2.events_folded, 0);
         assert!(!r2.snapshot_written);
     }
@@ -2009,7 +1980,7 @@ mod tests {
 
         // Compaction path: compact the log → snapshot, then apply the
         // snapshot to a fresh DB.
-        compact_own_log(shared, &log, None).unwrap();
+        compact_own_log(shared, &log).unwrap();
         let snap =
             Snapshot::read_from(&shared.join("logs/dev-A.snapshot.json")).unwrap();
         let mut db_via_snap = open_db();
@@ -2086,7 +2057,7 @@ mod tests {
         let snap_dst = shared.join("logs/dev-A.snapshot.json");
         std::fs::create_dir_all(&snap_dst).unwrap();
 
-        let result = compact_own_log(shared, &log, None);
+        let result = compact_own_log(shared, &log);
         assert!(
             result.is_err(),
             "compaction must propagate snapshot write failure"
@@ -2111,10 +2082,10 @@ mod tests {
         std::fs::create_dir_all(shared.join("logs")).unwrap();
         let log = seed_log(shared, "dev-A", vec![import("b1")]);
 
-        compact_own_log(shared, &log, None).unwrap();
+        compact_own_log(shared, &log).unwrap();
         // New event lands after the first compaction.
         log.append(import("b2"), 9_999).unwrap();
-        compact_own_log(shared, &log, None).unwrap();
+        compact_own_log(shared, &log).unwrap();
 
         let snap =
             Snapshot::read_from(&shared.join("logs/dev-A.snapshot.json")).unwrap();

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -26,7 +26,6 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-use base64::Engine;
 use rusqlite::{params, Connection, Transaction};
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
@@ -711,14 +710,11 @@ pub fn compact_own_log(
 // ---------------------------------------------------------------------------
 
 fn upsert_book(tx: &Transaction, id: &str, r: &BookRow) -> AppResult<()> {
-    let cover_bytes: Option<Vec<u8>> = r.cover_data.as_ref().and_then(|b64| {
-        base64::engine::general_purpose::STANDARD.decode(b64).ok()
-    });
     tx.execute(
         "INSERT INTO books
          (id, title, author, description, cover_path, file_path, genre, pages,
-          format, status, progress, current_cfi, created_at, updated_at, updated_by_device, cover_data)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+          format, status, progress, current_cfi, created_at, updated_at, updated_by_device)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
          ON CONFLICT(id) DO UPDATE SET
            title=excluded.title,
            author=excluded.author,
@@ -731,7 +727,6 @@ fn upsert_book(tx: &Transaction, id: &str, r: &BookRow) -> AppResult<()> {
            status=excluded.status,
            progress=excluded.progress,
            current_cfi=excluded.current_cfi,
-           cover_data=COALESCE(excluded.cover_data, books.cover_data),
            updated_at=excluded.updated_at,
            updated_by_device=excluded.updated_by_device
          WHERE (books.updated_at, books.updated_by_device)
@@ -739,16 +734,9 @@ fn upsert_book(tx: &Transaction, id: &str, r: &BookRow) -> AppResult<()> {
         params![
             id, r.title, r.author, r.description, r.cover_path, r.file_path,
             r.genre, r.pages, r.format, r.status, r.progress, r.current_cfi,
-            r.created_at, r.updated_at, r.updated_by_device, cover_bytes,
+            r.created_at, r.updated_at, r.updated_by_device,
         ],
     )?;
-    // Fill cover_data from snapshot even when LWW doesn't update (same timestamp)
-    if let Some(ref bytes) = cover_bytes {
-        tx.execute(
-            "UPDATE books SET cover_data = ?1 WHERE id = ?2 AND cover_data IS NULL",
-            params![bytes, id],
-        )?;
-    }
     Ok(())
 }
 
@@ -913,15 +901,14 @@ fn upsert_replay_state(
 fn dump_state(conn: &Connection) -> AppResult<SnapshotState> {
     let mut state = SnapshotState::default();
 
-    // books
+    // books — cover_data excluded from snapshots; covers sync via .img files
     let mut stmt = conn.prepare(
         "SELECT id, title, author, description, cover_path, file_path, genre, pages,
                 format, status, progress, current_cfi,
-                created_at, updated_at, updated_by_device, cover_data
+                created_at, updated_at, updated_by_device
          FROM books",
     )?;
     let rows = stmt.query_map([], |r| {
-        let cover_blob: Option<Vec<u8>> = r.get(15)?;
         Ok((
             r.get::<_, String>(0)?,
             BookRow {
@@ -939,9 +926,7 @@ fn dump_state(conn: &Connection) -> AppResult<SnapshotState> {
                 created_at: r.get(12)?,
                 updated_at: r.get(13)?,
                 updated_by_device: r.get(14)?,
-                cover_data: cover_blob.map(|b| {
-                    base64::engine::general_purpose::STANDARD.encode(&b)
-                }),
+                cover_data: None,
             },
         ))
     })?;

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -601,6 +601,7 @@ pub fn should_compact(shared_dir: &Path, device: &str) -> bool {
 pub fn compact_own_log(
     shared_dir: &Path,
     log_handle: &EventLog,
+    live_db: Option<&Db>,
 ) -> AppResult<CompactReport> {
     let device = log_handle.device().to_string();
     let snap_path = shared_dir
@@ -637,7 +638,35 @@ pub fn compact_own_log(
             }
             tx.commit()?;
         }
-        let state = dump_state(&conn)?;
+        let mut state = dump_state(&conn)?;
+
+        // cover_data is written directly to SQLite (not through events),
+        // so the event replay above misses it. Overlay from the live DB
+        // so the compacted snapshot carries covers to peers.
+        if let Some(db) = live_db {
+            if let Ok(live_conn) = db.read_conn.lock() {
+                let mut stmt = live_conn.prepare(
+                    "SELECT id, cover_data FROM books WHERE cover_data IS NOT NULL AND LENGTH(cover_data) > 0",
+                ).ok();
+                if let Some(ref mut s) = stmt {
+                    let rows: Vec<(String, Vec<u8>)> = s
+                        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+                        .into_iter()
+                        .flatten()
+                        .flatten()
+                        .collect();
+                    for (id, bytes) in rows {
+                        if let Some(book) = state.books.get_mut(&id) {
+                            if book.cover_data.is_none() {
+                                book.cover_data = Some(
+                                    base64::engine::general_purpose::STANDARD.encode(&bytes),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         // The new snapshot's watermark is the highest event id we
         // just folded. After truncation the log is empty, so any
@@ -731,7 +760,7 @@ fn upsert_book(tx: &Transaction, id: &str, r: &BookRow) -> AppResult<()> {
            status=excluded.status,
            progress=excluded.progress,
            current_cfi=excluded.current_cfi,
-           cover_data=excluded.cover_data,
+           cover_data=COALESCE(excluded.cover_data, books.cover_data),
            updated_at=excluded.updated_at,
            updated_by_device=excluded.updated_by_device
          WHERE (books.updated_at, books.updated_by_device)
@@ -1894,7 +1923,7 @@ mod tests {
             vec![import("b1"), import("b2"), import("b3")],
         );
 
-        let report = compact_own_log(shared, &log).unwrap();
+        let report = compact_own_log(shared, &log, None).unwrap();
         assert_eq!(report.events_folded, 3);
         assert!(report.snapshot_written);
 
@@ -1917,7 +1946,7 @@ mod tests {
         let log_path = shared.join("logs/dev-A.jsonl");
         let log = EventLog::open(&log_path, "dev-A", false).unwrap();
 
-        let report = compact_own_log(shared, &log).unwrap();
+        let report = compact_own_log(shared, &log, None).unwrap();
         assert_eq!(report.events_folded, 0);
         assert!(!report.snapshot_written);
         assert!(!shared.join("logs/dev-A.snapshot.json").exists());
@@ -1930,11 +1959,11 @@ mod tests {
         std::fs::create_dir_all(shared.join("logs")).unwrap();
         let log = seed_log(shared, "dev-A", vec![import("b1"), import("b2")]);
 
-        let r1 = compact_own_log(shared, &log).unwrap();
+        let r1 = compact_own_log(shared, &log, None).unwrap();
         assert_eq!(r1.events_folded, 2);
 
         // Second run sees an empty log → no snapshot rewrite.
-        let r2 = compact_own_log(shared, &log).unwrap();
+        let r2 = compact_own_log(shared, &log, None).unwrap();
         assert_eq!(r2.events_folded, 0);
         assert!(!r2.snapshot_written);
     }
@@ -1980,7 +2009,7 @@ mod tests {
 
         // Compaction path: compact the log → snapshot, then apply the
         // snapshot to a fresh DB.
-        compact_own_log(shared, &log).unwrap();
+        compact_own_log(shared, &log, None).unwrap();
         let snap =
             Snapshot::read_from(&shared.join("logs/dev-A.snapshot.json")).unwrap();
         let mut db_via_snap = open_db();
@@ -2057,7 +2086,7 @@ mod tests {
         let snap_dst = shared.join("logs/dev-A.snapshot.json");
         std::fs::create_dir_all(&snap_dst).unwrap();
 
-        let result = compact_own_log(shared, &log);
+        let result = compact_own_log(shared, &log, None);
         assert!(
             result.is_err(),
             "compaction must propagate snapshot write failure"
@@ -2082,10 +2111,10 @@ mod tests {
         std::fs::create_dir_all(shared.join("logs")).unwrap();
         let log = seed_log(shared, "dev-A", vec![import("b1")]);
 
-        compact_own_log(shared, &log).unwrap();
+        compact_own_log(shared, &log, None).unwrap();
         // New event lands after the first compaction.
         log.append(import("b2"), 9_999).unwrap();
-        compact_own_log(shared, &log).unwrap();
+        compact_own_log(shared, &log, None).unwrap();
 
         let snap =
             Snapshot::read_from(&shared.join("logs/dev-A.snapshot.json")).unwrap();

--- a/src-tauri/src/sync/writer.rs
+++ b/src-tauri/src/sync/writer.rs
@@ -190,6 +190,35 @@ impl SyncWriter {
         }
     }
 
+    /// One-time backfill: ensure every book with `cover_data` in the DB
+    /// has a corresponding `.img` file in the covers directory. Queues
+    /// missing files to the cover-writer thread. Only needed when
+    /// upgrading from schema <13 (before covers-in-db existed).
+    pub fn backfill_cover_files(&self, db: &crate::db::Db) {
+        let Ok(data_dir) = db.data_dir.lock() else { return };
+        let covers_dir = data_dir.join("covers");
+
+        let Ok(conn) = db.read_conn.lock() else { return };
+        let Ok(mut stmt) = conn.prepare(
+            "SELECT id, cover_data FROM books WHERE cover_data IS NOT NULL AND LENGTH(cover_data) > 0",
+        ) else { return };
+        let rows: Vec<(String, Vec<u8>)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .into_iter()
+            .flatten()
+            .flatten()
+            .collect();
+        drop(stmt);
+        drop(conn);
+
+        let Ok(guard) = self.cover_tx.lock() else { return };
+        let Some(tx) = guard.as_ref() else { return };
+
+        for (id, bytes) in rows {
+            let _ = tx.send((covers_dir.join(format!("{id}.img")), bytes));
+        }
+    }
+
     /// Test/probe accessor — `true` when an `EventLog` is wired up
     /// (i.e. the post-commit flush will run, not just the queue write).
     pub fn is_sync_enabled(&self) -> bool {

--- a/src-tauri/src/sync/writer.rs
+++ b/src-tauri/src/sync/writer.rs
@@ -214,8 +214,16 @@ impl SyncWriter {
         let Ok(guard) = self.cover_tx.lock() else { return };
         let Some(tx) = guard.as_ref() else { return };
 
+        let mut queued = 0usize;
         for (id, bytes) in rows {
-            let _ = tx.send((covers_dir.join(format!("{id}.img")), bytes));
+            let path = covers_dir.join(format!("{id}.img"));
+            if !path.exists() {
+                let _ = tx.send((path, bytes));
+                queued += 1;
+            }
+        }
+        if queued > 0 {
+            log::info!("sync: queued {queued} cover file(s) for backfill");
         }
     }
 

--- a/src-tauri/src/sync/writer.rs
+++ b/src-tauri/src/sync/writer.rs
@@ -161,6 +161,22 @@ impl SyncWriter {
         *self.cover_tx.lock().expect("cover_tx mutex") = tx;
     }
 
+    pub fn spawn_cover_writer(&self) {
+        let (tx, rx) = std::sync::mpsc::channel::<(std::path::PathBuf, Vec<u8>)>();
+        std::thread::Builder::new()
+            .name("cover-writer".into())
+            .spawn(move || {
+                for (path, bytes) in rx {
+                    if let Some(parent) = path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
+                    let _ = std::fs::write(&path, &bytes);
+                }
+            })
+            .ok();
+        self.set_cover_tx(Some(tx));
+    }
+
     pub fn queue_cover_write(&self, db: &crate::db::Db, book_id: &str, bytes: &[u8]) {
         if !self.should_queue.load(Ordering::SeqCst) {
             return;

--- a/src-tauri/src/sync/writer.rs
+++ b/src-tauri/src/sync/writer.rs
@@ -103,6 +103,10 @@ pub struct SyncWriter {
     /// UI never blocks on `bird` / `NSFileCoordinator`. Tests flip it
     /// on so they can assert post-commit log state without polling.
     flush_inline_for_tests: AtomicBool,
+    /// Channel sender for the `cover-writer` background thread. Set by
+    /// `boot_sync_engine` when sync is enabled. Cover file writes go
+    /// through this channel so iCloud I/O never blocks the import path.
+    cover_tx: Mutex<Option<std::sync::mpsc::Sender<(std::path::PathBuf, Vec<u8>)>>>,
 }
 
 impl SyncWriter {
@@ -113,6 +117,7 @@ impl SyncWriter {
             should_queue: AtomicBool::new(false),
             progress_throttle: Mutex::new(HashMap::new()),
             flush_inline_for_tests: AtomicBool::new(false),
+            cover_tx: Mutex::new(None),
         }
     }
 
@@ -147,6 +152,26 @@ impl SyncWriter {
     /// launch flushes them via `ReplayEngine::tick`.
     pub fn set_should_queue(&self, queue: bool) {
         self.should_queue.store(queue, Ordering::SeqCst);
+    }
+
+    pub fn set_cover_tx(
+        &self,
+        tx: Option<std::sync::mpsc::Sender<(std::path::PathBuf, Vec<u8>)>>,
+    ) {
+        *self.cover_tx.lock().expect("cover_tx mutex") = tx;
+    }
+
+    pub fn queue_cover_write(&self, db: &crate::db::Db, book_id: &str, bytes: &[u8]) {
+        if !self.should_queue.load(Ordering::SeqCst) {
+            return;
+        }
+        let Ok(data_dir) = db.data_dir.lock() else { return };
+        let path = data_dir.join("covers").join(format!("{book_id}.img"));
+        if let Ok(guard) = self.cover_tx.lock() {
+            if let Some(tx) = guard.as_ref() {
+                let _ = tx.send((path, bytes.to_vec()));
+            }
+        }
     }
 
     /// Test/probe accessor — `true` when an `EventLog` is wired up

--- a/src/components/BookGrid.tsx
+++ b/src/components/BookGrid.tsx
@@ -62,7 +62,7 @@ export default function BookGrid({ books, hasMore, loadMore, loadingMore, active
           >
             <div className="relative bg-border rounded-lg overflow-hidden shadow-card aspect-[3/4]">
               {book.cover_data ? (
-                <CoverImage src={`data:image/png;base64,${book.cover_data}`} alt={book.title} title={book.title} />
+                <CoverImage src={book.cover_data} alt={book.title} title={book.title} />
               ) : (
                 <div className="w-full h-full flex items-center justify-center bg-bg-muted">
                   <span className="text-[14px] text-text-muted text-center px-4">

--- a/src/components/BookGrid.tsx
+++ b/src/components/BookGrid.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from "react";
-import { convertFileSrc } from "@tauri-apps/api/core";
 import { Loader2 } from "lucide-react";
 import type { Book } from "../hooks/useBooks";
 import { openReaderWindow } from "../utils/openReaderWindow";
@@ -62,8 +61,8 @@ export default function BookGrid({ books, hasMore, loadMore, loadingMore, active
             className={`text-left cursor-pointer group ${book.available === false ? "opacity-60" : ""}`}
           >
             <div className="relative bg-border rounded-lg overflow-hidden shadow-card aspect-[3/4]">
-              {book.cover_path ? (
-                <CoverImage src={convertFileSrc(book.cover_path)} alt={book.title} title={book.title} />
+              {book.cover_data ? (
+                <CoverImage src={`data:image/png;base64,${book.cover_data}`} alt={book.title} title={book.title} />
               ) : (
                 <div className="w-full h-full flex items-center justify-center bg-bg-muted">
                   <span className="text-[14px] text-text-muted text-center px-4">

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from "react";
-import { convertFileSrc } from "@tauri-apps/api/core";
 import { openReaderWindow } from "../utils/openReaderWindow";
 import { Check, CloudDownload, Loader2 } from "lucide-react";
 import type { Book } from "../hooks/useBooks";
@@ -60,8 +59,8 @@ export default function BookList({ books, hasMore, loadMore, loadingMore, active
           >
             {/* Cover */}
             <div className="relative w-[96px] h-[144px] shrink-0 rounded-lg overflow-hidden bg-border shadow-card">
-              {book.cover_path ? (
-                <CoverImage src={convertFileSrc(book.cover_path)} alt={book.title} title={book.title} />
+              {book.cover_data ? (
+                <CoverImage src={`data:image/png;base64,${book.cover_data}`} alt={book.title} title={book.title} />
               ) : (
                 <div className="w-full h-full flex items-center justify-center bg-bg-muted">
                   <span className="text-[10px] text-text-muted text-center px-1">

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -60,7 +60,7 @@ export default function BookList({ books, hasMore, loadMore, loadingMore, active
             {/* Cover */}
             <div className="relative w-[96px] h-[144px] shrink-0 rounded-lg overflow-hidden bg-border shadow-card">
               {book.cover_data ? (
-                <CoverImage src={`data:image/png;base64,${book.cover_data}`} alt={book.title} title={book.title} />
+                <CoverImage src={book.cover_data} alt={book.title} title={book.title} />
               ) : (
                 <div className="w-full h-full flex items-center justify-center bg-bg-muted">
                   <span className="text-[10px] text-text-muted text-center px-1">

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -18,6 +18,7 @@ export interface Book {
   created_at: number;
   updated_at: number;
   available: boolean;
+  cover_data: string | null;
 }
 
 interface BookPage {
@@ -44,10 +45,7 @@ export function useBooks(filter?: string, search?: string, collectionId?: string
         cursor: null,
         limit: null,
       });
-      setBooks(page.books.map((b) => ({
-        ...b,
-        cover_path: b.cover_path === "none" ? null : b.cover_path,
-      })));
+      setBooks(page.books);
       setTotal(page.total);
       setCursor(page.next_cursor);
       setHasMore(page.next_cursor !== null);
@@ -69,13 +67,7 @@ export function useBooks(filter?: string, search?: string, collectionId?: string
         cursor,
         limit: null,
       });
-      setBooks((prev) => [
-        ...prev,
-        ...page.books.map((b) => ({
-          ...b,
-          cover_path: b.cover_path === "none" ? null : b.cover_path,
-        })),
-      ]);
+      setBooks((prev) => [...prev, ...page.books]);
       setCursor(page.next_cursor);
       setHasMore(page.next_cursor !== null);
     } catch (err) {
@@ -137,7 +129,7 @@ const BACKFILL_DELAY_MS = 1000;
 let backfillRunning = false;
 
 function needsCover(b: Book): boolean {
-  return b.format === "pdf" && !b.cover_path;
+  return b.format === "pdf" && !b.cover_data && b.cover_path !== "none";
 }
 
 export async function backfillMissingCovers(): Promise<void> {
@@ -182,9 +174,7 @@ export async function backfillMissingCovers(): Promise<void> {
 }
 
 export async function getBook(id: string): Promise<Book> {
-  const b = await invoke<Book>("get_book", { id });
-  if (b.cover_path === "none") b.cover_path = null;
-  return b;
+  return invoke<Book>("get_book", { id });
 }
 
 export async function deleteBook(id: string): Promise<void> {

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -124,40 +124,40 @@ async function importPdfStaged(filePath: string): Promise<Book> {
 
 export const importBookDialog = { pickFile, importFile };
 
+interface CoverBackfillEntry {
+  id: string;
+  file_path: string;
+}
+
 const BACKFILL_BATCH_SIZE = 3;
 const BACKFILL_DELAY_MS = 1000;
 let backfillRunning = false;
-
-function needsCover(b: Book): boolean {
-  return b.format === "pdf" && !b.cover_data && b.cover_path !== "none";
-}
 
 export async function backfillMissingCovers(): Promise<void> {
   if (backfillRunning) return;
   backfillRunning = true;
   try {
-    const page = await invoke<BookPage>("list_books", { filter: null, search: null, cursor: null, limit: 1000 });
-    const missing = page.books.filter(needsCover);
+    const missing = await invoke<CoverBackfillEntry[]>("list_books_needing_covers");
     if (missing.length === 0) {
       backfillRunning = false;
       return;
     }
     const batch = missing.slice(0, BACKFILL_BATCH_SIZE);
     const { extractPdfCover } = await import("../utils/pdfMetadata");
-    for (const book of batch) {
+    for (const entry of batch) {
       try {
-        const coverData = await extractPdfCover(book.file_path);
+        const coverData = await extractPdfCover(entry.file_path);
         if (coverData) {
           await invoke("save_book_cover", {
-            bookId: book.id,
+            bookId: entry.id,
             coverData: Array.from(coverData),
           });
         } else {
-          await invoke("mark_cover_unavailable", { bookId: book.id });
+          await invoke("mark_cover_unavailable", { bookId: entry.id });
         }
       } catch (err) {
-        console.warn(`Cover backfill failed for ${book.id}:`, err);
-        await invoke("mark_cover_unavailable", { bookId: book.id }).catch(() => {});
+        console.warn(`Cover backfill failed for ${entry.id}:`, err);
+        await invoke("mark_cover_unavailable", { bookId: entry.id }).catch(() => {});
       }
     }
     if (missing.length > BACKFILL_BATCH_SIZE) {


### PR DESCRIPTION
## Summary

- Store cover images as `cover_data BLOB` in the `books` table instead of files in `covers/` directory
- Migration 013 adds the column; startup backfill reads existing cover files into DB
- Frontend renders covers via `data:image/png;base64,...` data URIs — no more `convertFileSrc` or asset protocol for covers
- Sync snapshots include `cover_data` so peers get covers immediately without iCloud file downloads
- Removes `trigger_cover_downloads` and cover file I/O from import/save/delete paths

## Test plan

- [ ] Fresh install: import EPUB with cover → cover renders from DB
- [ ] Fresh install: import PDF, backfill cover → cover renders
- [ ] Upgrade from v1.1.6: existing covers backfilled from disk into DB on first launch
- [ ] Synced device: books show covers immediately after snapshot apply (no iCloud download needed)
- [ ] Grid view and list view both render covers correctly
- [ ] Delete book → no orphan cover files
- [ ] PDF without cover → "no cover" placeholder shown, backfill marks unavailable

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)