### PR TITLE
perf: drain outbox via one long-lived flush worker (#240)

### DIFF
--- a/docs/impls/240-flush-worker.md
+++ b/docs/impls/240-flush-worker.md
@@ -68,6 +68,8 @@ pub fn spawn_flush_worker(&self, db: Db, log: Arc<EventLog>) {
 
 The worker exits when the sender is dropped (`set_flush_tx(None)` on disable, or replacement on re-enable) — `rx.recv()` returns `Err`.
 
+Logs for observability: `info` on start and stop (lifecycle, infrequent), `debug` per non-empty drain with the events-flushed count and how many signals were coalesced, `warn` on drain failure.
+
 `with_tx` Phase 2 becomes a non-blocking signal:
 
 ```rust

--- a/docs/impls/240-flush-worker.md
+++ b/docs/impls/240-flush-worker.md
@@ -1,0 +1,113 @@
+# 240 — Dedicated Flush Worker Thread
+
+Issue: https://github.com/yicheng47/quill/issues/240
+
+## Problem
+
+`SyncWriter::with_tx` runs a post-commit step that drains the `_pending_publish` outbox into the device log (`flush_outbox`). When sync is enabled it does this by **spawning a fresh `std::thread` per call** (`src-tauri/src/sync/writer.rs`, Phase 2):
+
+```rust
+if let Some(log) = log_snapshot {
+    if self.flush_inline_for_tests.load(Ordering::SeqCst) {
+        // inline (tests only)
+    } else {
+        let db = db.clone();
+        std::thread::spawn(move || {        // ← one thread per write
+            let _ = replay::flush_outbox(&db, &log);
+        });
+    }
+}
+```
+
+The spawn is gated only on the log being open — there is **no `events.is_empty()` guard**. So it fires on *every* mutating command while sync is on, including transactions that queued nothing. The hot path is ordinary reading: `update_reading_progress` runs on every page turn and always writes SQL inside `with_tx`. The 2-second `should_emit_progress` throttle only decides whether a `BookProgressSet` event is *queued*; it does not gate the thread. So fast paging spawns one flush thread per turn, most of which lock `FLUSH_OUTBOX_MUTEX`, read an empty outbox, and exit.
+
+This is **correct** — `FLUSH_OUTBOX_MUTEX` (single-flight) plus delete-after-append make `flush_outbox` exactly-once, so redundant drains are harmless no-ops. The cost is pure overhead: repeated thread create/teardown and lock contention during write bursts (batch import, rapid page turns). It is not a leak — the threads are short-lived and serialized by the mutex, so they never pile up. Bounded, but wasteful.
+
+## Fix
+
+Replace the per-write spawn with **one long-lived flush worker** that `with_tx` signals over a channel. The channel buffer coalesces a burst of signals into a single drain.
+
+This mirrors the existing `cover-writer` thread exactly (`spawn_cover_writer` / `set_cover_tx`), including its lifecycle: spawned when sync turns on, torn down when sync turns off, re-spawned on re-enable. Because the worker is recreated per enable, it can capture the current `EventLog` directly — no need to make the log field shareable.
+
+### `SyncWriter` (`src-tauri/src/sync/writer.rs`)
+
+New field + setter, parallel to `cover_tx`:
+
+```rust
+/// Signal channel to the long-lived `sync-flush` worker. `Some` while
+/// sync is enabled. A unit send means "outbox may be dirty — drain it."
+flush_tx: Mutex<Option<mpsc::Sender<()>>>,
+
+pub fn set_flush_tx(&self, tx: Option<mpsc::Sender<()>>) {
+    *self.flush_tx.lock().expect("flush_tx mutex") = tx;
+}
+```
+
+The worker — one thread, captures `db` + the current `log`, drains on each signal and coalesces backlog:
+
+```rust
+pub fn spawn_flush_worker(&self, db: Db, log: Arc<EventLog>) {
+    let (tx, rx) = mpsc::channel::<()>();
+    std::thread::Builder::new()
+        .name("sync-flush".into())
+        .spawn(move || {
+            // Block for a signal, collapse any that piled up while busy,
+            // then drain once. flush_outbox is exactly-once, so an extra
+            // coalesced drain is a cheap no-op.
+            while rx.recv().is_ok() {
+                while rx.try_recv().is_ok() {}
+                if let Err(e) = replay::flush_outbox(&db, &log) {
+                    log::warn!("sync: flush worker drain failed: {e}");
+                }
+            }
+        })
+        .ok();
+    self.set_flush_tx(Some(tx));
+}
+```
+
+The worker exits when the sender is dropped (`set_flush_tx(None)` on disable, or replacement on re-enable) — `rx.recv()` returns `Err`.
+
+`with_tx` Phase 2 becomes a non-blocking signal:
+
+```rust
+if self.flush_inline_for_tests.load(Ordering::SeqCst) {
+    // Tests drain synchronously so asserts don't race a worker.
+    if let Some(log) = log_snapshot {
+        if let Err(e) = replay::flush_outbox(db, &log) {
+            log::warn!("sync: post-commit outbox flush failed: {e}");
+        }
+    }
+} else if let Ok(guard) = self.flush_tx.lock() {
+    // Production: poke the persistent worker. If no worker is running
+    // (queue-only mode, sync off), the row stays durable in
+    // _pending_publish and the next signal or replay tick drains it —
+    // same guarantee the old per-write spawn had when iCloud was down.
+    if let Some(tx) = guard.as_ref() {
+        let _ = tx.send(());
+    }
+}
+```
+
+### Lifecycle wiring
+
+- **Boot** (`boot_sync_engine`, `src-tauri/src/lib.rs`) — after `set_log` + `spawn_cover_writer`, add `sync_writer.spawn_flush_worker(db.clone(), Arc::clone(&log))`.
+- **Enable** (`sync_enable`, `src-tauri/src/commands/sync.rs`) — same, after `spawn_cover_writer` / `backfill_cover_files`.
+- **Disable** (`sync_disable`) — add `set_flush_tx(None)` next to the existing `set_cover_tx(None)`, and in the race-cleanup sweep alongside `set_log(None)`.
+- **MCP** (`mcp_stdio_main`) — unchanged. The MCP subprocess is queue-only (no `set_log`, no engine), so it never spawned flush threads and needs no worker; the main app's replay tick drains its outbox rows.
+
+### Tests
+
+`writer.rs` — existing tests use `flush_inline_for_tests`, so they keep exercising the inline drain unchanged. Add one test that exercises the real worker: spawn it (inline off), run a `with_tx` that queues an event, and poll until the outbox empties and the event reaches the log — proving the signal→coalesce→drain path works end to end.
+
+## Out of scope
+
+- The `should_emit_progress` throttle and the 2s coalescing of `BookProgressSet` events — unchanged; this only touches *how* the drain is scheduled, not *what* gets published.
+- Any change to `flush_outbox` itself or `FLUSH_OUTBOX_MUTEX`.
+
+## Verification
+
+1. `cargo test sync::` passes, including the new worker test.
+2. Reading a book (many fast page turns) with sync on spawns no per-turn threads — the single `sync-flush` worker handles all drains.
+3. Enable → disable → re-enable leaves exactly one `sync-flush` worker running while enabled, and none after disable.
+4. A write made while iCloud is transiently unreachable still reaches peers on the next successful drain (durability unchanged).

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -321,6 +321,7 @@ pub fn sync_enable(
     // of the app sees sync as on.
     sync_writer.set_log(Some(Arc::clone(&log)));
     sync_writer.spawn_cover_writer();
+    sync_writer.spawn_flush_worker(db.inner().clone(), Arc::clone(&log));
     sync_writer.backfill_cover_files(&db);
     {
         let mut g = sync_state
@@ -442,6 +443,7 @@ pub fn sync_disable(
     sync_writer.set_log(None);
     sync_writer.set_should_queue(false);
     sync_writer.set_cover_tx(None);
+    sync_writer.set_flush_tx(None);
 
     // Repoint data_dir at local now that the binary copy-back has
     // finished. Mid-flight reads during phase 1 still resolved
@@ -479,6 +481,7 @@ pub fn sync_disable(
             *eg = None;
             *wg = None;
             sync_writer.set_log(None);
+            sync_writer.set_flush_tx(None);
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -287,8 +287,9 @@ fn boot_sync_engine(
             .map_err(|e| error::AppError::Other(format!("watcher mutex: {e}")))?;
         *engine_guard = Some(Arc::clone(&engine));
         *watcher_guard = Some(watcher);
-        sync_writer.set_log(Some(log));
+        sync_writer.set_log(Some(Arc::clone(&log)));
         sync_writer.spawn_cover_writer();
+        sync_writer.spawn_flush_worker(db.clone(), log);
     }
 
     let bg_engine = Arc::clone(&engine);

--- a/src-tauri/src/sync/writer.rs
+++ b/src-tauri/src/sync/writer.rs
@@ -205,16 +205,28 @@ impl SyncWriter {
         std::thread::Builder::new()
             .name("sync-flush".into())
             .spawn(move || {
+                log::info!("sync: flush worker started");
                 // Block for a signal, collapse any that piled up while we
                 // were draining, then drain once. `flush_outbox` is
                 // exactly-once (FLUSH_OUTBOX_MUTEX + delete-after-append),
                 // so a coalesced extra drain is a cheap no-op.
                 while rx.recv().is_ok() {
-                    while rx.try_recv().is_ok() {}
-                    if let Err(e) = replay::flush_outbox(&db, &log) {
-                        log::warn!("sync: flush worker drain failed: {e}");
+                    let coalesced = {
+                        let mut n = 0usize;
+                        while rx.try_recv().is_ok() {
+                            n += 1;
+                        }
+                        n
+                    };
+                    match replay::flush_outbox(&db, &log) {
+                        Ok(0) => {}
+                        Ok(n) => log::debug!(
+                            "sync: flush worker drained {n} event(s) ({coalesced} signal(s) coalesced)"
+                        ),
+                        Err(e) => log::warn!("sync: flush worker drain failed: {e}"),
                     }
                 }
+                log::info!("sync: flush worker stopped (channel closed)");
             })
             .ok();
         self.set_flush_tx(Some(tx));

--- a/src-tauri/src/sync/writer.rs
+++ b/src-tauri/src/sync/writer.rs
@@ -113,6 +113,12 @@ pub struct SyncWriter {
     /// `boot_sync_engine` when sync is enabled. Cover file writes go
     /// through this channel so iCloud I/O never blocks the import path.
     cover_tx: Mutex<Option<CoverTx>>,
+    /// Signal channel to the long-lived `sync-flush` worker. `Some` while
+    /// sync is enabled. A unit send means "the outbox may be dirty —
+    /// drain it." Replaces the old per-write `std::thread::spawn`: the
+    /// worker coalesces a burst of signals into a single drain. Mirrors
+    /// `cover_tx`'s lifecycle (set on boot/enable, cleared on disable).
+    flush_tx: Mutex<Option<mpsc::Sender<()>>>,
 }
 
 impl SyncWriter {
@@ -124,6 +130,7 @@ impl SyncWriter {
             progress_throttle: Mutex::new(HashMap::new()),
             flush_inline_for_tests: AtomicBool::new(false),
             cover_tx: Mutex::new(None),
+            flush_tx: Mutex::new(None),
         }
     }
 
@@ -178,6 +185,39 @@ impl SyncWriter {
             })
             .ok();
         self.set_cover_tx(Some(tx));
+    }
+
+    pub fn set_flush_tx(&self, tx: Option<mpsc::Sender<()>>) {
+        *self.flush_tx.lock().expect("flush_tx mutex") = tx;
+    }
+
+    /// Spawn the long-lived `sync-flush` worker and wire its sender.
+    /// One thread for the whole "sync on" period — `with_tx` pokes it
+    /// over the channel instead of spawning a thread per write.
+    ///
+    /// Captures `db` and the current `log`; since the worker is torn
+    /// down on disable and respawned on enable (mirroring the
+    /// cover-writer), the captured `log` is always the live one. The
+    /// worker exits when its sender is dropped (`set_flush_tx(None)` on
+    /// disable, or replacement on re-enable) — `recv` then returns `Err`.
+    pub fn spawn_flush_worker(&self, db: Db, log: Arc<EventLog>) {
+        let (tx, rx) = mpsc::channel::<()>();
+        std::thread::Builder::new()
+            .name("sync-flush".into())
+            .spawn(move || {
+                // Block for a signal, collapse any that piled up while we
+                // were draining, then drain once. `flush_outbox` is
+                // exactly-once (FLUSH_OUTBOX_MUTEX + delete-after-append),
+                // so a coalesced extra drain is a cheap no-op.
+                while rx.recv().is_ok() {
+                    while rx.try_recv().is_ok() {}
+                    if let Err(e) = replay::flush_outbox(&db, &log) {
+                        log::warn!("sync: flush worker drain failed: {e}");
+                    }
+                }
+            })
+            .ok();
+        self.set_flush_tx(Some(tx));
     }
 
     pub fn queue_cover_write(&self, db: &crate::db::Db, book_id: &str, bytes: &[u8]) {
@@ -314,37 +354,39 @@ impl SyncWriter {
             result
         }; // db.conn lock released.
 
-        // Phase 2 — post-commit flush. Only runs when the log is open
-        // (i.e. the engine booted this session). Failures just leave
-        // rows in the outbox for the next caller / replay tick to
-        // retry.
+        // Phase 2 — post-commit flush. Failures just leave rows in the
+        // outbox for the next signal / replay tick to retry.
         //
-        // Runs on a background thread so the command thread never
-        // blocks on `EventLog::append`. On macOS, `append` wraps the
-        // write in `NSFileCoordinator.coordinateWritingItemAtURL`,
-        // which synchronously waits for Apple's `bird` daemon to
-        // settle on the log file. `bird` can hold the writing
-        // accessor for several seconds after any nearby iCloud
-        // activity (just-copied EPUB, a peer's snapshot landing,
-        // etc.), so a synchronous flush stalls every UI write —
-        // exactly the "import spinner hangs" symptom users reported
-        // on v1.0.x. The row is durable in `_pending_publish` after
-        // commit, and both the watcher tick and the next write's
-        // post-commit flush retry, so dropping this onto a worker
-        // thread loses nothing — only the optimistic "publish before
-        // returning to the UI" timing.
-        if let Some(log) = log_snapshot {
-            if self.flush_inline_for_tests.load(Ordering::SeqCst) {
+        // The drain runs off the command thread so the UI never blocks
+        // on `EventLog::append`. On macOS, `append` wraps the write in
+        // `NSFileCoordinator.coordinateWritingItemAtURL`, which
+        // synchronously waits for Apple's `bird` daemon to settle on the
+        // log file. `bird` can hold the writing accessor for several
+        // seconds after any nearby iCloud activity (just-copied EPUB, a
+        // peer's snapshot landing, etc.), so a synchronous flush stalls
+        // every UI write — exactly the "import spinner hangs" symptom
+        // users reported on v1.0.x. The row is durable in
+        // `_pending_publish` after commit, and both the watcher tick and
+        // the next write's signal retry, so deferring the drain loses
+        // nothing — only the optimistic "publish before returning to the
+        // UI" timing.
+        //
+        // Rather than spawn a thread per write (#240 — burst writes and
+        // page turns churned short-lived no-op threads), poke the
+        // long-lived `sync-flush` worker over its channel; it coalesces a
+        // burst into one drain.
+        if self.flush_inline_for_tests.load(Ordering::SeqCst) {
+            // Tests drain synchronously so asserts don't race a worker.
+            if let Some(log) = log_snapshot {
                 if let Err(e) = replay::flush_outbox(db, &log) {
                     log::warn!("sync: post-commit outbox flush failed: {e}");
                 }
-            } else {
-                let db = db.clone();
-                std::thread::spawn(move || {
-                    if let Err(e) = replay::flush_outbox(&db, &log) {
-                        log::warn!("sync: post-commit outbox flush failed: {e}");
-                    }
-                });
+            }
+        } else if let Ok(guard) = self.flush_tx.lock() {
+            // No worker (queue-only mode / sync off) → leave the row in
+            // `_pending_publish`; the next enable's boot tick drains it.
+            if let Some(tx) = guard.as_ref() {
+                let _ = tx.send(());
             }
         }
 
@@ -698,6 +740,49 @@ mod tests {
         assert!(
             log_events.iter().any(|e| matches!(e.body, EventBody::BookImport(_))),
             "phase 1's BookImport must reach the log on phase 2's boot drain"
+        );
+    }
+
+    /// The real (non-inline) flush worker drains the outbox after a
+    /// `with_tx` signal — exercising the signal → coalesce → drain path
+    /// that replaced the per-write `std::thread::spawn` (#240).
+    #[test]
+    fn flush_worker_drains_outbox_on_signal() {
+        let (dir, db) = setup_db();
+        let writer = SyncWriter::new("dev-A".into());
+        let log_path = dir
+            .path()
+            .join("logs")
+            .join(format!("{}.jsonl", writer.self_device()));
+        let log = Arc::new(EventLog::open(&log_path, writer.self_device(), false).unwrap());
+        writer.set_should_queue(true);
+        writer.set_log(Some(log.clone()));
+        // Real worker — leave flush_inline_for_tests off so with_tx
+        // signals the channel rather than draining synchronously.
+        writer.spawn_flush_worker(db.clone(), log.clone());
+
+        writer
+            .with_tx(&db, 1_000, |tx, events| {
+                insert_book_row(tx, "b1", 1_000, "dev-A")?;
+                events.push(import_body("b1"));
+                Ok(())
+            })
+            .unwrap();
+
+        // The worker drains asynchronously — poll until the outbox empties.
+        let mut drained = false;
+        for _ in 0..200 {
+            if outbox_count(&db.conn.lock().unwrap()) == 0 {
+                drained = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(drained, "flush worker should drain the outbox after a with_tx signal");
+        assert_eq!(
+            log.read_all().unwrap().len(),
+            1,
+            "the queued event should reach the device log via the worker",
         );
     }
 


### PR DESCRIPTION
## Problem

`SyncWriter::with_tx` ran its post-commit outbox flush by spawning a `std::thread` per call. The spawn was gated only on the log being open — there's **no `events.is_empty()` guard** — so it fired on every mutating command while sync is on, including the throttled page-turn writes that queue nothing. Ordinary reading is the hot path: `update_reading_progress` enters `with_tx` on every page turn, so fast paging (and batch import) churned short-lived threads that mostly lock `FLUSH_OUTBOX_MUTEX`, read an empty outbox, and exit.

Correct (single-flight + delete-after-append make `flush_outbox` exactly-once, so redundant drains are no-ops; threads are short-lived and never pile up) but wasteful — pure spawn/teardown + lock-contention overhead during write bursts.

## Fix

Replace the per-write spawn with **one long-lived `sync-flush` worker** that `with_tx` pokes over a channel. The worker blocks on the signal, collapses any backlog (`try_recv` drain) into a single `flush_outbox`, and exits when its sender is dropped.

This mirrors the existing `cover-writer` lifecycle exactly: spawned on boot/enable, torn down on disable (`set_flush_tx(None)`), respawned on re-enable. Because it's recreated per enable, the worker captures the live `EventLog` directly — no need to make the log field shareable.

- `sync/writer.rs` — new `flush_tx` channel, `set_flush_tx` / `spawn_flush_worker`, rewritten `with_tx` Phase 2 (signal instead of spawn). Tests keep the synchronous inline path.
- `lib.rs` (`boot_sync_engine`) + `commands/sync.rs` (`sync_enable`) — spawn the worker next to `spawn_cover_writer`.
- `commands/sync.rs` (`sync_disable`, both teardown points) — drop the sender so the worker exits.
- MCP subprocess unchanged (queue-only: no log, no worker, drained by the main app's replay tick).

## Tests

- New `flush_worker_drains_outbox_on_signal` exercises the real signal→coalesce→drain path (worker on, not inline).
- `cargo test --lib` → 240 passed, 0 failed. `cargo clippy --lib` clean.

## Notes

Out of scope: the `should_emit_progress` 2s event throttle and `flush_outbox`/`FLUSH_OUTBOX_MUTEX` themselves are untouched — this changes only *how* the drain is scheduled. Durability is unchanged: a write made while iCloud is transiently unreachable still reaches peers via the next signal or replay tick.

Closes #240