### PR TITLE
feat: auto-refresh library grid when synced covers land (#246)

### DIFF
--- a/docs/impls/246-download-progress.md
+++ b/docs/impls/246-download-progress.md
@@ -1,0 +1,103 @@
+# 246 — Download Feedback for iCloud-Evicted Books
+
+Issue: https://github.com/yicheng47/quill/issues/246
+
+## Problem
+
+When a user enables sync on a fresh device, book metadata arrives quickly via the event log, but the binaries (cover images, EPUB/PDF files) live in the iCloud Documents container and arrive as evicted placeholders (`.‹name›.icloud`). Two symptoms follow.
+
+**1. The library grid shows blank cover cards that never fill in on their own.** This is the live bug. Covers already sync correctly at the data layer — `ingest_peer_covers` (`src-tauri/src/sync/replay.rs`) runs every replay tick, eagerly triggers `startDownloadingUbiquitousItemAtURL` for any evicted `covers/‹id›.img` placeholder, and on a later tick reads the materialized bytes into the `cover_data` BLOB. The frontend renders covers from that BLOB. The gap is purely the refresh signal: only the **initial** sync tick emits a frontend event (`sync-initial-tick-done`), and covers are almost never ingested on that first tick — they're still placeholders that were *just* triggered for download. They land on subsequent **watcher** ticks, and watcher ticks emit nothing. So the grid keeps showing title-only placeholder cards until the user manually navigates or relaunches, even though the covers are sitting in the DB.
+
+**2. Opening a not-yet-downloaded book shows an indeterminate spinner with no progress.** `check_book_available` (`books.rs`) triggers the download and `Reader.tsx` polls every 2s, showing a spinner ("Downloading from iCloud…") with a 60s timeout. It works, but gives no sense of how long the wait will be.
+
+### Scope decision
+
+- **Fix symptom 1 now** — small, high-value, fixes the headline complaint.
+- **Defer symptom 2's progress bar.** A real percentage is only obtainable from `NSMetadataQuery` + `NSMetadataUbiquitousItemPercentDownloadedKey`: iCloud materializes an evicted file atomically (placeholder → full file in one swap), so there's no partial file on disk to measure, and `NSURL` resource keys expose only a binary downloading *status*, not a percent. Bridging `NSMetadataQuery` from Rust needs a notification observer on a thread with a live run loop — meaningful `unsafe` objc2 work for a download that's usually only seconds long, where the spinner already covers the case. Documented in "Deferred" below so the design isn't lost.
+
+## Fix
+
+Emit a frontend event whenever a replay tick ingests one or more covers, and refresh the library grid when it fires. Because the grid renders from the `cover_data` BLOB and `list_books` already selects that column, a plain refresh re-renders the covers — no new query or data path needed.
+
+### Backend
+
+**`ReplayEngine` holds an optional `AppHandle`** (`src-tauri/src/sync/replay.rs`). This is deliberately separate from the `app_handle` parameter already threaded into `tick_with_progress`: that parameter drives the `sync-progress` modal and is `None` for watcher ticks (per the 236 design, watcher ticks are silent for the modal). Covers land precisely *on* watcher ticks, so the cover event must come from a handle the engine owns, independent of the modal path.
+
+```rust
+pub struct ReplayEngine {
+    pub shared_dir: PathBuf,
+    pub self_device: String,
+    pub own_log: Arc<EventLog>,
+    app_handle: Option<tauri::AppHandle>,   // NEW — for non-modal emits
+    cancelled: std::sync::atomic::AtomicBool,
+}
+
+impl ReplayEngine {
+    // `new` keeps its current signature (tests construct it with no handle).
+    pub fn with_app_handle(mut self, handle: tauri::AppHandle) -> Self {
+        self.app_handle = Some(handle);
+        self
+    }
+}
+```
+
+In `tick_with_progress`, after the existing `ingest_peer_covers` call, emit when it ingested anything:
+
+```rust
+let covers_ingested = ingest_peer_covers(&self.shared_dir, db);
+if covers_ingested > 0 {
+    if let Some(handle) = &self.app_handle {
+        let _ = handle.emit("sync-covers-ingested", covers_ingested);
+    }
+}
+```
+
+`ingest_peer_covers` itself is unchanged — it already returns the count and already triggers placeholder downloads.
+
+**Set the handle at both engine construction sites:**
+
+- `boot_sync_engine` (`src-tauri/src/lib.rs`) — has `app_handle: &tauri::AppHandle`; build with `ReplayEngine::new(...).with_app_handle(app_handle.clone())`.
+- `sync_enable` (`src-tauri/src/commands/sync.rs`) — has `app: tauri::AppHandle`; same.
+
+### Frontend
+
+**`Home.tsx`** — add a listener mirroring the existing debounced `mcp:books-changed` handler. Covers fill in over a few watcher ticks, so debounce coalesces the burst into one reload.
+
+```ts
+useEffect(() => {
+  let debounce: ReturnType<typeof setTimeout> | null = null;
+  const unlisten = listen("sync-covers-ingested", () => {
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(() => refreshRef.current(), 500);
+  });
+  return () => {
+    if (debounce) clearTimeout(debounce);
+    unlisten.then((fn) => fn());
+  };
+}, []);
+```
+
+Only the book list needs refreshing — cover ingestion changes no counts or collections, so this does not call the counts/collections refreshers.
+
+No i18n changes (no new user-facing strings) and no Reader changes (the spinner stays).
+
+### Tests
+
+`src-tauri/src/sync/replay.rs` — add a focused test for `ingest_peer_covers` (currently untested): seed a book row with `NULL cover_data`, write `covers/‹id›.img`, assert the BLOB is populated and the return count is 1; and a placeholder-only case returns 0 (download is triggered, ingestion deferred to the next tick). The emit path isn't unit-tested — `AppHandle` isn't constructible in unit tests, and the engine is built with no handle there, so the emit is simply skipped.
+
+## Deferred — book download progress bar (symptom 2)
+
+Sketch for a future pass, not built here:
+
+- Enable `objc2-foundation` features `NSMetadata`, `NSNotification`, `NSPredicate` (`block2` is already on).
+- On book open, start one `NSMetadataQuery` scoped to `NSMetadataQueryUbiquitousDataScope`, predicate matched to the file name, on a thread with a running `CFRunLoop`.
+- Observe `NSMetadataQueryDidUpdateNotification` (block-based observer), read `NSMetadataUbiquitousItemPercentDownloadedKey`, emit `book-download-progress { book_id, percent }`.
+- Tear the query down on completion, timeout, or reader-window close.
+- Reader replaces the indeterminate spinner with a determinate bar driven by the event.
+
+## Verification
+
+1. Fresh device, enable sync with a multi-book library: books appear with blank cover cards, then covers fill in automatically within a tick or two — no manual navigation/relaunch.
+2. `sync-progress` modal still behaves as before (no regression from the new engine field).
+3. `cargo test` passes, including the new `ingest_peer_covers` test.
+4. Local-only (sync off) and single-device users see no behavior change.

--- a/docs/impls/246-download-progress.md
+++ b/docs/impls/246-download-progress.md
@@ -59,6 +59,8 @@ if covers_ingested > 0 {
 - `boot_sync_engine` (`src-tauri/src/lib.rs`) — has `app_handle: &tauri::AppHandle`; build with `ReplayEngine::new(...).with_app_handle(app_handle.clone())`.
 - `sync_enable` (`src-tauri/src/commands/sync.rs`) — has `app: tauri::AppHandle`; same.
 
+**Watch `covers/` so cover arrivals actually wake the engine** (`src-tauri/src/sync/watcher.rs`). This is load-bearing: `ingest_peer_covers` only runs inside a tick, ticks fire only on watched fs events, and there is no periodic tick. The watcher previously watched `logs/` only — so a cover file materializing under `covers/` triggered nothing, and the emit above would never fire until some unrelated `logs/` event, a manual sync, or a relaunch. The fix adds a second non-recursive watch on `covers/` and broadens the event filter (`is_log_event` → `is_relevant_event`) to also tick on `.img` (a cover materialized → ingest) and `.icloud` (a placeholder appeared → trigger its download). Without this, the steady-state "peer adds one book while I'm running" case leaves a blank card for the whole session.
+
 ### Frontend
 
 **`Home.tsx`** — add a listener mirroring the existing debounced `mcp:books-changed` handler. Covers fill in over a few watcher ticks, so debounce coalesces the burst into one reload.

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -236,11 +236,14 @@ pub fn sync_enable(
         .join(format!("{}.jsonl", device.device_uuid));
     let log = Arc::new(EventLog::open(&log_path, &device.device_uuid, true)?);
 
-    let engine = Arc::new(ReplayEngine::new(
-        icloud_dir.clone(),
-        device.device_uuid.clone(),
-        Arc::clone(&log),
-    ));
+    let engine = Arc::new(
+        ReplayEngine::new(
+            icloud_dir.clone(),
+            device.device_uuid.clone(),
+            Arc::clone(&log),
+        )
+        .with_app_handle(app.clone()),
+    );
 
     // Watcher spawn is the most likely failure point — do it before
     // any durable write. If it fails, we abort cleanly; the log file

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -255,11 +255,14 @@ fn boot_sync_engine(
     let log_path = shared_dir.join("logs").join(format!("{device_uuid}.jsonl"));
     let log = Arc::new(EventLog::open(&log_path, device_uuid, true)?);
 
-    let engine = Arc::new(ReplayEngine::new(
-        shared_dir.clone(),
-        device_uuid.to_string(),
-        Arc::clone(&log),
-    ));
+    let engine = Arc::new(
+        ReplayEngine::new(
+            shared_dir.clone(),
+            device_uuid.to_string(),
+            Arc::clone(&log),
+        )
+        .with_app_handle(app_handle.clone()),
+    );
 
     let watcher = sync::watcher::spawn(
         shared_dir,

--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -148,6 +148,12 @@ pub struct ReplayEngine {
     /// Own log handle, shared with `SyncWriter`. `tick()` writes here when
     /// flushing the outbox.
     pub own_log: Arc<EventLog>,
+    /// Handle for emitting non-modal frontend events (e.g.
+    /// `sync-covers-ingested`) from any tick — including the silent
+    /// watcher ticks where covers actually land. Deliberately separate
+    /// from `tick_with_progress`'s `app_handle` parameter, which drives
+    /// the `sync-progress` modal and is `None` for watcher ticks.
+    app_handle: Option<tauri::AppHandle>,
     /// Set to `true` by `cancel()` to abort an in-flight tick early.
     /// Checked between events in Phase C so a `sync_disable` doesn't
     /// have to wait for a long replay to finish.
@@ -160,8 +166,16 @@ impl ReplayEngine {
             shared_dir,
             self_device,
             own_log,
+            app_handle: None,
             cancelled: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// Attach an `AppHandle` so ticks can emit non-modal frontend events.
+    /// Set at both engine boot sites (`boot_sync_engine`, `sync_enable`).
+    pub fn with_app_handle(mut self, handle: tauri::AppHandle) -> Self {
+        self.app_handle = Some(handle);
+        self
     }
 
     /// Signal any in-flight tick to stop after the current event.
@@ -231,6 +245,16 @@ impl ReplayEngine {
             })?;
 
         let covers_ingested = ingest_peer_covers(&self.shared_dir, db);
+        if covers_ingested > 0 {
+            // Covers land on watcher ticks (the placeholder triggered for
+            // download a tick or two earlier), which pass `None` for the
+            // modal `app_handle`. Use the engine-held handle so the grid
+            // refreshes when covers fill in — otherwise blank cards persist
+            // until the user navigates or relaunches.
+            if let Some(handle) = &self.app_handle {
+                let _ = handle.emit("sync-covers-ingested", covers_ingested);
+            }
+        }
 
         if events_applied > 0 || snapshots_applied > 0 || outbox_flushed > 0 || covers_ingested > 0 {
             ::log::info!(
@@ -1360,6 +1384,84 @@ mod tests {
             !is_in_flight(&log_path),
             "in-flight should be cleared after successful read",
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Cover ingestion
+    // -----------------------------------------------------------------------
+
+    fn insert_book_no_cover(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO books
+             (id, title, author, file_path, format, status, progress, created_at, updated_at, updated_by_device)
+             VALUES (?1, 'T', 'A', 'books/x.epub', 'epub', 'unread', 0, 1, 1, 'peer-A')",
+            params![id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn ingest_peer_covers_reads_file_into_blob() {
+        let env = setup("self");
+        insert_book_no_cover(&env.conn(), "b1");
+
+        let covers = env.shared.join("covers");
+        fs::create_dir_all(&covers).unwrap();
+        fs::write(covers.join("b1.img"), b"\x89PNG fake cover bytes").unwrap();
+
+        let ingested = ingest_peer_covers(&env.shared, &env.db);
+        assert_eq!(ingested, 1, "the one new cover file should be ingested");
+
+        let blob: Vec<u8> = env
+            .conn()
+            .query_row("SELECT cover_data FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(blob, b"\x89PNG fake cover bytes");
+    }
+
+    #[test]
+    fn ingest_peer_covers_skips_books_that_already_have_a_blob() {
+        let env = setup("self");
+        {
+            let conn = env.conn();
+            insert_book_no_cover(&conn, "b1");
+            conn.execute("UPDATE books SET cover_data = ?1 WHERE id = 'b1'", params![b"existing"])
+                .unwrap();
+        }
+
+        let covers = env.shared.join("covers");
+        fs::create_dir_all(&covers).unwrap();
+        fs::write(covers.join("b1.img"), b"newer bytes").unwrap();
+
+        let ingested = ingest_peer_covers(&env.shared, &env.db);
+        assert_eq!(ingested, 0, "a book that already has a cover BLOB is left untouched");
+
+        let blob: Vec<u8> = env
+            .conn()
+            .query_row("SELECT cover_data FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(blob, b"existing", "existing BLOB must not be overwritten");
+    }
+
+    #[test]
+    fn ingest_peer_covers_defers_placeholder_only_covers() {
+        let env = setup("self");
+        insert_book_no_cover(&env.conn(), "b1");
+
+        // Only an iCloud placeholder exists — the real .img isn't materialized
+        // yet. Ingestion triggers a download and defers to a later tick.
+        let covers = env.shared.join("covers");
+        fs::create_dir_all(&covers).unwrap();
+        fs::write(covers.join(".b1.img.icloud"), b"placeholder").unwrap();
+
+        let ingested = ingest_peer_covers(&env.shared, &env.db);
+        assert_eq!(ingested, 0, "placeholder-only cover is deferred, not ingested");
+
+        let blob: Option<Vec<u8>> = env
+            .conn()
+            .query_row("SELECT cover_data FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert!(blob.is_none(), "no bytes should be written from a placeholder");
     }
 
 }

--- a/src-tauri/src/sync/watcher.rs
+++ b/src-tauri/src/sync/watcher.rs
@@ -81,8 +81,14 @@ impl Drop for WatcherHandle {
     }
 }
 
-/// Spawn the watcher. Watches `shared_dir/logs/` non-recursively (own
-/// log + peer logs + snapshots are all flat in there).
+/// Spawn the watcher. Watches `shared_dir/logs/` (own log + peer logs +
+/// snapshots) and `shared_dir/covers/` (synced cover images), both
+/// non-recursively — each dir is flat. Covers are watched because peer
+/// cover files (and their iCloud placeholders) materialize independently
+/// of any `logs/` event: a cover that lands after its book's log event
+/// would otherwise never trigger the tick that ingests it, leaving a
+/// blank card until some unrelated `logs/` change, a manual sync, or a
+/// relaunch.
 ///
 /// The closure inside the dedicated thread holds `Arc<Db>` and
 /// `Arc<ReplayEngine>`. It locks `db.conn` only for the duration of one
@@ -99,6 +105,8 @@ pub fn spawn(
 ) -> AppResult<WatcherHandle> {
     let logs_dir = shared_dir.join("logs");
     std::fs::create_dir_all(&logs_dir)?;
+    let covers_dir = shared_dir.join("covers");
+    std::fs::create_dir_all(&covers_dir)?;
 
     let (tx, rx) = mpsc::channel();
     let mut watcher = recommended_watcher(move |res: notify::Result<notify::Event>| {
@@ -113,6 +121,9 @@ pub fn spawn(
     watcher
         .watch(&logs_dir, RecursiveMode::NonRecursive)
         .map_err(|e| AppError::Other(format!("notify watch {logs_dir:?}: {e}")))?;
+    watcher
+        .watch(&covers_dir, RecursiveMode::NonRecursive)
+        .map_err(|e| AppError::Other(format!("notify watch {covers_dir:?}: {e}")))?;
 
     let stop = Arc::new(AtomicBool::new(false));
     let stop_thread = Arc::clone(&stop);
@@ -147,10 +158,10 @@ fn run_loop(
             Err(mpsc::RecvTimeoutError::Disconnected) => return,
         };
         // Filter out unrelated events early — saves a tick on noisy
-        // file managers. We tick on any change inside `logs/`; the
-        // engine's watermarks make it cheap to re-tick when nothing
-        // actually moved.
-        if !is_log_event(&first) {
+        // file managers. We tick on any log/snapshot/cover change; the
+        // engine's watermarks (and `ingest_peer_covers`' has-cover guard)
+        // make it cheap to re-tick when nothing actually moved.
+        if !is_relevant_event(&first) {
             continue;
         }
 
@@ -186,13 +197,23 @@ fn run_loop(
 
 /// True if this fs event is interesting enough to trigger a tick.
 /// `notify` reports a lot of noise on macOS (mod time bumps from
-/// Spotlight, Finder previews, etc.); we only care about events that
-/// touch a `.jsonl` or `.snapshot.json` file directly.
-fn is_log_event(ev: &notify::Event) -> bool {
+/// Spotlight, Finder previews, etc.); we only tick on files we actually
+/// consume across the two watched dirs:
+///   - `.jsonl` / `.snapshot.json` — peer event logs and snapshots
+///   - `.img` — a cover file materialized, so `ingest_peer_covers` can
+///     read it into the `cover_data` BLOB
+///   - `.icloud` — a placeholder appeared (log or cover); ticking lets
+///     the engine trigger its download so the real file follows
+fn is_relevant_event(ev: &notify::Event) -> bool {
     ev.paths.iter().any(|p| {
         p.extension()
             .and_then(|e| e.to_str())
-            .map(|ext| ext.eq_ignore_ascii_case("jsonl") || ext.eq_ignore_ascii_case("json"))
+            .map(|ext| {
+                ext.eq_ignore_ascii_case("jsonl")
+                    || ext.eq_ignore_ascii_case("json")
+                    || ext.eq_ignore_ascii_case("img")
+                    || ext.eq_ignore_ascii_case("icloud")
+            })
             .unwrap_or(false)
             || is_snapshot_path(p)
     })
@@ -348,22 +369,69 @@ mod tests {
     }
 
     #[test]
-    fn is_log_event_filters_irrelevant_paths() {
-        let mut ev = notify::Event::new(notify::EventKind::Modify(
+    fn is_relevant_event_filters_irrelevant_paths() {
+        let base = notify::Event::new(notify::EventKind::Modify(
             notify::event::ModifyKind::Data(notify::event::DataChange::Content),
         ));
-        ev.paths.push(PathBuf::from("/tmp/random.txt"));
-        assert!(!is_log_event(&ev));
+        let relevant = |p: &str| {
+            let mut ev = base.clone();
+            ev.paths.clear();
+            ev.paths.push(PathBuf::from(p));
+            is_relevant_event(&ev)
+        };
 
-        let mut ev2 = ev.clone();
-        ev2.paths.clear();
-        ev2.paths.push(PathBuf::from("/shared/logs/peer.jsonl"));
-        assert!(is_log_event(&ev2));
+        assert!(!relevant("/tmp/random.txt"));
+        assert!(relevant("/shared/logs/peer.jsonl"));
+        assert!(relevant("/shared/logs/peer.snapshot.json"));
+        // Cover files and placeholders under covers/ must wake the engine.
+        assert!(relevant("/shared/covers/b1.img"));
+        assert!(relevant("/shared/covers/.b1.img.icloud"));
+        // A log placeholder materializing also counts.
+        assert!(relevant("/shared/logs/.peer.jsonl.icloud"));
+    }
 
-        let mut ev3 = ev.clone();
-        ev3.paths.clear();
-        ev3.paths.push(PathBuf::from("/shared/logs/peer.snapshot.json"));
-        assert!(is_log_event(&ev3));
+    /// End-to-end: a cover file landing under `covers/` (no `logs/` event
+    /// at all) must trigger a tick that ingests it into the `cover_data`
+    /// BLOB. Regression for PR #253's review: the watcher previously only
+    /// watched `logs/`, so a cover materializing was invisible.
+    #[test]
+    fn watcher_picks_up_cover_writes() {
+        let shared_dir = TempDir::new().unwrap();
+        let (engine, _logs_dir) = make_engine(shared_dir.path(), "self");
+        let (_db_tmp, db) = make_db();
+
+        // A book with no cover yet (as if its import event already synced).
+        db.conn
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO books
+                 (id, title, author, file_path, format, status, progress, created_at, updated_at, updated_by_device)
+                 VALUES ('b1', 'T', 'A', 'books/b1.epub', 'epub', 'unread', 0, 1, 1, 'peer-A')",
+                [],
+            )
+            .unwrap();
+
+        let covers_dir = shared_dir.path().join("covers");
+        fs::create_dir_all(&covers_dir).unwrap();
+
+        let handle = spawn(shared_dir.path().to_path_buf(), db.clone(), engine).unwrap();
+        thread::sleep(Duration::from_millis(100));
+
+        fs::write(covers_dir.join("b1.img"), b"\x89PNG cover bytes").unwrap();
+        handle.drain_for_test(Duration::from_millis(1500));
+
+        let blob: Option<Vec<u8>> = db
+            .conn
+            .lock()
+            .unwrap()
+            .query_row("SELECT cover_data FROM books WHERE id = 'b1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            blob.as_deref(),
+            Some(b"\x89PNG cover bytes".as_slice()),
+            "a cover landing under covers/ should be ingested by the watcher tick",
+        );
     }
 
     /// Constructing a watcher should not hang on a missing logs dir —

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -170,6 +170,22 @@ export default function Home() {
     };
   }, []);
 
+  // Covers arrive a tick or two after the books they belong to (the sync
+  // engine triggers their iCloud download, then ingests the bytes into the
+  // cover_data BLOB on a later watcher tick). Refresh so blank cover cards
+  // fill in on their own. Debounced: covers land in bursts.
+  useEffect(() => {
+    let coverDebounce: ReturnType<typeof setTimeout> | null = null;
+    const unlisten = listen("sync-covers-ingested", () => {
+      if (coverDebounce) clearTimeout(coverDebounce);
+      coverDebounce = setTimeout(() => refreshRef.current(), 500);
+    });
+    return () => {
+      if (coverDebounce) clearTimeout(coverDebounce);
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
   // Listen for Tauri file drag-and-drop events
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Problem

On a fresh device, book metadata syncs in quickly, but covers arrive as evicted iCloud placeholders. They download and ingest into the `cover_data` BLOB on **watcher ticks a moment after** the initial sync — and those background ticks emitted no frontend event. Only the *initial* tick emits one (`sync-initial-tick-done`), and covers are almost never ingested on that first pass (they're placeholders just triggered for download). Result: books appear but their cover cards stay blank until the user navigates away and back, or relaunches. This is the "library grid shows blank cover cards" symptom in #246.

## Fix

- **Backend** (`sync/replay.rs`): `ReplayEngine` gains an optional `AppHandle` (`.with_app_handle()`, set at both boot sites — `boot_sync_engine` and `sync_enable`). After `ingest_peer_covers`, the tick emits `sync-covers-ingested` when it ingests ≥1 cover. This handle is deliberately separate from `tick_with_progress`'s modal handle, which is `None` on the silent watcher ticks where covers actually land.
- **Frontend** (`Home.tsx`): a debounced `sync-covers-ingested` listener refreshes the book list. The grid renders from the `cover_data` BLOB that `list_books` already selects, so a plain refresh re-renders the now-present covers — no new data path.
- **Tests**: 3 new unit tests for the previously-untested `ingest_peer_covers` (file→BLOB, skip-existing-BLOB, defer-placeholder).

## Scope note

The `NSMetadataQuery` download-progress **bar** from the issue is **deferred** — see `docs/impls/246-download-progress.md` for the rationale (iCloud materializes files atomically, so a real percent needs an `NSMetadataQuery` run-loop bridge, heavy for a seconds-long download where the existing spinner already covers the case) and a design sketch for a future pass. The reader's spinner is unchanged. So this **partially addresses** #246; leaving the issue open for the progress bar.

## Verification

- `cargo test sync::` → 140 passed, 0 failed
- `tsc --noEmit` → clean
- Not yet verified live on a two-device iCloud pair (logic is unit-tested; end-to-end timing best confirmed on-device).

Refs #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)