### PR TITLE
fix: unify the reader's loading spinner across all states

### DIFF
--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -998,8 +998,9 @@ export default function Reader() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-screen">
-        <p className="text-text-muted">{t("reader.loading")}</p>
+      <div className="flex flex-col items-center justify-center h-screen gap-3">
+        <Loader2 size={24} className="animate-spin text-text-muted" />
+        <p className="text-text-muted text-[14px]">{t("reader.loading")}</p>
       </div>
     );
   }
@@ -1019,7 +1020,7 @@ export default function Reader() {
           <p className="text-text-muted text-[14px]">{t("reader.downloadTimeout")}</p>
         ) : (
           <>
-            <Loader2 size={24} className="text-accent animate-spin" />
+            <Loader2 size={24} className="animate-spin text-text-muted" />
             <p className="text-text-muted text-[14px]">{t("reader.downloadingFromICloud")}</p>
           </>
         )}


### PR DESCRIPTION
## Problem

Opening a book stepped through inconsistent loading UI:

1. Initial metadata fetch (`loading`) showed **text with no spinner**.
2. iCloud download (`downloadingFromICloud`) showed a spinner in **`text-accent`**.
3. Foliate init (`!bookReady` / "preparing book") showed a spinner in **`text-text-muted`**.

So any open flickered text → spinner, and the two spinner phases didn't even match colors. Same for EPUB and PDF (none of these branch on format) — just inconsistent across phases.

## Fix

All three reader full-screen loading states now use one treatment: `Loader2` 24px `animate-spin text-text-muted` with a 14px muted label in a centered `flex-col … gap-3`.

Home's import overlay is intentionally left as-is — a prominent accent modal in a card — since it's an active, user-initiated action rather than a passive wait. Inline spinners (AI/translation streaming, pagination, settings) are untouched.

## Verification

- `tsc --noEmit` clean.
- Visual: opening a book shows a consistent spinner+label through metadata load → (iCloud download) → preparing.