### PR TITLE
feat: split Ask AI into Explain (inline) and Quote (side panel) (#215)

### DIFF
--- a/design/quill-desktop.pen
+++ b/design/quill-desktop.pen
@@ -1,5 +1,5 @@
 {
-  "version": "2.11",
+  "version": "2.13",
   "children": [
     {
       "type": "frame",
@@ -20,13 +20,11 @@
           "width": 224,
           "height": "fill_container",
           "fill": "$bg-muted",
-          "stroke": {
-            "align": "inside",
-            "thickness": {
-              "right": 1
-            },
-            "fill": "$border"
+          "stroke": "$border",
+          "strokeWidth": {
+            "right": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "gap": 24,
           "padding": [
@@ -61,13 +59,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "xnPx0",
                       "name": "logoIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "feather",
-                      "iconFontFamily": "lucide",
+                      "icon": "feather",
+                      "library": "lucide",
                       "fill": "$white"
                     }
                   ]
@@ -97,12 +95,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Mnb7P",
                       "width": 12,
                       "height": 12,
-                      "iconFontName": "refresh-cw",
-                      "iconFontFamily": "lucide",
+                      "icon": "refresh-cw",
+                      "library": "lucide",
                       "fill": "$accent"
                     },
                     {
@@ -169,13 +167,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "Y9ZR7",
                               "name": "allBooksIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "library",
-                              "iconFontFamily": "lucide",
+                              "icon": "library",
+                              "library": "lucide",
                               "fill": "$accent"
                             },
                             {
@@ -226,13 +224,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "MxuDu",
                               "name": "readingIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "book-open",
-                              "iconFontFamily": "lucide",
+                              "icon": "book-open",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -283,13 +281,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "18hMt",
                               "name": "finishedIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "circle-check",
-                              "iconFontFamily": "lucide",
+                              "icon": "circle-check",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -363,13 +361,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "r3q8V",
                           "name": "dictIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "book-a",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-a",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -400,13 +398,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "rne2U",
                           "name": "chatsIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "message-square",
-                          "iconFontFamily": "lucide",
+                          "icon": "message-square",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -437,13 +435,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "AtyYr",
                           "name": "transIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "globe",
-                          "iconFontFamily": "lucide",
+                          "icon": "globe",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -493,13 +491,13 @@
                       "letterSpacing": 0.3
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "aVpUk",
                       "name": "colsPlus",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "plus",
-                      "iconFontFamily": "lucide",
+                      "icon": "plus",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -538,23 +536,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "oYmuk",
                               "name": "fictionGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "ISNrO",
                               "name": "fictionIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -607,23 +605,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "tsfNL",
                               "name": "scifiGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "CDXog",
                               "name": "scifiIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -676,23 +674,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "enunc",
                               "name": "historyGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "8armr",
                               "name": "historyIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -745,23 +743,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "R84M0",
                               "name": "chineseGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "V5m9l",
                               "name": "chineseIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -814,23 +812,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "yvPdG",
                               "name": "russianGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "FLPcs",
                               "name": "russianIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -883,23 +881,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "aanQG",
                               "name": "japaneseGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "ofVRh",
                               "name": "japaneseIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -952,23 +950,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "HUOg7",
                               "name": "fashionGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "SzHst",
                               "name": "fashionIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -1021,23 +1019,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "FJH41",
                               "name": "musicGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "b6R3M",
                               "name": "musicIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -1090,23 +1088,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "gWLe9",
                               "name": "csGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "0N00b",
                               "name": "csIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -1143,13 +1141,11 @@
               "id": "6VxhY",
               "name": "User profile",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "top": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "padding": [
                 12,
@@ -1243,13 +1239,11 @@
               "id": "0kQ7c",
               "name": "Header",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "gap": 16,
               "padding": [
@@ -1296,13 +1290,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "NcTfZ",
                               "name": "gridIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "layout-grid",
-                              "iconFontFamily": "lucide",
+                              "icon": "layout-grid",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -1318,13 +1312,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "WOl5k",
                               "name": "listIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "list",
-                              "iconFontFamily": "lucide",
+                              "icon": "list",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             }
                           ]
@@ -1349,13 +1343,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "LKuRx",
                       "name": "searchIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "search",
-                      "iconFontFamily": "lucide",
+                      "icon": "search",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     },
                     {
@@ -2365,11 +2359,9 @@
                   "width": "fill_container",
                   "height": 56,
                   "cornerRadius": 8,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 1,
-                    "fill": "#71717b66"
-                  },
+                  "stroke": "#71717b66",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 8,
                   "padding": [
                     0,
@@ -2379,13 +2371,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "YOuDi",
                       "name": "dropIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "upload",
-                      "iconFontFamily": "lucide",
+                      "icon": "upload",
+                      "library": "lucide",
                       "fill": "$text-secondary"
                     },
                     {
@@ -2424,13 +2416,11 @@
           "name": "Top bar",
           "width": "fill_container",
           "fill": "$bg-surface",
-          "stroke": {
-            "align": "inside",
-            "thickness": {
-              "bottom": 1
-            },
-            "fill": "$border"
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
           },
+          "strokeAlignment": "inner",
           "padding": [
             32,
             24,
@@ -2459,13 +2449,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "cAOMz",
                       "name": "backIcon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "$white"
                     }
                   ]
@@ -2481,13 +2471,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "lzGSh",
                       "name": "tocIcon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "list",
-                      "iconFontFamily": "lucide",
+                      "icon": "list",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -2574,13 +2564,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Q5hXR",
                       "name": "bookmarkIcon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "bookmark",
-                      "iconFontFamily": "lucide",
+                      "icon": "bookmark",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -2596,13 +2586,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "FfNnc",
                       "name": "translateIcon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "languages",
-                      "iconFontFamily": "lucide",
+                      "icon": "languages",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -2641,13 +2631,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "0nxt9",
                       "name": "aiIcon",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "$accent"
                     },
                     {
@@ -2840,13 +2830,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "GevdY",
                                   "name": "leftIcon",
                                   "width": 16,
                                   "height": 16,
-                                  "iconFontName": "chevron-left",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "chevron-left",
+                                  "library": "lucide",
                                   "fill": "$text-muted"
                                 }
                               ]
@@ -2872,13 +2862,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "RhShl",
                                   "name": "rightIcon",
                                   "width": 16,
                                   "height": 16,
-                                  "iconFontName": "chevron-right",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "chevron-right",
+                                  "library": "lucide",
                                   "fill": "$text-muted"
                                 }
                               ]
@@ -2909,13 +2899,11 @@
               "width": 440,
               "height": "fill_container",
               "fill": "$bg-muted",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "left": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "left": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "children": [
                 {
@@ -2924,13 +2912,11 @@
                   "name": "AI header",
                   "width": "fill_container",
                   "height": 63,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border"
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "padding": [
                     0,
                     16
@@ -2946,13 +2932,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "a07b9",
                           "name": "aiHeaderIcon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "sparkles",
-                          "iconFontFamily": "lucide",
+                          "icon": "sparkles",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -2967,13 +2953,13 @@
                           "letterSpacing": -0.23
                         },
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "galkk",
                           "name": "aiHeaderChevron",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "chevron-down",
-                          "iconFontFamily": "lucide",
+                          "icon": "chevron-down",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         }
                       ]
@@ -2989,13 +2975,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "YeVb3",
                           "name": "aiHeaderPlusIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "plus",
-                          "iconFontFamily": "lucide",
+                          "icon": "plus",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         }
                       ]
@@ -3026,13 +3012,11 @@
                           "type": "frame",
                           "id": "JhrLQ",
                           "name": "Context quote",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "left": 2
-                            },
-                            "fill": "$lavender"
+                          "stroke": "$lavender",
+                          "strokeWidth": {
+                            "left": 2
                           },
+                          "strokeAlignment": "inner",
                           "padding": [
                             2,
                             0,
@@ -3084,11 +3068,9 @@
                       "name": "Assistant msg",
                       "fill": "$bg-surface",
                       "cornerRadius": 8,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border"
-                      },
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "gap": 10,
                       "padding": 13,
@@ -3238,11 +3220,9 @@
                       "name": "Assistant msg 2",
                       "fill": "$bg-surface",
                       "cornerRadius": 8,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border"
-                      },
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "gap": 6,
                       "padding": 13,
@@ -3283,13 +3263,11 @@
                   "name": "AI input",
                   "width": "fill_container",
                   "fill": "$bg-muted",
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "top": 1
-                    },
-                    "fill": "$border"
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
                   },
+                  "strokeAlignment": "inner",
                   "layout": "vertical",
                   "gap": 8,
                   "padding": [
@@ -3348,13 +3326,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "TkgxO",
                               "name": "aiSendIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "send",
-                              "iconFontFamily": "lucide",
+                              "icon": "send",
+                              "library": "lucide",
                               "fill": "$white"
                             }
                           ]
@@ -3422,13 +3400,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "6edd5",
                       "name": "popHdrIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "$accent"
                     },
                     {
@@ -3455,13 +3433,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "ryyNq",
                       "name": "popHdrCloseIcon",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -3558,13 +3536,11 @@
               "id": "sBHBq",
               "name": "Footer",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "top": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
               },
+              "strokeAlignment": "inner",
               "padding": [
                 10,
                 16
@@ -3580,13 +3556,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "AUfLJ",
                       "name": "popSaveIcon",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "bookmark-plus",
-                      "iconFontFamily": "lucide",
+                      "icon": "bookmark-plus",
+                      "library": "lucide",
                       "fill": "$accent"
                     },
                     {
@@ -3609,13 +3585,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "EdftX",
                       "name": "popCopyIcon",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "copy",
-                      "iconFontFamily": "lucide",
+                      "icon": "copy",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     },
                     {
@@ -3655,13 +3631,11 @@
           "width": 224,
           "height": "fill_container",
           "fill": "$bg-muted",
-          "stroke": {
-            "align": "inside",
-            "thickness": {
-              "right": 1
-            },
-            "fill": "$border"
+          "stroke": "$border",
+          "strokeWidth": {
+            "right": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "gap": 24,
           "padding": [
@@ -3696,13 +3670,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "ajIwc",
                       "name": "logoIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "feather",
-                      "iconFontFamily": "lucide",
+                      "icon": "feather",
+                      "library": "lucide",
                       "fill": "$white"
                     }
                   ]
@@ -3775,13 +3749,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "tU8eX",
                               "name": "allBooksIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "library",
-                              "iconFontFamily": "lucide",
+                              "icon": "library",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -3832,13 +3806,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "f59VT",
                               "name": "readingIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "book-open",
-                              "iconFontFamily": "lucide",
+                              "icon": "book-open",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -3889,13 +3863,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "mz1Yy",
                               "name": "finishedIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "circle-check",
-                              "iconFontFamily": "lucide",
+                              "icon": "circle-check",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -3970,13 +3944,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "Ezl6R",
                           "name": "dictIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "book-a",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-a",
+                          "library": "lucide",
                           "fill": "$accent"
                         },
                         {
@@ -4007,13 +3981,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "eiYmh",
                           "name": "chatsIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "message-square",
-                          "iconFontFamily": "lucide",
+                          "icon": "message-square",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -4044,13 +4018,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "gp0t5",
                           "name": "transIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "globe",
-                          "iconFontFamily": "lucide",
+                          "icon": "globe",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -4100,13 +4074,13 @@
                       "letterSpacing": 0.3
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "9IesA",
                       "name": "colsPlus",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "plus",
-                      "iconFontFamily": "lucide",
+                      "icon": "plus",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -4145,23 +4119,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "3Oe3L",
                               "name": "fictionGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "Xk4QH",
                               "name": "fictionIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -4214,23 +4188,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "7vZOz",
                               "name": "scifiGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "QGDh3",
                               "name": "scifiIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -4283,23 +4257,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "GW0eF",
                               "name": "historyGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "eDrgn",
                               "name": "historyIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -4352,23 +4326,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "hFG7F",
                               "name": "chineseGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "MtB8v",
                               "name": "chineseIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -4421,23 +4395,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "B0g68",
                               "name": "russianGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "yByDe",
                               "name": "russianIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -4490,23 +4464,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "eVnmW",
                               "name": "japaneseGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "TIkaG",
                               "name": "japaneseIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -4559,23 +4533,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "5w5lv",
                               "name": "fashionGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "HsRyD",
                               "name": "fashionIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -4628,23 +4602,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "zkCy7",
                               "name": "musicGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "DuCZk",
                               "name": "musicIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -4697,23 +4671,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "NqQg0",
                               "name": "csGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "Swpvw",
                               "name": "csIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -4750,13 +4724,11 @@
               "id": "lowr0",
               "name": "User profile",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "top": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "padding": [
                 12,
@@ -4850,13 +4822,11 @@
               "id": "Ql6qg",
               "name": "Header",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "gap": 16,
               "padding": [
@@ -4907,13 +4877,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "dltjL",
                               "name": "gridIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "layout-grid",
-                              "iconFontFamily": "lucide",
+                              "icon": "layout-grid",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             }
                           ]
@@ -4930,13 +4900,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "6OIwZ",
                               "name": "listIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "list",
-                              "iconFontFamily": "lucide",
+                              "icon": "list",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -4961,13 +4931,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Un4jU",
                       "name": "searchIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "search",
-                      "iconFontFamily": "lucide",
+                      "icon": "search",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     },
                     {
@@ -4998,13 +4968,11 @@
                   "id": "jnjO2",
                   "name": "Filter row",
                   "width": "fill_container",
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-light"
+                  "stroke": "$border-light",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 10,
                   "padding": [
                     16,
@@ -5019,11 +4987,9 @@
                       "height": 32,
                       "fill": "$accent-bg",
                       "cornerRadius": 9999,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "#c4b5fd"
-                      },
+                      "stroke": "#c4b5fd",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "gap": 6,
                       "padding": [
                         0,
@@ -5032,13 +4998,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "10Abq",
                           "name": "pillAllIcon",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "book-open",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-open",
+                          "library": "lucide",
                           "fill": "$accent"
                         },
                         {
@@ -5069,11 +5035,9 @@
                       "name": "IC pill",
                       "height": 32,
                       "cornerRadius": 9999,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border"
-                      },
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "gap": 6,
                       "padding": [
                         0,
@@ -5082,13 +5046,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "QTCZc",
                           "name": "pillICIcon",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "book-open",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-open",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -5119,11 +5083,9 @@
                       "name": "FC pill",
                       "height": 32,
                       "cornerRadius": 9999,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border"
-                      },
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "gap": 6,
                       "padding": [
                         0,
@@ -5132,13 +5094,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "xFFjR",
                           "name": "pillFCIcon",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "book-open",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-open",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -5169,11 +5131,9 @@
                       "name": "TOP pill",
                       "height": 32,
                       "cornerRadius": 9999,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border"
-                      },
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "gap": 6,
                       "padding": [
                         0,
@@ -5182,13 +5142,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "MYIzA",
                           "name": "pillTOPIcon",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "book-open",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-open",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -5219,11 +5179,9 @@
                       "name": "NM pill",
                       "height": 32,
                       "cornerRadius": 9999,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border"
-                      },
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "gap": 6,
                       "padding": [
                         0,
@@ -5232,13 +5190,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "ZrpYJ",
                           "name": "pillNMIcon",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "book-open",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-open",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -5269,11 +5227,9 @@
                       "name": "Zen pill",
                       "height": 32,
                       "cornerRadius": 9999,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border"
-                      },
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "gap": 6,
                       "padding": [
                         0,
@@ -5282,13 +5238,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "oNg2u",
                           "name": "pillZenIcon",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "book-open",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-open",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -5328,13 +5284,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "GksE5",
                           "name": "sortNewestIcon",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "arrow-down-wide-narrow",
-                          "iconFontFamily": "lucide",
+                          "icon": "arrow-down-wide-narrow",
+                          "library": "lucide",
                           "fill": "$accent"
                         },
                         {
@@ -5357,13 +5313,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "WY1sU",
                           "name": "sortOldestIcon",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "arrow-up-narrow-wide",
-                          "iconFontFamily": "lucide",
+                          "icon": "arrow-up-narrow-wide",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -5386,13 +5342,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "hpdF4",
                           "name": "sortAZIcon",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "arrow-down-a-z",
-                          "iconFontFamily": "lucide",
+                          "icon": "arrow-down-a-z",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -5438,13 +5394,11 @@
                           "id": "fDsmC",
                           "name": "A header",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "padding": [
                             0,
                             0,
@@ -5481,13 +5435,11 @@
                           "id": "nNTIE",
                           "name": "armature entry",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "gap": 24,
                           "padding": [
                             4,
@@ -5522,13 +5474,13 @@
                                   "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "slS6O",
                                       "name": "armSourceIcon",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "book-open",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "book-open",
+                                      "library": "lucide",
                                       "fill": "$text-muted"
                                     },
                                     {
@@ -5606,13 +5558,13 @@
                                       "fontWeight": "500"
                                     },
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "tWuz5",
                                       "name": "armOpenArrow",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "arrow-right",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "arrow-right",
+                                      "library": "lucide",
                                       "fill": "$accent"
                                     }
                                   ]
@@ -5626,13 +5578,11 @@
                           "id": "6Y0eZ",
                           "name": "awning entry",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "gap": 24,
                           "padding": [
                             4,
@@ -5667,13 +5617,13 @@
                                   "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "TIzpt",
                                       "name": "awnSrcIcon",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "book-open",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "book-open",
+                                      "library": "lucide",
                                       "fill": "$text-muted"
                                     },
                                     {
@@ -5751,13 +5701,13 @@
                                       "fontWeight": "500"
                                     },
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "XB9NS",
                                       "name": "awnOpenArrow",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "arrow-right",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "arrow-right",
+                                      "library": "lucide",
                                       "fill": "$accent"
                                     }
                                   ]
@@ -5771,13 +5721,11 @@
                           "id": "ozh3I",
                           "name": "astringent entry",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "gap": 24,
                           "padding": [
                             4,
@@ -5812,13 +5760,13 @@
                                   "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "YbXpQ",
                                       "name": "astSrcIcon",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "book-open",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "book-open",
+                                      "library": "lucide",
                                       "fill": "$text-muted"
                                     },
                                     {
@@ -5896,13 +5844,13 @@
                                       "fontWeight": "500"
                                     },
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "fcBJy",
                                       "name": "astOpenArrow",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "arrow-right",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "arrow-right",
+                                      "library": "lucide",
                                       "fill": "$accent"
                                     }
                                   ]
@@ -5916,13 +5864,11 @@
                           "id": "exJ7H",
                           "name": "Arson entry",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "gap": 24,
                           "padding": [
                             4,
@@ -5957,13 +5903,13 @@
                                   "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "IcedD",
                                       "name": "arsSrcIcon",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "book-open",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "book-open",
+                                      "library": "lucide",
                                       "fill": "$text-muted"
                                     },
                                     {
@@ -6041,13 +5987,13 @@
                                       "fontWeight": "500"
                                     },
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "4TZmW",
                                       "name": "arsOpenArrow",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "arrow-right",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "arrow-right",
+                                      "library": "lucide",
                                       "fill": "$accent"
                                     }
                                   ]
@@ -6061,13 +6007,11 @@
                           "id": "RTI4U",
                           "name": "avarice entry",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "gap": 24,
                           "padding": [
                             4,
@@ -6102,13 +6046,13 @@
                                   "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "m0lar",
                                       "name": "avaSrcIcon",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "book-open",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "book-open",
+                                      "library": "lucide",
                                       "fill": "$text-muted"
                                     },
                                     {
@@ -6186,13 +6130,13 @@
                                       "fontWeight": "500"
                                     },
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "BuOoq",
                                       "name": "avaOpenArrow",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "arrow-right",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "arrow-right",
+                                      "library": "lucide",
                                       "fill": "$accent"
                                     }
                                   ]
@@ -6216,13 +6160,11 @@
                           "id": "3oW4m",
                           "name": "B header",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "padding": [
                             0,
                             0,
@@ -6259,13 +6201,11 @@
                           "id": "GkqkW",
                           "name": "banisters entry",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "gap": 24,
                           "padding": [
                             4,
@@ -6300,13 +6240,13 @@
                                   "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "ldufz",
                                       "name": "banSrcIcon",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "book-open",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "book-open",
+                                      "library": "lucide",
                                       "fill": "$text-muted"
                                     },
                                     {
@@ -6384,13 +6324,13 @@
                                       "fontWeight": "500"
                                     },
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "4qKQ6",
                                       "name": "banOpenArrow",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "arrow-right",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "arrow-right",
+                                      "library": "lucide",
                                       "fill": "$accent"
                                     }
                                   ]
@@ -6404,13 +6344,11 @@
                           "id": "0Qp5h",
                           "name": "beseech entry",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "gap": 24,
                           "padding": [
                             4,
@@ -6445,13 +6383,13 @@
                                   "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "AAbUT",
                                       "name": "besSrcIcon",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "book-open",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "book-open",
+                                      "library": "lucide",
                                       "fill": "$text-muted"
                                     },
                                     {
@@ -6529,13 +6467,13 @@
                                       "fontWeight": "500"
                                     },
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "QmIbu",
                                       "name": "besOpenArrow",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "arrow-right",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "arrow-right",
+                                      "library": "lucide",
                                       "fill": "$accent"
                                     }
                                   ]
@@ -6549,13 +6487,11 @@
                           "id": "2Bssy",
                           "name": "braziers entry",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "gap": 24,
                           "padding": [
                             4,
@@ -6590,13 +6526,13 @@
                                   "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "UQMI8",
                                       "name": "braSrcIcon",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "book-open",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "book-open",
+                                      "library": "lucide",
                                       "fill": "$text-muted"
                                     },
                                     {
@@ -6674,13 +6610,13 @@
                                       "fontWeight": "500"
                                     },
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "PyOri",
                                       "name": "braOpenArrow",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "arrow-right",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "arrow-right",
+                                      "library": "lucide",
                                       "fill": "$accent"
                                     }
                                   ]
@@ -6704,13 +6640,11 @@
                           "id": "yYvnC",
                           "name": "C header",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "padding": [
                             0,
                             0,
@@ -6747,13 +6681,11 @@
                           "id": "hnL5e",
                           "name": "cornucopia entry",
                           "width": "fill_container",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "$border-light"
+                          "stroke": "$border-light",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "gap": 24,
                           "padding": [
                             4,
@@ -6788,13 +6720,13 @@
                                   "alignItems": "center",
                                   "children": [
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "5130Z",
                                       "name": "corSrcIcon",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "book-open",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "book-open",
+                                      "library": "lucide",
                                       "fill": "$text-muted"
                                     },
                                     {
@@ -6872,13 +6804,13 @@
                                       "fontWeight": "500"
                                     },
                                     {
-                                      "type": "icon_font",
+                                      "type": "icon",
                                       "id": "e2R0g",
                                       "name": "corOpenArrow",
                                       "width": 12,
                                       "height": 12,
-                                      "iconFontName": "arrow-right",
-                                      "iconFontFamily": "lucide",
+                                      "icon": "arrow-right",
+                                      "library": "lucide",
                                       "fill": "$accent"
                                     }
                                   ]
@@ -6945,13 +6877,11 @@
               "id": "s1Z4q",
               "name": "Header",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-light"
+              "stroke": "$border-light",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "padding": [
                 20,
                 24,
@@ -7010,13 +6940,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "TgNEi",
                       "name": "closeIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -7063,11 +6993,9 @@
                       "width": "fill_container",
                       "fill": "$bg-muted",
                       "cornerRadius": 10,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border-light"
-                      },
+                      "stroke": "$border-light",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "gap": 12,
                       "padding": [
                         12,
@@ -7095,13 +7023,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "SR8SM",
                                   "name": "srcIcon",
                                   "width": 16,
                                   "height": 16,
-                                  "iconFontName": "book-open",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "book-open",
+                                  "library": "lucide",
                                   "fill": "$accent"
                                 }
                               ]
@@ -7162,13 +7090,13 @@
                               "fontWeight": "500"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "L4sXk",
                               "name": "srcOpenIcon",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "arrow-right",
-                              "iconFontFamily": "lucide",
+                              "icon": "arrow-right",
+                              "library": "lucide",
                               "fill": "$white"
                             }
                           ]
@@ -7216,11 +7144,9 @@
                       "width": "fill_container",
                       "fill": "$bg-muted",
                       "cornerRadius": 10,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border-light"
-                      },
+                      "stroke": "$border-light",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "gap": 6,
                       "padding": [
@@ -7279,13 +7205,11 @@
                       "id": "79Oak",
                       "name": "ctxQuote",
                       "width": "fill_container",
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": {
-                          "left": 2
-                        },
-                        "fill": "$lavender"
+                      "stroke": "$lavender",
+                      "strokeWidth": {
+                        "left": 2
                       },
+                      "strokeAlignment": "inner",
                       "padding": [
                         6,
                         0,
@@ -7318,13 +7242,11 @@
               "id": "273tO",
               "name": "Footer",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "top": 1
-                },
-                "fill": "$border-light"
+              "stroke": "$border-light",
+              "strokeWidth": {
+                "top": 1
               },
+              "strokeAlignment": "inner",
               "padding": [
                 12,
                 20
@@ -7347,13 +7269,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Qml6u",
                       "name": "delIcon",
                       "width": 15,
                       "height": 15,
-                      "iconFontName": "trash-2",
-                      "iconFontFamily": "lucide",
+                      "icon": "trash-2",
+                      "library": "lucide",
                       "fill": "$danger"
                     },
                     {
@@ -7393,13 +7315,11 @@
           "width": 224,
           "height": "fill_container",
           "fill": "$bg-muted",
-          "stroke": {
-            "align": "inside",
-            "thickness": {
-              "right": 1
-            },
-            "fill": "$border"
+          "stroke": "$border",
+          "strokeWidth": {
+            "right": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "gap": 24,
           "padding": [
@@ -7434,13 +7354,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "bJnVf",
                       "name": "logoIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "feather",
-                      "iconFontFamily": "lucide",
+                      "icon": "feather",
+                      "library": "lucide",
                       "fill": "$white"
                     }
                   ]
@@ -7513,13 +7433,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "JB1Zh",
                               "name": "allBooksIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "library",
-                              "iconFontFamily": "lucide",
+                              "icon": "library",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -7570,13 +7490,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "e6m6D",
                               "name": "readingIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "book-open",
-                              "iconFontFamily": "lucide",
+                              "icon": "book-open",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -7627,13 +7547,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "Thu82",
                               "name": "finishedIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "circle-check",
-                              "iconFontFamily": "lucide",
+                              "icon": "circle-check",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -7707,13 +7627,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "Oz4z8",
                           "name": "dictIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "book-a",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-a",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -7745,13 +7665,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "A1GKG",
                           "name": "chatsIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "message-square",
-                          "iconFontFamily": "lucide",
+                          "icon": "message-square",
+                          "library": "lucide",
                           "fill": "$accent"
                         },
                         {
@@ -7782,13 +7702,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "r3GIX",
                           "name": "transIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "globe",
-                          "iconFontFamily": "lucide",
+                          "icon": "globe",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -7838,13 +7758,13 @@
                       "letterSpacing": 0.3
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Us9OS",
                       "name": "colsPlus",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "plus",
-                      "iconFontFamily": "lucide",
+                      "icon": "plus",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -7883,23 +7803,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "qVxTI",
                               "name": "fictionGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "iJhpN",
                               "name": "fictionIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -7952,23 +7872,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "xi7XW",
                               "name": "scifiGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "3G8MS",
                               "name": "scifiIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -8021,23 +7941,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "Ch0aN",
                               "name": "historyGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "EQhef",
                               "name": "historyIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -8090,23 +8010,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "hrFrS",
                               "name": "chineseGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "PVzcM",
                               "name": "chineseIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -8159,23 +8079,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "YFuLA",
                               "name": "russianGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "VifIW",
                               "name": "russianIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -8228,23 +8148,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "GB0rh",
                               "name": "japaneseGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "YgHNh",
                               "name": "japaneseIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -8297,23 +8217,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "chZIL",
                               "name": "fashionGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "OESjh",
                               "name": "fashionIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -8366,23 +8286,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "cXYeR",
                               "name": "musicGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "S5piJ",
                               "name": "musicIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -8435,23 +8355,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "ZgU0B",
                               "name": "csGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "vB38w",
                               "name": "csIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -8488,13 +8408,11 @@
               "id": "Pl0yo",
               "name": "User profile",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "top": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "padding": [
                 12,
@@ -8589,13 +8507,11 @@
               "name": "Chat Detail Header",
               "width": "fill_container",
               "fill": "$bg-surface",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "padding": [
                 44,
                 24,
@@ -8623,13 +8539,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "v61gr",
                           "name": "backIcon",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "arrow-left",
-                          "iconFontFamily": "lucide",
+                          "icon": "arrow-left",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         }
                       ]
@@ -8699,13 +8615,13 @@
                           "letterSpacing": 0.06
                         },
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "sMob1",
                           "name": "openArrow",
                           "width": 12,
                           "height": 12,
-                          "iconFontName": "arrow-right",
-                          "iconFontFamily": "lucide",
+                          "icon": "arrow-right",
+                          "library": "lucide",
                           "fill": "$accent"
                         }
                       ]
@@ -8721,13 +8637,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "IjUJW",
                           "name": "delIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "trash-2",
-                          "iconFontFamily": "lucide",
+                          "icon": "trash-2",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         }
                       ]
@@ -8764,13 +8680,11 @@
                       "type": "frame",
                       "id": "pRpxa",
                       "name": "Context quote",
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": {
-                          "left": 2
-                        },
-                        "fill": "$lavender"
+                      "stroke": "$lavender",
+                      "strokeWidth": {
+                        "left": 2
                       },
+                      "strokeAlignment": "inner",
                       "padding": [
                         2,
                         0,
@@ -8822,11 +8736,9 @@
                   "name": "Assistant msg",
                   "fill": "$bg-surface",
                   "cornerRadius": 8,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 1,
-                    "fill": "$border"
-                  },
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "layout": "vertical",
                   "gap": 10,
                   "padding": 13,
@@ -8940,11 +8852,9 @@
                   "name": "Assistant msg 2",
                   "fill": "$bg-surface",
                   "cornerRadius": 8,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 1,
-                    "fill": "$border"
-                  },
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "layout": "vertical",
                   "gap": 6,
                   "padding": 13,
@@ -8984,13 +8894,11 @@
               "id": "WyxDO",
               "name": "Input bar",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "top": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "gap": 8,
               "padding": [
@@ -9045,13 +8953,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "rATYs",
                           "name": "sendIcn",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "send",
-                          "iconFontFamily": "lucide",
+                          "icon": "send",
+                          "library": "lucide",
                           "fill": "$white"
                         }
                       ]
@@ -9093,13 +9001,11 @@
           "width": 224,
           "height": "fill_container",
           "fill": "$bg-muted",
-          "stroke": {
-            "align": "inside",
-            "thickness": {
-              "right": 1
-            },
-            "fill": "$border"
+          "stroke": "$border",
+          "strokeWidth": {
+            "right": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "gap": 24,
           "padding": [
@@ -9134,13 +9040,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "zOiUP",
                       "name": "logoIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "feather",
-                      "iconFontFamily": "lucide",
+                      "icon": "feather",
+                      "library": "lucide",
                       "fill": "$white"
                     }
                   ]
@@ -9213,13 +9119,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "vv1CD",
                               "name": "allBooksIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "library",
-                              "iconFontFamily": "lucide",
+                              "icon": "library",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -9270,13 +9176,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "aKcgT",
                               "name": "readingIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "book-open",
-                              "iconFontFamily": "lucide",
+                              "icon": "book-open",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -9327,13 +9233,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "iooBR",
                               "name": "finishedIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "circle-check",
-                              "iconFontFamily": "lucide",
+                              "icon": "circle-check",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -9407,13 +9313,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "SkWVB",
                           "name": "dictIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "book-a",
-                          "iconFontFamily": "lucide",
+                          "icon": "book-a",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -9445,13 +9351,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "SZwc7",
                           "name": "chatsIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "message-square",
-                          "iconFontFamily": "lucide",
+                          "icon": "message-square",
+                          "library": "lucide",
                           "fill": "$accent"
                         },
                         {
@@ -9482,13 +9388,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "GFTAD",
                           "name": "transIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "globe",
-                          "iconFontFamily": "lucide",
+                          "icon": "globe",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -9538,13 +9444,13 @@
                       "letterSpacing": 0.3
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "4PCUn",
                       "name": "colsPlus",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "plus",
-                      "iconFontFamily": "lucide",
+                      "icon": "plus",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -9583,23 +9489,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "V5aWk",
                               "name": "fictionGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "MmAaI",
                               "name": "fictionIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -9652,23 +9558,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "TILX2",
                               "name": "scifiGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "NhOJI",
                               "name": "scifiIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -9721,23 +9627,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "SQ16s",
                               "name": "historyGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "7WKNt",
                               "name": "historyIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -9790,23 +9696,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "UF1zz",
                               "name": "chineseGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "bQVsM",
                               "name": "chineseIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -9859,23 +9765,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "Yk4xP",
                               "name": "russianGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "a83Dh",
                               "name": "russianIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -9928,23 +9834,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "6hEAa",
                               "name": "japaneseGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "XcB2n",
                               "name": "japaneseIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -9997,23 +9903,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "EPD0q",
                               "name": "fashionGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "uQe9C",
                               "name": "fashionIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -10066,23 +9972,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "mNwqt",
                               "name": "musicGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "Ik3Aj",
                               "name": "musicIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -10135,23 +10041,23 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "ZUqho",
                               "name": "csGrip",
                               "width": 12,
                               "height": 12,
-                              "iconFontName": "grip-vertical",
-                              "iconFontFamily": "lucide",
+                              "icon": "grip-vertical",
+                              "library": "lucide",
                               "fill": "#71717b66"
                             },
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "FmvVp",
                               "name": "csIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$text-muted"
                             },
                             {
@@ -10188,13 +10094,11 @@
               "id": "yl5ZU",
               "name": "User profile",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "top": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "padding": [
                 12,
@@ -10288,13 +10192,11 @@
               "id": "7XYSl",
               "name": "Header",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "gap": 16,
               "padding": [
@@ -10341,13 +10243,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "ihtNp",
                       "name": "searchIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "search",
-                      "iconFontFamily": "lucide",
+                      "icon": "search",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     },
                     {
@@ -10369,13 +10271,11 @@
               "id": "9FmN9",
               "name": "Filter pills row",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 8,
               "padding": [
                 8,
@@ -10390,11 +10290,9 @@
                   "height": 32,
                   "fill": "$accent-bg",
                   "cornerRadius": 9999,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 1,
-                    "fill": "#7c3aed4d"
-                  },
+                  "stroke": "#7c3aed4d",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 6,
                   "padding": [
                     0,
@@ -10403,13 +10301,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "mcBTX",
                       "name": "allIcon",
                       "width": 12,
                       "height": 12,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "$accent"
                     },
                     {
@@ -10441,11 +10339,9 @@
                   "height": 32,
                   "fill": "$bg-surface",
                   "cornerRadius": 9999,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 1,
-                    "fill": "$border"
-                  },
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 6,
                   "padding": [
                     0,
@@ -10454,13 +10350,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "wW19D",
                       "name": "fcIcon",
                       "width": 12,
                       "height": 12,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     },
                     {
@@ -10492,11 +10388,9 @@
                   "height": 32,
                   "fill": "$bg-surface",
                   "cornerRadius": 9999,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 1,
-                    "fill": "$border"
-                  },
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 6,
                   "padding": [
                     0,
@@ -10505,13 +10399,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "EKtjK",
                       "name": "icIcon",
                       "width": 12,
                       "height": 12,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     },
                     {
@@ -10543,11 +10437,9 @@
                   "height": 32,
                   "fill": "$bg-surface",
                   "cornerRadius": 9999,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 1,
-                    "fill": "$border"
-                  },
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 6,
                   "padding": [
                     0,
@@ -10556,13 +10448,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "QYTMl",
                       "name": "bsIcon",
                       "width": 12,
                       "height": 12,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     },
                     {
@@ -10615,13 +10507,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "cNcgc",
                           "name": "newestIcon",
                           "width": 12,
                           "height": 12,
-                          "iconFontName": "arrow-down-wide-narrow",
-                          "iconFontFamily": "lucide",
+                          "icon": "arrow-down-wide-narrow",
+                          "library": "lucide",
                           "fill": "$accent"
                         },
                         {
@@ -10650,13 +10542,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "QHPOw",
                           "name": "oldestIcon",
                           "width": 12,
                           "height": 12,
-                          "iconFontName": "arrow-up-wide-narrow",
-                          "iconFontFamily": "lucide",
+                          "icon": "arrow-up-wide-narrow",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -10715,13 +10607,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "jqTCa",
                               "name": "fcHdrIcon",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "book-open",
-                              "iconFontFamily": "lucide",
+                              "icon": "book-open",
+                              "library": "lucide",
                               "fill": "$accent"
                             },
                             {
@@ -10777,22 +10669,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "LlvzR",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -10907,22 +10797,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "YjVwI",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -11037,22 +10925,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "k6WEU",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -11167,22 +11053,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "3SlEr",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -11297,22 +11181,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "o4ulZ",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -11427,22 +11309,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "vaA4z",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -11567,13 +11447,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "g4aLq",
                               "name": "icHdrIcon",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "book-open",
-                              "iconFontFamily": "lucide",
+                              "icon": "book-open",
+                              "library": "lucide",
                               "fill": "$accent"
                             },
                             {
@@ -11629,22 +11509,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "bNnI4",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -11759,22 +11637,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "nHUoe",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -11889,22 +11765,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "3JKm1",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -12029,13 +11903,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "5Vg5p",
                               "name": "bsHdrIcon",
                               "width": 14,
                               "height": 14,
-                              "iconFontName": "book-open",
-                              "iconFontFamily": "lucide",
+                              "icon": "book-open",
+                              "library": "lucide",
                               "fill": "$accent"
                             },
                             {
@@ -12091,22 +11965,20 @@
                           "height": 36,
                           "fill": "$accent-bg",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": 1,
-                            "fill": "#7c3aed33"
-                          },
+                          "stroke": "#7c3aed33",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "justifyContent": "center",
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "8wiZE",
                               "name": "sparkle1",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "sparkles",
-                              "iconFontFamily": "lucide",
+                              "icon": "sparkles",
+                              "library": "lucide",
                               "fill": "$accent"
                             }
                           ]
@@ -12293,12 +12165,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "VnWz6",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "settings",
-                      "iconFontFamily": "lucide",
+                      "icon": "settings",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -12347,12 +12219,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "H3QHI",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "globe",
-                      "iconFontFamily": "lucide",
+                      "icon": "globe",
+                      "library": "lucide",
                       "fill": "#A855F7"
                     },
                     {
@@ -12400,12 +12272,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "0Oqu3",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -12453,12 +12325,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "FkvD8",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -12506,12 +12378,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "CJAE9",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "search",
-                      "iconFontFamily": "lucide",
+                      "icon": "search",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -12559,12 +12431,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "pzWC5",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "languages",
-                      "iconFontFamily": "lucide",
+                      "icon": "languages",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -12612,12 +12484,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "ZaEV9",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "cloud",
-                      "iconFontFamily": "lucide",
+                      "icon": "cloud",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -12665,12 +12537,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "MyZeu",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "info",
-                      "iconFontFamily": "lucide",
+                      "icon": "info",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -12715,7 +12587,7 @@
               "height": "fill_container"
             },
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "RL6PF",
               "layoutPosition": "absolute",
               "x": 492,
@@ -12723,8 +12595,8 @@
               "name": "closeBtn",
               "width": 18,
               "height": 18,
-              "iconFontName": "x",
-              "iconFontFamily": "lucide",
+              "icon": "x",
+              "library": "lucide",
               "fill": "#A1A1AA"
             },
             {
@@ -12828,12 +12700,12 @@
                           "fontWeight": "500"
                         },
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "zkRoM",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "chevron-down",
-                          "iconFontFamily": "lucide",
+                          "icon": "chevron-down",
+                          "library": "lucide",
                           "fill": "#71717A"
                         }
                       ]
@@ -12931,12 +12803,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "nnC7K",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "settings",
-                      "iconFontFamily": "lucide",
+                      "icon": "settings",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -12985,12 +12857,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "KU32t",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "globe",
-                      "iconFontFamily": "lucide",
+                      "icon": "globe",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13038,12 +12910,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "jl5oE",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13091,12 +12963,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "IQoFV",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13145,12 +13017,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "j4R6R",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "search",
-                      "iconFontFamily": "lucide",
+                      "icon": "search",
+                      "library": "lucide",
                       "fill": "#A855F7"
                     },
                     {
@@ -13198,12 +13070,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "q7vSD",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "languages",
-                      "iconFontFamily": "lucide",
+                      "icon": "languages",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13251,12 +13123,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "B608g",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "cloud",
-                      "iconFontFamily": "lucide",
+                      "icon": "cloud",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13304,12 +13176,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "lxZ68",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "info",
-                      "iconFontFamily": "lucide",
+                      "icon": "info",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13354,7 +13226,7 @@
               "height": "fill_container"
             },
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "rk40n",
               "layoutPosition": "absolute",
               "x": 492,
@@ -13362,8 +13234,8 @@
               "name": "closeBtn",
               "width": 18,
               "height": 18,
-              "iconFontName": "x",
-              "iconFontFamily": "lucide",
+              "icon": "x",
+              "library": "lucide",
               "fill": "#A1A1AA"
             },
             {
@@ -13471,12 +13343,12 @@
                           "fontWeight": "500"
                         },
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "MisUy",
                           "width": 12,
                           "height": 12,
-                          "iconFontName": "chevron-down",
-                          "iconFontFamily": "lucide",
+                          "icon": "chevron-down",
+                          "library": "lucide",
                           "fill": "#71717A"
                         }
                       ]
@@ -13708,12 +13580,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Lf6iR",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "settings",
-                      "iconFontFamily": "lucide",
+                      "icon": "settings",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13762,12 +13634,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "WO1bS",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "globe",
-                      "iconFontFamily": "lucide",
+                      "icon": "globe",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13815,12 +13687,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "uQmiV",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13868,12 +13740,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "aRH8Z",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13921,12 +13793,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "GL0Py",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "search",
-                      "iconFontFamily": "lucide",
+                      "icon": "search",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -13975,12 +13847,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "RfV1z",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "languages",
-                      "iconFontFamily": "lucide",
+                      "icon": "languages",
+                      "library": "lucide",
                       "fill": "#A855F7"
                     },
                     {
@@ -14028,12 +13900,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "X29og",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "cloud",
-                      "iconFontFamily": "lucide",
+                      "icon": "cloud",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -14081,12 +13953,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "yEvRX",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "info",
-                      "iconFontFamily": "lucide",
+                      "icon": "info",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -14131,7 +14003,7 @@
               "height": "fill_container"
             },
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "E5IXM",
               "layoutPosition": "absolute",
               "x": 492,
@@ -14139,8 +14011,8 @@
               "name": "closeBtn",
               "width": 18,
               "height": 18,
-              "iconFontName": "x",
-              "iconFontFamily": "lucide",
+              "icon": "x",
+              "library": "lucide",
               "fill": "#A1A1AA"
             },
             {
@@ -14244,12 +14116,12 @@
                           "fontWeight": "500"
                         },
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "RNAt4",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "chevron-down",
-                          "iconFontFamily": "lucide",
+                          "icon": "chevron-down",
+                          "library": "lucide",
                           "fill": "#71717A"
                         }
                       ]
@@ -14280,13 +14152,11 @@
           "name": "Top bar",
           "width": "fill_container",
           "fill": "$bg-surface",
-          "stroke": {
-            "align": "inside",
-            "thickness": {
-              "bottom": 1
-            },
-            "fill": "$border"
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
           },
+          "strokeAlignment": "inner",
           "padding": [
             32,
             24,
@@ -14315,13 +14185,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "acxBy",
                       "name": "backIcon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "$white"
                     }
                   ]
@@ -14337,13 +14207,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "FmfqS",
                       "name": "tocIcon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "list",
-                      "iconFontFamily": "lucide",
+                      "icon": "list",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -14430,13 +14300,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Zo2Sn",
                       "name": "bookmarkIcon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "bookmark",
-                      "iconFontFamily": "lucide",
+                      "icon": "bookmark",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -14452,13 +14322,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "a0fsT",
                       "name": "translateIcon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "languages",
-                      "iconFontFamily": "lucide",
+                      "icon": "languages",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -14497,13 +14367,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "hnXlY",
                       "name": "aiIcon",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "$accent"
                     },
                     {
@@ -14569,13 +14439,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "x7JSt",
                       "name": "popHdrIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "$accent"
                     },
                     {
@@ -14602,13 +14472,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "7O103",
                       "name": "popHdrCloseIcon",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -14705,13 +14575,11 @@
               "id": "PcOuq",
               "name": "Footer",
               "width": "fill_container",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "top": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
               },
+              "strokeAlignment": "inner",
               "padding": [
                 10,
                 16
@@ -14727,13 +14595,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "aPope",
                       "name": "popSaveIcon",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "bookmark-plus",
-                      "iconFontFamily": "lucide",
+                      "icon": "bookmark-plus",
+                      "library": "lucide",
                       "fill": "$accent"
                     },
                     {
@@ -14756,13 +14624,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "BXqEs",
                       "name": "popCopyIcon",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "copy",
-                      "iconFontFamily": "lucide",
+                      "icon": "copy",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     },
                     {
@@ -14954,13 +14822,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "SFqG0",
                                   "name": "leftIcon",
                                   "width": 16,
                                   "height": 16,
-                                  "iconFontName": "chevron-left",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "chevron-left",
+                                  "library": "lucide",
                                   "fill": "$text-muted"
                                 }
                               ]
@@ -14986,13 +14854,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "EPOpo",
                                   "name": "rightIcon",
                                   "width": 16,
                                   "height": 16,
-                                  "iconFontName": "chevron-right",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "chevron-right",
+                                  "library": "lucide",
                                   "fill": "$text-muted"
                                 }
                               ]
@@ -15022,11 +14890,8 @@
                   "name": "Back Button",
                   "fill": "$accent-bg",
                   "cornerRadius": 20,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 0,
-                    "fill": "$accent"
-                  },
+                  "stroke": "$accent",
+                  "strokeAlignment": "inner",
                   "effect": {
                     "type": "shadow",
                     "shadowType": "outer",
@@ -15047,13 +14912,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "i3LVV",
                       "name": "backIcon",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "arrow-left",
-                      "iconFontFamily": "lucide",
+                      "icon": "arrow-left",
+                      "library": "lucide",
                       "fill": "$accent"
                     },
                     {
@@ -15078,13 +14943,11 @@
               "width": 440,
               "height": "fill_container",
               "fill": "$bg-muted",
-              "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "left": 1
-                },
-                "fill": "$border"
+              "stroke": "$border",
+              "strokeWidth": {
+                "left": 1
               },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "children": [
                 {
@@ -15093,13 +14956,11 @@
                   "name": "AI header",
                   "width": "fill_container",
                   "height": 63,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border"
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "padding": [
                     0,
                     16
@@ -15115,13 +14976,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "mI3sp",
                           "name": "aiHeaderIcon",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "sparkles",
-                          "iconFontFamily": "lucide",
+                          "icon": "sparkles",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         },
                         {
@@ -15136,13 +14997,13 @@
                           "letterSpacing": -0.23
                         },
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "ZF2B2",
                           "name": "aiHeaderChevron",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "chevron-down",
-                          "iconFontFamily": "lucide",
+                          "icon": "chevron-down",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         }
                       ]
@@ -15158,13 +15019,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "JxM0f",
                           "name": "aiHeaderPlusIcon",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "plus",
-                          "iconFontFamily": "lucide",
+                          "icon": "plus",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         }
                       ]
@@ -15195,13 +15056,11 @@
                           "type": "frame",
                           "id": "O2i4C",
                           "name": "Context quote",
-                          "stroke": {
-                            "align": "inside",
-                            "thickness": {
-                              "left": 2
-                            },
-                            "fill": "$lavender"
+                          "stroke": "$lavender",
+                          "strokeWidth": {
+                            "left": 2
                           },
+                          "strokeAlignment": "inner",
                           "padding": [
                             2,
                             0,
@@ -15253,11 +15112,9 @@
                       "name": "Assistant msg",
                       "fill": "$bg-surface",
                       "cornerRadius": 8,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border"
-                      },
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "gap": 10,
                       "padding": 13,
@@ -15407,11 +15264,9 @@
                       "name": "Assistant msg 2",
                       "fill": "$bg-surface",
                       "cornerRadius": 8,
-                      "stroke": {
-                        "align": "inside",
-                        "thickness": 1,
-                        "fill": "$border"
-                      },
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "gap": 6,
                       "padding": 13,
@@ -15452,13 +15307,11 @@
                   "name": "AI input",
                   "width": "fill_container",
                   "fill": "$bg-muted",
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "top": 1
-                    },
-                    "fill": "$border"
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
                   },
+                  "strokeAlignment": "inner",
                   "layout": "vertical",
                   "gap": 8,
                   "padding": [
@@ -15517,13 +15370,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "3UvX0",
                               "name": "aiSendIcon",
                               "width": 16,
                               "height": 16,
-                              "iconFontName": "send",
-                              "iconFontFamily": "lucide",
+                              "icon": "send",
+                              "library": "lucide",
                               "fill": "$white"
                             }
                           ]
@@ -15633,12 +15486,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "QUCT1",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "settings",
-                      "iconFontFamily": "lucide",
+                      "icon": "settings",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -15687,12 +15540,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "sSvQx",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "globe",
-                      "iconFontFamily": "lucide",
+                      "icon": "globe",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -15740,12 +15593,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "M5NQf",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -15793,12 +15646,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "oITFX",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -15847,12 +15700,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "I9fFZ",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "search",
-                      "iconFontFamily": "lucide",
+                      "icon": "search",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -15900,12 +15753,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "aVPC2",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "languages",
-                      "iconFontFamily": "lucide",
+                      "icon": "languages",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -15954,12 +15807,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "t1ALn",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "cloud",
-                      "iconFontFamily": "lucide",
+                      "icon": "cloud",
+                      "library": "lucide",
                       "fill": "#A855F7"
                     },
                     {
@@ -16007,12 +15860,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "DisvU",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "info",
-                      "iconFontFamily": "lucide",
+                      "icon": "info",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16057,7 +15910,7 @@
               "height": "fill_container"
             },
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "ijQ2w",
               "layoutPosition": "absolute",
               "x": 492,
@@ -16065,8 +15918,8 @@
               "name": "closeBtn",
               "width": 18,
               "height": 18,
-              "iconFontName": "x",
-              "iconFontFamily": "lucide",
+              "icon": "x",
+              "library": "lucide",
               "fill": "#A1A1AA"
             },
             {
@@ -16211,13 +16064,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "i2oNi",
                       "name": "peerIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "monitor",
-                      "iconFontFamily": "lucide",
+                      "icon": "monitor",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16404,12 +16257,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "G8qEb",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "settings",
-                      "iconFontFamily": "lucide",
+                      "icon": "settings",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16458,12 +16311,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "rUfXo",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "globe",
-                      "iconFontFamily": "lucide",
+                      "icon": "globe",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16511,12 +16364,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "l54Ezd",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
+                      "icon": "book-open",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16565,12 +16418,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "CpEEL",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "sparkles",
-                      "iconFontFamily": "lucide",
+                      "icon": "sparkles",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16619,12 +16472,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "K6AvaL",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "search",
-                      "iconFontFamily": "lucide",
+                      "icon": "search",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16672,12 +16525,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "ucmi4",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "languages",
-                      "iconFontFamily": "lucide",
+                      "icon": "languages",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16726,12 +16579,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "TYxZJ",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "cloud",
-                      "iconFontFamily": "lucide",
+                      "icon": "cloud",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16780,12 +16633,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "RLMtp",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "terminal",
-                      "iconFontFamily": "lucide",
+                      "icon": "terminal",
+                      "library": "lucide",
                       "fill": "#A855F7"
                     },
                     {
@@ -16833,12 +16686,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "xbhZK",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "info",
-                      "iconFontFamily": "lucide",
+                      "icon": "info",
+                      "library": "lucide",
                       "fill": "#71717A"
                     },
                     {
@@ -16883,7 +16736,7 @@
               "height": "fill_container"
             },
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "qnRoS",
               "layoutPosition": "absolute",
               "x": 492,
@@ -16891,8 +16744,8 @@
               "name": "closeBtn",
               "width": 18,
               "height": 18,
-              "iconFontName": "x",
-              "iconFontFamily": "lucide",
+              "icon": "x",
+              "library": "lucide",
               "fill": "#A1A1AA"
             },
             {
@@ -17107,12 +16960,12 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "B1niyv",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "settings-2",
-                          "iconFontFamily": "lucide",
+                          "icon": "settings-2",
+                          "library": "lucide",
                           "fill": "#71717A"
                         },
                         {
@@ -17132,10 +16985,9 @@
                       "name": "copyCfgBtn",
                       "fill": "#FFFFFF",
                       "cornerRadius": 6,
-                      "stroke": {
-                        "thickness": 1,
-                        "fill": "#E5E7EB"
-                      },
+                      "stroke": "#E5E7EB",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "gap": 6,
                       "padding": [
                         5,
@@ -17144,12 +16996,12 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "B5qcd0",
                           "width": 12,
                           "height": 12,
-                          "iconFontName": "copy",
-                          "iconFontFamily": "lucide",
+                          "icon": "copy",
+                          "library": "lucide",
                           "fill": "#52525B"
                         },
                         {
@@ -17189,12 +17041,12 @@
                   "padding": 12,
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "jO8Ba",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "shield-alert",
-                      "iconFontFamily": "lucide",
+                      "icon": "shield-alert",
+                      "library": "lucide",
                       "fill": "#A855F7"
                     },
                     {
@@ -17285,11 +17137,9 @@
               "id": "bJBDO",
               "fill": "$bg-surface",
               "cornerRadius": "$radius-xl",
-              "stroke": {
-                "align": "inside",
-                "thickness": 1,
-                "fill": "$border"
-              },
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "effect": {
                 "type": "shadow",
                 "shadowType": "outer",
@@ -17377,12 +17227,12 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "yqUJ4",
                       "width": 14,
                       "height": 14,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -17414,11 +17264,9 @@
               "width": 300,
               "fill": "$bg-surface",
               "cornerRadius": "$radius-xl",
-              "stroke": {
-                "align": "inside",
-                "thickness": 1,
-                "fill": "$border"
-              },
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "effect": {
                 "type": "shadow",
                 "shadowType": "outer",
@@ -17466,12 +17314,12 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "YHvWD",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "x",
-                          "iconFontFamily": "lucide",
+                          "icon": "x",
+                          "library": "lucide",
                           "fill": "$text-muted"
                         }
                       ]
@@ -17523,11 +17371,9 @@
               "id": "jfknW",
               "fill": "$bg-surface",
               "cornerRadius": "$radius-xl",
-              "stroke": {
-                "align": "inside",
-                "thickness": 1,
-                "fill": "$border"
-              },
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "effect": {
                 "type": "shadow",
                 "shadowType": "outer",
@@ -17548,12 +17394,12 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "OaV3l",
                   "width": 14,
                   "height": 14,
-                  "iconFontName": "loader-circle",
-                  "iconFontFamily": "lucide",
+                  "icon": "loader-circle",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 },
                 {
@@ -17591,11 +17437,9 @@
               "id": "WIzGw",
               "fill": "$bg-surface",
               "cornerRadius": "$radius-xl",
-              "stroke": {
-                "align": "inside",
-                "thickness": 1,
-                "fill": "$border"
-              },
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "effect": {
                 "type": "shadow",
                 "shadowType": "outer",
@@ -17616,12 +17460,12 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "n13Qis",
                   "width": 14,
                   "height": 14,
-                  "iconFontName": "check",
-                  "iconFontFamily": "lucide",
+                  "icon": "check",
+                  "library": "lucide",
                   "fill": "$success"
                 },
                 {
@@ -17632,6 +17476,3132 @@
                   "fontFamily": "Inter",
                   "fontSize": 13,
                   "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Sb8hK",
+      "x": 6343,
+      "y": 1484,
+      "name": "Reader — Explain (215)",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "sv0ca",
+          "name": "Top bar",
+          "width": "fill_container",
+          "fill": "$bg-surface",
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            32,
+            24,
+            8,
+            24
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "qxJ45",
+              "name": "Top left",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "V0s5Y7",
+                  "name": "Back icon",
+                  "width": 40,
+                  "height": 40,
+                  "fill": "$accent",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "aUuuo",
+                      "name": "backIcon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "book-open",
+                      "library": "lucide",
+                      "fill": "$white"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "QL1VP",
+                  "name": "TOC",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "HSlhy",
+                      "name": "tocIcon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "list",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "oPagI",
+              "name": "Title center",
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "aZ4cV",
+                  "name": "titleText",
+                  "fill": "$text-primary",
+                  "content": "Fight Club",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "hifJB",
+                  "name": "chapterText",
+                  "fill": "$text-muted",
+                  "content": "Chapter 22 of 38",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ugm9b",
+              "name": "Top right",
+              "gap": 2,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "nyJe2",
+                  "name": "Font",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "gap": 1,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ilZOz",
+                      "name": "fontBig",
+                      "fill": "$text-primary",
+                      "content": "A",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Y70vPs",
+                      "name": "fontSmall",
+                      "fill": "$text-primary",
+                      "content": "A",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "B76BQ7",
+                  "name": "Bookmark",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "MtfVM",
+                      "name": "bookmarkIcon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "bookmark",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HXKv8",
+                  "name": "Translate",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "vFI9G",
+                      "name": "translateIcon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "languages",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "YgIEN",
+                  "name": "dividerWrap",
+                  "padding": [
+                    0,
+                    4
+                  ],
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "mnZEP",
+                      "name": "divider",
+                      "fill": "$border",
+                      "width": 1,
+                      "height": 24
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "UHZ9N",
+                  "name": "AI Assistant",
+                  "height": 32,
+                  "fill": "$accent-bg",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "ZLeQu",
+                      "name": "aiIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "sparkles",
+                      "library": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "c81CBo",
+                      "name": "aiLabel",
+                      "fill": "$accent",
+                      "content": "AI Assistant",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.15
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "uSuZy",
+          "name": "Body",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg-surface",
+          "children": [
+            {
+              "type": "frame",
+              "id": "tFAdV",
+              "name": "Reader column",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$bg-surface",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "oNsfW",
+                  "name": "Reading area",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": [
+                    32,
+                    120,
+                    16,
+                    120
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "U0TE2",
+                      "name": "p1",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "And one night in an uptown square park, another group of men poured gasoline around every tree and from tree to tree and set a perfect little forest fire. It was in the newspaper, how townhouse windows across the street from the fire melted, and parked cars farted and settled on melted flat tires.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "wQdZi",
+                      "name": "p2",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    Tyler's rented house on Paper Street is a living thing wet on the inside from so many people sweating and breathing. So many people are moving inside, the house moves.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "AoLbD",
+                      "name": "p4",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    And Tyler was a few of the space monkeys had Tyler drilling holes in their hand. Then those space monkeys are on the front porch to replace them.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "K15Gb6",
+                      "name": "p3",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    Another night that Tyler didn't come home, someone was drilling bank machines and lube fittings into the drilled holes... bank machines and pay telephones.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ewnTL",
+                      "name": "p5",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    And every day in different cars. You never saw the same car twice. One evening, I hear Marla on the front",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "I73eS",
+                  "name": "Bottom progress",
+                  "width": "fill_container",
+                  "fill": "$bg-surface",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    24,
+                    8,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "EBtB4",
+                      "name": "Progress track",
+                      "width": "fill_container",
+                      "height": 2,
+                      "fill": "$border",
+                      "cornerRadius": 9999,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "oBerK",
+                          "name": "Progress fill",
+                          "width": 760,
+                          "height": 2,
+                          "fill": "$accent",
+                          "cornerRadius": 9999
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zenja",
+                      "name": "Progress row",
+                      "width": "fill_container",
+                      "height": 32,
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "cjDd8",
+                          "name": "pageText",
+                          "fill": "$text-muted",
+                          "content": "Page 162 of 267",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "zH7bb",
+                          "name": "Nav arrows",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "NsMGr",
+                              "name": "leftArrow",
+                              "width": 24,
+                              "height": 24,
+                              "cornerRadius": 4,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "i0zfp",
+                                  "name": "leftIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "icon": "chevron-left",
+                                  "library": "lucide",
+                                  "fill": "$text-muted"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "AqvUB",
+                              "name": "pctText",
+                              "fill": "$text-muted",
+                              "content": "61%",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "yCYIY",
+                              "name": "rightArrow",
+                              "width": 24,
+                              "height": 24,
+                              "cornerRadius": 4,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "kiNLs",
+                                  "name": "rightIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "icon": "chevron-right",
+                                  "library": "lucide",
+                                  "fill": "$text-muted"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "lgF7U",
+                          "name": "leftText",
+                          "fill": "$text-muted",
+                          "content": "105 pages left",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "C2IK9",
+              "name": "AI Panel",
+              "clip": true,
+              "width": 440,
+              "height": "fill_container",
+              "fill": "$bg-muted",
+              "stroke": "$border",
+              "strokeWidth": {
+                "left": 1
+              },
+              "strokeAlignment": "inner",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "mpfvO",
+                  "name": "AI header",
+                  "width": "fill_container",
+                  "height": 63,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "bottom": 1
+                  },
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    0,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "akmxc",
+                      "name": "aiHeaderLeft",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "JnnCY",
+                          "name": "aiHeaderIcon",
+                          "width": 20,
+                          "height": 20,
+                          "icon": "sparkles",
+                          "library": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "CjUbT",
+                          "name": "aiHeaderTitle",
+                          "fill": "$text-primary",
+                          "content": "Tyler Explains Harsh Initiation Test",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.23
+                        },
+                        {
+                          "type": "icon",
+                          "id": "sOSbc",
+                          "name": "aiHeaderChevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevron-down",
+                          "library": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "A8c08u",
+                      "name": "aiHeaderPlus",
+                      "width": 28,
+                      "height": 28,
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "lK22X",
+                          "name": "aiHeaderPlusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "plus",
+                          "library": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tak0W",
+                  "name": "Messages",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "rS455",
+                      "name": "User context msg",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "s6tGE6",
+                          "name": "Context quote",
+                          "stroke": "$lavender",
+                          "strokeWidth": {
+                            "left": 2
+                          },
+                          "strokeAlignment": "inner",
+                          "padding": [
+                            2,
+                            0,
+                            2,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "NDy1w",
+                              "name": "userCtxText",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": 340,
+                              "content": "This is how Buddhist temples have tested applicants going back for bah-zillion years, Tyler says. You tell the applicant to go away, and if...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "f25qD",
+                          "name": "Explain bubble",
+                          "fill": "$user-bubble",
+                          "cornerRadius": 8,
+                          "padding": 13,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "JQcW0",
+                              "name": "userExplainText",
+                              "fill": "$text-primary",
+                              "content": "Explain",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LkM5w",
+                      "name": "Assistant msg",
+                      "fill": "$bg-surface",
+                      "cornerRadius": 8,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Do5sW",
+                          "name": "assistIntro",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "In this passage, Tyler is justifying the harsh \"test\" he gives new recruits by comparing it to an old spiritual tradition.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "paLwv",
+                          "name": "assistH1",
+                          "fill": "$text-primary",
+                          "content": "What he's saying",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "iE6vI",
+                          "name": "assistP1",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "He claims Buddhist temples used to test people by rejecting them at first. Only if someone waited outside for days—hungry, uncomfortable, ignored—would they be accepted for training.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "h5s9p",
+                          "name": "assistH2",
+                          "fill": "$text-primary",
+                          "content": "Why this matters in Fight Club",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "kb2M6",
+                          "name": "assistP2",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Tyler is using this idea to support his philosophy:",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "hCXEx",
+                          "name": "assistBullets",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Commitment must be proven through suffering\nOnly the truly devoted deserve entry\nEgo gets stripped away by humiliation and endurance",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "wq3ZA",
+                          "name": "assistP3",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "It turns Project Mayhem into something like a cult initiation: people must show total obedience before belonging.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "om3sY",
+                          "name": "assistH3",
+                          "fill": "$text-primary",
+                          "content": "Tone / characterization",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "k7BoyK",
+                          "name": "assistP4",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "The \"bah-zillion years\" phrasing is sarcastic and exaggerated. It shows Tyler's charismatic, performative style — he mixes half-history, myth, and confidence to make extreme behavior sound meaningful and inevitable.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "l6zVZ",
+                      "name": "User msg 2",
+                      "width": "fill_container",
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "yucXL",
+                          "name": "userMsg2",
+                          "fill": "$user-bubble",
+                          "cornerRadius": 8,
+                          "padding": 13,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "lvy34",
+                              "name": "userMsg2Text",
+                              "fill": "$text-primary",
+                              "content": "Interesting a lot of current society",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zvD0R",
+                      "name": "Assistant msg 2",
+                      "fill": "$bg-surface",
+                      "cornerRadius": 8,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "coNab",
+                          "name": "assist2P1",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Absolutely — you're picking up on one of the novel's biggest points.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "t8aTBn",
+                          "name": "assist2P2",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "I think you're starting to say: a lot of current society still works like this—people are made to \"prove\" themselves through stress, rejection, and grind before they're accepted.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qsQtA",
+                  "name": "AI input",
+                  "width": "fill_container",
+                  "fill": "$bg-muted",
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    17,
+                    16,
+                    16,
+                    16
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ojsfV",
+                      "name": "aiInputRow",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "k25kp",
+                          "name": "aiInputBox",
+                          "width": "fill_container",
+                          "height": 60,
+                          "fill": "$bg-input",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "QyiPU",
+                              "name": "aiInputPlaceholder",
+                              "fill": "$text-placeholder",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask me anything about what you're reading...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TFwlE",
+                          "name": "Send",
+                          "width": 60,
+                          "height": 60,
+                          "fill": "$accent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "Q4Qpph",
+                              "name": "aiSendIcon",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "send",
+                              "library": "lucide",
+                              "fill": "$white"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "PvUwv",
+                      "name": "aiHint",
+                      "fill": "$text-muted",
+                      "content": "Press Enter to send, Shift+Enter for new line",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "EH2E0",
+          "layoutPosition": "absolute",
+          "x": 284,
+          "y": 340,
+          "name": "Look Up popover",
+          "enabled": false,
+          "width": 440,
+          "fill": "#ffffff",
+          "cornerRadius": 14,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000026",
+            "offset": {
+              "x": 0,
+              "y": 20
+            },
+            "blur": 25
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "YkNbs",
+              "name": "Header",
+              "width": "fill_container",
+              "fill": "$accent-bg",
+              "padding": [
+                12,
+                16,
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "o71PL",
+                  "name": "popHdrLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "kURi5",
+                      "name": "popHdrIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "sparkles",
+                      "library": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "pC8z4",
+                      "name": "popHdrTitle",
+                      "fill": "$accent",
+                      "content": "Look Up",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.15
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "v6qpQ",
+                  "name": "popHdrClose",
+                  "width": 24,
+                  "height": 24,
+                  "cornerRadius": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "H8OBl",
+                      "name": "popHdrCloseIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "x",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JaQng",
+              "name": "Body",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "padding": [
+                12,
+                16,
+                8,
+                16
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "T4bu1",
+                  "name": "popWord",
+                  "fill": "$text-primary",
+                  "content": "Another nigh",
+                  "fontFamily": "Inter",
+                  "fontSize": 20,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "SxzzH",
+                  "name": "popTrans",
+                  "fill": "$accent",
+                  "content": "又一个夜晚",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "kjhhl",
+                  "name": "popDef",
+                  "fill": "$text-primary",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "/əˈnʌðər naɪ/ phrase. Means \"one more night\" or \"an additional night\"; in this context, it introduces yet another night when Tyler did not come home.",
+                  "lineHeight": 1.55,
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "kSGx1",
+                  "name": "In this context card",
+                  "width": "fill_container",
+                  "fill": "$bg-muted",
+                  "cornerRadius": 8,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "gaXmL",
+                      "name": "popCtxLabel",
+                      "fill": "$text-muted",
+                      "content": "In this context",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "rr483",
+                      "name": "popCtxBody",
+                      "fill": "$text-secondary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "\"Another nigh[t]\" signals repetition and escalation: this isn't a one-off event, but part of a continuing pattern of Tyler's absence and chaos. The clipped, slightly off phrasing also matches the narrator's frantic, exhausted voice, as if thoughts are tumbling out faster than they can be neatly framed. It sets a tone of inevitability before launching into the absurd sabotage details.",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "RmZw0",
+              "name": "Footer",
+              "width": "fill_container",
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
+              },
+              "strokeAlignment": "inner",
+              "padding": [
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "TElys",
+                  "name": "popSave",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "oDxwJ",
+                      "name": "popSaveIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "bookmark-plus",
+                      "library": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "q781I",
+                      "name": "popSaveLabel",
+                      "fill": "$accent",
+                      "content": "Save to Dict",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MnDRN",
+                  "name": "popCopy",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Tv26q",
+                      "name": "popCopyIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "copy",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "x7vWjz",
+                      "name": "popCopyLabel",
+                      "fill": "$text-muted",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "GIuE9",
+          "layoutPosition": "absolute",
+          "x": 280,
+          "y": 300,
+          "name": "Selection menu",
+          "width": 240,
+          "fill": "#ffffffF2",
+          "cornerRadius": 8,
+          "stroke": "$border",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000001f",
+            "offset": {
+              "x": 0,
+              "y": 8
+            },
+            "blur": 24
+          },
+          "layout": "vertical",
+          "padding": [
+            4,
+            0
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "Pm54i",
+              "name": "Look Up row",
+              "width": "fill_container",
+              "height": 31.5,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vRqAM",
+                  "name": "left",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "VHz2Y",
+                      "name": "Look UpIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "sparkles",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "I0iBT",
+                      "name": "Look UpLabel",
+                      "fill": "$text-primary",
+                      "content": "Look Up",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.08
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "NhBLD",
+              "name": "Explain row",
+              "width": "fill_container",
+              "height": 31.5,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "znWV1",
+                  "name": "left",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "itBzW",
+                      "name": "ExplainIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "wand-sparkles",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "VkYZ9",
+                      "name": "ExplainLabel",
+                      "fill": "$text-primary",
+                      "content": "Explain",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.08
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "RIGHT",
+              "name": "Quote row",
+              "width": "fill_container",
+              "height": 31.5,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zN9Ug",
+                  "name": "left",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "hzEUQ",
+                      "name": "QuoteIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "quote",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "N4KK2",
+                      "name": "QuoteLabel",
+                      "fill": "$text-primary",
+                      "content": "Quote",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.08
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ldk59",
+              "name": "Translate row",
+              "width": "fill_container",
+              "height": 31.5,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "O1PO8",
+                  "name": "left",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "DMuGf",
+                      "name": "TranslateIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "languages",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "jyaCd",
+                      "name": "TranslateLabel",
+                      "fill": "$text-primary",
+                      "content": "Translate",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.08
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "s3aVZe",
+              "name": "divider wrap",
+              "width": "fill_container",
+              "padding": [
+                4,
+                12
+              ],
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "W9kn9z",
+                  "name": "divider",
+                  "fill": "$border",
+                  "width": "fill_container",
+                  "height": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QJ8RS",
+              "name": "Highlight row",
+              "width": "fill_container",
+              "height": 31.5,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dMMlQ",
+                  "name": "left",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "nlcec",
+                      "name": "HighlightIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "highlighter",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "jhiuF",
+                      "name": "HighlightLabel",
+                      "fill": "$text-primary",
+                      "content": "Highlight",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.08
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MAShK",
+                  "name": "dots",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "H6r7mK",
+                      "name": "dot",
+                      "fill": "#FBBF24",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "I0vCSt",
+                      "name": "dot",
+                      "fill": "#34D399",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "U4XlV",
+                      "name": "dot",
+                      "fill": "#60A5FA",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "PetN5",
+                      "name": "dot",
+                      "fill": "#F472B6",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "s1Bmz8",
+                      "name": "dot",
+                      "fill": "#A78BFA",
+                      "width": 14,
+                      "height": 14
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "h0X2K",
+              "name": "divider wrap",
+              "width": "fill_container",
+              "padding": [
+                4,
+                12
+              ],
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "LctTw",
+                  "name": "divider",
+                  "fill": "$border",
+                  "width": "fill_container",
+                  "height": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "j7XSxp",
+              "name": "Copy row",
+              "width": "fill_container",
+              "height": 31.5,
+              "padding": [
+                0,
+                12
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "R30ytK",
+                  "name": "left",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "zOXft",
+                      "name": "CopyIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "copy",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "gEuhO",
+                      "name": "CopyLabel",
+                      "fill": "$text-primary",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.08
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "KbuRa",
+                  "name": "shortcut",
+                  "fill": "$text-muted",
+                  "content": "⌘C",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.06
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "LUsdL",
+          "layoutPosition": "absolute",
+          "x": 540,
+          "y": 300,
+          "name": "Explain popover",
+          "width": 440,
+          "fill": "#ffffff",
+          "cornerRadius": 14,
+          "stroke": "$border",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000026",
+            "offset": {
+              "x": 0,
+              "y": 20
+            },
+            "blur": 25
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "OhtIT",
+              "name": "Header",
+              "width": "fill_container",
+              "fill": "$accent-bg",
+              "padding": [
+                12,
+                16,
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "w8o8ZL",
+                  "name": "hdrLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "nAPx4",
+                      "name": "hdrIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "wand-sparkles",
+                      "library": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "TR8bL",
+                      "name": "hdrTitle",
+                      "fill": "$accent",
+                      "content": "Explain",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.15
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "eVLL7",
+                  "name": "hdrClose",
+                  "width": 24,
+                  "height": 24,
+                  "cornerRadius": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "YSkCL",
+                      "name": "closeIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "x",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BQ8hC",
+              "name": "Body",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "padding": [
+                14,
+                16,
+                12,
+                16
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "x7NH4",
+                  "name": "Passage quote",
+                  "width": "fill_container",
+                  "stroke": "$lavender",
+                  "strokeWidth": {
+                    "left": 2
+                  },
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    2,
+                    0,
+                    2,
+                    12
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CBywl",
+                      "name": "quoteText",
+                      "fill": "$text-muted",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "And one night in an uptown square park, another group of men poured gasoline around every tree and set a perfect little forest fire.",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal",
+                      "fontStyle": "italic"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "aKREj",
+                  "name": "Explanation",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "by4M0",
+                      "name": "explP1",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "This is one of Project Mayhem's early acts of sabotage: anonymous members fan out across the city at night and stage surreal, destructive stunts — here torching an entire stand of park trees.",
+                      "lineHeight": 1.55,
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "mZBLW",
+                      "name": "explP2",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "The deadpan, almost gleeful \"perfect little forest fire\" is the novel's signature tone — chaos described with childlike satisfaction. It marks the moment Tyler's philosophy spills off the page into coordinated, real-world vandalism.",
+                      "lineHeight": 1.55,
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "hT3oC",
+              "name": "Footer",
+              "width": "fill_container",
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
+              },
+              "strokeAlignment": "inner",
+              "padding": [
+                10,
+                16
+              ],
+              "justifyContent": "end",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "n4w5S",
+                  "name": "copyBtn",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Evaf2",
+                      "name": "copyIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "copy",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ZAvj4",
+                      "name": "copyLabel",
+                      "fill": "$text-muted",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "kn0Wp",
+      "x": 7903,
+      "y": 1484,
+      "name": "Reader — Quote (215)",
+      "clip": true,
+      "width": 1440,
+      "height": 960,
+      "fill": "$bg-surface",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "d8hZJN",
+          "name": "Top bar",
+          "width": "fill_container",
+          "fill": "$bg-surface",
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            32,
+            24,
+            8,
+            24
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "o6By9n",
+              "name": "Top left",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "HdvL4",
+                  "name": "Back icon",
+                  "width": 40,
+                  "height": 40,
+                  "fill": "$accent",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "x2SGA",
+                      "name": "backIcon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "book-open",
+                      "library": "lucide",
+                      "fill": "$white"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "IGuzv",
+                  "name": "TOC",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Sc7im",
+                      "name": "tocIcon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "list",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "g1mVnp",
+              "name": "Title center",
+              "layout": "vertical",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "E9lif",
+                  "name": "titleText",
+                  "fill": "$text-primary",
+                  "content": "Fight Club",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "oyFNl",
+                  "name": "chapterText",
+                  "fill": "$text-muted",
+                  "content": "Chapter 22 of 38",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "qMsrK",
+              "name": "Top right",
+              "gap": 2,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "f3yzd",
+                  "name": "Font",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "gap": 1,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "h9gwA",
+                      "name": "fontBig",
+                      "fill": "$text-primary",
+                      "content": "A",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "a8PCy",
+                      "name": "fontSmall",
+                      "fill": "$text-primary",
+                      "content": "A",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "VfznU",
+                  "name": "Bookmark",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "ACC95",
+                      "name": "bookmarkIcon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "bookmark",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "w5a7N",
+                  "name": "Translate",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "k8ZrQG",
+                      "name": "translateIcon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "languages",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "A1rRp",
+                  "name": "dividerWrap",
+                  "padding": [
+                    0,
+                    4
+                  ],
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "oWTXU",
+                      "name": "divider",
+                      "fill": "$border",
+                      "width": 1,
+                      "height": 24
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "v88B3f",
+                  "name": "AI Assistant",
+                  "height": 32,
+                  "fill": "$accent-bg",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "vrwwM",
+                      "name": "aiIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "sparkles",
+                      "library": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "r9WtnM",
+                      "name": "aiLabel",
+                      "fill": "$accent",
+                      "content": "AI Assistant",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.15
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "jKZpV",
+          "name": "Body",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg-surface",
+          "children": [
+            {
+              "type": "frame",
+              "id": "cfTao",
+              "name": "Reader column",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$bg-surface",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KPiSb",
+                  "name": "Reading area",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": [
+                    32,
+                    120,
+                    16,
+                    120
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "PWX5U",
+                      "name": "p1",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "And one night in an uptown square park, another group of men poured gasoline around every tree and from tree to tree and set a perfect little forest fire. It was in the newspaper, how townhouse windows across the street from the fire melted, and parked cars farted and settled on melted flat tires.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "iJUuO",
+                      "name": "p2",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    Tyler's rented house on Paper Street is a living thing wet on the inside from so many people sweating and breathing. So many people are moving inside, the house moves.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "JuvoT",
+                      "name": "p4",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    And Tyler was a few of the space monkeys had Tyler drilling holes in their hand. Then those space monkeys are on the front porch to replace them.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "YJBxc",
+                      "name": "p3",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    Another night that Tyler didn't come home, someone was drilling bank machines and lube fittings into the drilled holes... bank machines and pay telephones.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "vmGcN",
+                      "name": "p5",
+                      "fill": "$text-primary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "    And every day in different cars. You never saw the same car twice. One evening, I hear Marla on the front",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JxyG8",
+                  "name": "Bottom progress",
+                  "width": "fill_container",
+                  "fill": "$bg-surface",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    24,
+                    8,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "fPenx",
+                      "name": "Progress track",
+                      "width": "fill_container",
+                      "height": 2,
+                      "fill": "$border",
+                      "cornerRadius": 9999,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "JFKEU",
+                          "name": "Progress fill",
+                          "width": 760,
+                          "height": 2,
+                          "fill": "$accent",
+                          "cornerRadius": 9999
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "KfYdC",
+                      "name": "Progress row",
+                      "width": "fill_container",
+                      "height": 32,
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "fdogg",
+                          "name": "pageText",
+                          "fill": "$text-muted",
+                          "content": "Page 162 of 267",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "opEeF",
+                          "name": "Nav arrows",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "G9Ksz",
+                              "name": "leftArrow",
+                              "width": 24,
+                              "height": 24,
+                              "cornerRadius": 4,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "tpCwk",
+                                  "name": "leftIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "icon": "chevron-left",
+                                  "library": "lucide",
+                                  "fill": "$text-muted"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "sww6Z",
+                              "name": "pctText",
+                              "fill": "$text-muted",
+                              "content": "61%",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "zDFRd",
+                              "name": "rightArrow",
+                              "width": 24,
+                              "height": 24,
+                              "cornerRadius": 4,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "A6iJo",
+                                  "name": "rightIcon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "icon": "chevron-right",
+                                  "library": "lucide",
+                                  "fill": "$text-muted"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "cdpgF",
+                          "name": "leftText",
+                          "fill": "$text-muted",
+                          "content": "105 pages left",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "V85kD",
+              "name": "AI Panel",
+              "clip": true,
+              "width": 440,
+              "height": "fill_container",
+              "fill": "$bg-muted",
+              "stroke": "$border",
+              "strokeWidth": {
+                "left": 1
+              },
+              "strokeAlignment": "inner",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "s1dB4",
+                  "name": "AI header",
+                  "width": "fill_container",
+                  "height": 63,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "bottom": 1
+                  },
+                  "strokeAlignment": "inner",
+                  "padding": [
+                    0,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "G0IgR",
+                      "name": "aiHeaderLeft",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "fJBaq",
+                          "name": "aiHeaderIcon",
+                          "width": 20,
+                          "height": 20,
+                          "icon": "sparkles",
+                          "library": "lucide",
+                          "fill": "$text-muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "q9QTmG",
+                          "name": "aiHeaderTitle",
+                          "fill": "$text-primary",
+                          "content": "Tyler Explains Harsh Initiation Test",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.23
+                        },
+                        {
+                          "type": "icon",
+                          "id": "W1o6GS",
+                          "name": "aiHeaderChevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevron-down",
+                          "library": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uGxFq",
+                      "name": "aiHeaderPlus",
+                      "width": 28,
+                      "height": 28,
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "FzjOz",
+                          "name": "aiHeaderPlusIcon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "plus",
+                          "library": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TB48o",
+                  "name": "Messages",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "I4Tmeh",
+                      "name": "User context msg",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "wYywP",
+                          "name": "Context quote",
+                          "stroke": "$lavender",
+                          "strokeWidth": {
+                            "left": 2
+                          },
+                          "strokeAlignment": "inner",
+                          "padding": [
+                            2,
+                            0,
+                            2,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "GGs2O",
+                              "name": "userCtxText",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": 340,
+                              "content": "This is how Buddhist temples have tested applicants going back for bah-zillion years, Tyler says. You tell the applicant to go away, and if...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "b2qF3",
+                          "name": "Explain bubble",
+                          "fill": "$user-bubble",
+                          "cornerRadius": 8,
+                          "padding": 13,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "GAiBw",
+                              "name": "userExplainText",
+                              "fill": "$text-primary",
+                              "content": "Why does Tyler test new recruits this way?",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ulsGv",
+                      "name": "Assistant msg",
+                      "fill": "$bg-surface",
+                      "cornerRadius": 8,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "u3owaK",
+                          "name": "assistIntro",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "In this passage, Tyler is justifying the harsh \"test\" he gives new recruits by comparing it to an old spiritual tradition.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "LyJ5J",
+                          "name": "assistH1",
+                          "fill": "$text-primary",
+                          "content": "What he's saying",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "EWAjp",
+                          "name": "assistP1",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "He claims Buddhist temples used to test people by rejecting them at first. Only if someone waited outside for days—hungry, uncomfortable, ignored—would they be accepted for training.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "lPUjL",
+                          "name": "assistH2",
+                          "fill": "$text-primary",
+                          "content": "Why this matters in Fight Club",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "b31QQZ",
+                          "name": "assistP2",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Tyler is using this idea to support his philosophy:",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "DpMRG",
+                          "name": "assistBullets",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Commitment must be proven through suffering\nOnly the truly devoted deserve entry\nEgo gets stripped away by humiliation and endurance",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "s2WmvO",
+                          "name": "assistP3",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "It turns Project Mayhem into something like a cult initiation: people must show total obedience before belonging.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "K4Yqz",
+                          "name": "assistH3",
+                          "fill": "$text-primary",
+                          "content": "Tone / characterization",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "qlu9q",
+                          "name": "assistP4",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "The \"bah-zillion years\" phrasing is sarcastic and exaggerated. It shows Tyler's charismatic, performative style — he mixes half-history, myth, and confidence to make extreme behavior sound meaningful and inevitable.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "g3ZNkq",
+                      "name": "User msg 2",
+                      "width": "fill_container",
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "g5RaZm",
+                          "name": "userMsg2",
+                          "fill": "$user-bubble",
+                          "cornerRadius": 8,
+                          "padding": 13,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "uApcc",
+                              "name": "userMsg2Text",
+                              "fill": "$text-primary",
+                              "content": "Interesting a lot of current society",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NuquP",
+                      "name": "Assistant msg 2",
+                      "fill": "$bg-surface",
+                      "cornerRadius": 8,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Z3A56n",
+                          "name": "assist2P1",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "Absolutely — you're picking up on one of the novel's biggest points.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "MqzXO",
+                          "name": "assist2P2",
+                          "fill": "$text-primary",
+                          "textGrowth": "fixed-width",
+                          "width": 344,
+                          "content": "I think you're starting to say: a lot of current society still works like this—people are made to \"prove\" themselves through stress, rejection, and grind before they're accepted.",
+                          "lineHeight": 1.4,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lFyJ5",
+                  "name": "AI input",
+                  "width": "fill_container",
+                  "fill": "$bg-muted",
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    17,
+                    16,
+                    16,
+                    16
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BBhYh",
+                      "name": "Quote chip",
+                      "width": "fill_container",
+                      "fill": "#c084fc1f",
+                      "cornerRadius": 8,
+                      "stroke": "$lavender",
+                      "strokeWidth": {
+                        "left": 2
+                      },
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ACBgL",
+                          "name": "chipTextWrap",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "wyuMz",
+                              "name": "chipText",
+                              "fill": "$text-muted",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "\"Tyler's rented house on Paper Street is a living thing, wet on the inside from so many people sweating and breathing…\"",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal",
+                              "fontStyle": "italic"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "f6IIm",
+                          "name": "chipClose",
+                          "width": 18,
+                          "height": 18,
+                          "cornerRadius": 4,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "e32Nm",
+                              "name": "chipCloseIcon",
+                              "width": 13,
+                              "height": 13,
+                              "icon": "x",
+                              "library": "lucide",
+                              "fill": "$text-muted"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "C1KWi",
+                      "name": "aiInputRow",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "qq8BJ",
+                          "name": "aiInputBox",
+                          "width": "fill_container",
+                          "height": 60,
+                          "fill": "$bg-input",
+                          "cornerRadius": 8,
+                          "layout": "vertical",
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "dAQQW",
+                              "name": "aiInputPlaceholder",
+                              "fill": "$text-placeholder",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ask me anything about what you're reading...",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal",
+                              "letterSpacing": -0.15
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "zDVcO",
+                          "name": "Send",
+                          "width": 60,
+                          "height": 60,
+                          "fill": "$accent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "ivwQZ",
+                              "name": "aiSendIcon",
+                              "width": 16,
+                              "height": 16,
+                              "icon": "send",
+                              "library": "lucide",
+                              "fill": "$white"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "hiG59",
+                      "name": "aiHint",
+                      "fill": "$text-muted",
+                      "content": "Press Enter to send, Shift+Enter for new line",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "HeMFZ",
+          "layoutPosition": "absolute",
+          "x": 284,
+          "y": 340,
+          "name": "Look Up popover",
+          "enabled": false,
+          "width": 440,
+          "fill": "#ffffff",
+          "cornerRadius": 14,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000026",
+            "offset": {
+              "x": 0,
+              "y": 20
+            },
+            "blur": 25
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "bGsnd",
+              "name": "Header",
+              "width": "fill_container",
+              "fill": "$accent-bg",
+              "padding": [
+                12,
+                16,
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "sC567",
+                  "name": "popHdrLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "u7XNyZ",
+                      "name": "popHdrIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "sparkles",
+                      "library": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "K8oHYH",
+                      "name": "popHdrTitle",
+                      "fill": "$accent",
+                      "content": "Look Up",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": -0.15
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "L4bQU",
+                  "name": "popHdrClose",
+                  "width": 24,
+                  "height": 24,
+                  "cornerRadius": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "xwB13",
+                      "name": "popHdrCloseIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "x",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "uyqMO",
+              "name": "Body",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "padding": [
+                12,
+                16,
+                8,
+                16
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "gwtMK",
+                  "name": "popWord",
+                  "fill": "$text-primary",
+                  "content": "Another nigh",
+                  "fontFamily": "Inter",
+                  "fontSize": 20,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "J2prP",
+                  "name": "popTrans",
+                  "fill": "$accent",
+                  "content": "又一个夜晚",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "EvlFi",
+                  "name": "popDef",
+                  "fill": "$text-primary",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "/əˈnʌðər naɪ/ phrase. Means \"one more night\" or \"an additional night\"; in this context, it introduces yet another night when Tyler did not come home.",
+                  "lineHeight": 1.55,
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "CvzFt",
+                  "name": "In this context card",
+                  "width": "fill_container",
+                  "fill": "$bg-muted",
+                  "cornerRadius": 8,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "cTZi5",
+                      "name": "popCtxLabel",
+                      "fill": "$text-muted",
+                      "content": "In this context",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "LO0Sg",
+                      "name": "popCtxBody",
+                      "fill": "$text-secondary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "\"Another nigh[t]\" signals repetition and escalation: this isn't a one-off event, but part of a continuing pattern of Tyler's absence and chaos. The clipped, slightly off phrasing also matches the narrator's frantic, exhausted voice, as if thoughts are tumbling out faster than they can be neatly framed. It sets a tone of inevitability before launching into the absurd sabotage details.",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "h5eqv",
+              "name": "Footer",
+              "width": "fill_container",
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1
+              },
+              "strokeAlignment": "inner",
+              "padding": [
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "JBQ7y",
+                  "name": "popSave",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "U5frns",
+                      "name": "popSaveIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "bookmark-plus",
+                      "library": "lucide",
+                      "fill": "$accent"
+                    },
+                    {
+                      "type": "text",
+                      "id": "o6b7aE",
+                      "name": "popSaveLabel",
+                      "fill": "$accent",
+                      "content": "Save to Dict",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "h1WFXT",
+                  "name": "popCopy",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "kwkhQ",
+                      "name": "popCopyIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "copy",
+                      "library": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Tcyu3",
+                      "name": "popCopyLabel",
+                      "fill": "$text-muted",
+                      "content": "Copy",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
                 }
               ]
             }

--- a/docs/features/257-persist-explanations.md
+++ b/docs/features/257-persist-explanations.md
@@ -1,0 +1,57 @@
+# 257 — Persist Explain results + Explanations tools page
+
+GitHub issue: https://github.com/yicheng47/quill/issues/257
+
+## Motivation
+
+[#215](https://github.com/yicheng47/quill/issues/215) added the inline **Explain** popover, but it's one-shot — the streamed explanation is discarded when the popover closes. By contrast, **Look Up** persists to the Dictionary/vocab page and **Translate** persists to the Translations page. Explain has no persistence and nowhere to revisit past explanations.
+
+The whole point is **persistence**; the Tools page is just the surface that exposes it.
+
+## Scope
+
+Persist explanations and surface them in a new **Explanations** entry under the sidebar **Tools** section, mirroring the Dictionary and Translations pages.
+
+Persist per explanation:
+- selected passage
+- explanation text
+- book id + title
+- chapter
+- cfi (for navigate-back)
+- timestamp
+
+The Tools page provides list + search + navigate-to-cfi, matching the existing `DictionaryPanel` / `TranslationsPanel` patterns.
+
+## Open question
+
+**Auto-persist vs. explicit Save.** Translate auto-persists every result; Look Up requires an explicit "Save to Dict". Explain could go either way:
+- *Auto-persist on completion* — zero friction, but every glance clutters the page.
+- *Explicit Save button in the `ExplainPopover` footer* — matches Look Up, keeps the page intentional.
+
+Leaning toward explicit Save. This is the deferred open question from the #215 feature spec.
+
+## Implementation Phases
+
+### Phase 1 — Schema + backend
+- New `explanations` table (migration), columns following the `translations` table: id, book_id, passage, explanation, chapter, cfi, created_at.
+- Commands in a new/existing module: `save_explanation`, `list_explanations`, `delete_explanation` — mirror `commands/translation.rs` / vocab commands.
+
+### Phase 2 — Capture from ExplainPopover
+- Persist on completion (auto) or via a Save affordance in the footer, per the open question.
+- Reuse the passage/cfi/book/chapter already available to `ExplainPopover`.
+
+### Phase 3 — Explanations page
+- `ExplanationsPanel` (+ standalone page if the others have one), modeled on `DictionaryPanel` / `TranslationsPanel`: list, search, click-to-navigate (`onNavigateToCfi`).
+- Sidebar **Tools** entry + icon.
+- i18n strings in `en.json` + `zh.json`.
+
+## Verification
+
+- [ ] Explaining a passage persists it; it appears on the Explanations page.
+- [ ] The page lists explanations with search; clicking an entry navigates to its cfi in the reader.
+- [ ] Delete works.
+- [ ] i18n works in both English and Chinese.
+
+## Context
+
+v2 follow-up explicitly deferred in `docs/impls/215-explain-and-quote.md` ("Save-Explain-as-note — v2") and the #215 feature spec's open question. Relates to #215.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,14 +1,11 @@
 # Feature Specs
 
-Specs for features that are in progress or planned. Shipped specs are moved to [`archive/`](archive/). Bug and feature tracking lives in [GitHub Issues](https://github.com/yicheng47/quill/issues).
+Specs for features that are in progress or planned. Shipped, dropped, or superseded specs are moved to [`archive/`](archive/). Bug and feature tracking lives in [GitHub Issues](https://github.com/yicheng47/quill/issues).
 
 ## In progress / Planned
 
 - [14 — Notes (AI-Assisted)](14-notes.md)
-- [17 — Voice (TTS)](17-voice-tts.md)
 - [18 — AI Summarization](18-ai-summarization.md)
-- [21 — AI Auto-Sort Books into Collections](21-ai-auto-sort-collections.md)
-- [22 — AI Book Recommendations](22-book-recommendations.md)
 - [25 — Collection Folders](25-collection-folders.md)
 - [26 — Smooth PDF Page Transitions](26-smooth-pdf-page-transitions.md)
 - [27 — Reading Stats](27-reading-stats.md)
@@ -16,3 +13,4 @@ Specs for features that are in progress or planned. Shipped specs are moved to [
 - [30 — MCP Server](30-mcp-server.md)
 - [32 — Library Backup](32-library-backup.md)
 - [215 — Split Ask AI into Explain and Quote](215-explain-and-quote.md)
+- [257 — Persist Explain results + Explanations tools page](257-persist-explanations.md)

--- a/docs/impls/215-explain-and-quote.md
+++ b/docs/impls/215-explain-and-quote.md
@@ -1,0 +1,177 @@
+# Impl — 215: Split Ask AI into Explain (inline) and Quote (side panel)
+
+Feature spec: [`docs/features/215-explain-and-quote.md`](../features/215-explain-and-quote.md) · GitHub: [#215](https://github.com/yicheng47/quill/issues/215)
+
+## Summary
+
+Today the reader selection menu has one **Ask AI Assistant** entry. It opens the side panel and — via `AiPanel`'s context effect — **resets the chat and auto-sends** `"Explain"` with the selection as context. This both (a) conflates quick comprehension with conversation, and (b) destroys the running session every time.
+
+We split it into two intents:
+
+- **Explain** — inline one-shot popover (sibling of `LookupPopover`), streams an explanation of the passage in context. No chat, no side panel.
+- **Quote** — opens the side panel and pins the passage as a **quote chip** above the composer. The user types their own question; the quote rides along as the message's citation. **Crucially, it attaches to the existing session chat instead of resetting it.**
+
+### Key discoveries from the codebase (drive the design below)
+
+1. **i18n keys are flat dotted strings**, not nested objects (e.g. `"contextMenu.askAI": "Ask AI Assistant"` is a top-level key in `en.json`). Add/rename keys as flat strings.
+2. **The chat data model already supports per-message quotes.** `useAiChat.send(content, context?, contextCfi?)` persists `context`/`cfi`, inlines it into the API call as `[Selected passage: "…"]`, and `MessageBubble` already renders `msg.context` as a left-border block-quote. Quote needs **no new data plumbing** — only a pending-quote UI and a changed trigger.
+3. **Session reuse is mostly subtractive.** `initialize()` (AiPanel mount) already loads the most-recent chat for the book (`chatList[0]`), or shows the empty state with lazy-create-on-send when none exists. The *only* reason a new chat is forced today is the context effect calling `reset()` then auto-sending. Quote = "don't reset, don't auto-send, show a chip." That single change satisfies the "reuse existing session chat / create only if none exists" requirement for free.
+4. **Explain gets its own `ai_explain` command — do not reuse `ai_lookup`.** `ai_lookup` is built for *words*: the frontend fires it **twice concurrently** (`kind: "definition"` + `kind: "context"`) and it carries word-specific translation-prepend logic (prepend a few-word native gloss before the definition). Explain is a *passage*: one stream, one prompt, and a translation gloss makes no sense for a whole sentence. A `"explain"` `kind` would bolt a third unrelated branch onto a function whose whole shape (two streams, definition/context split) is wrong for it. New command keeps both prompts short and single-purpose. It reuses the same provider-settings read block, the per-request `ai-lookup-chunk-{requestId}` channel convention, and the `AI_NOT_CONFIGURED` guard.
+5. **No `ai.explain` rename needed in the chat path** — once Quote no longer auto-sends `t("ai.explain")`, that string is only referenced by the old flow. Keep it (or drop it) but it's no longer load-bearing.
+
+## Phase 1 — Context menu split
+
+**`src/components/ReaderContextMenu.tsx`**
+
+- Replace the `onAskAI: () => void` prop with `onExplain: () => void` and `onQuote: () => void`.
+- Replace the single "Ask AI Assistant" `<button>` with two buttons, in order: **Explain**, then **Quote**.
+- Icons (lucide): Look Up keeps `Sparkles`; **Explain → `WandSparkles`** (AI-explanation feel, distinct glyph from Look Up); **Quote → `Quote`**. Drop the now-unused `Bot` import.
+- Both Explain and Quote are shown for **any** selection length. Look Up stays gated behind `wordCount <= 5`. Final order: `Look Up?` · `Explain` · `Quote` · `Translate` · divider · `Highlight` · divider · `Copy`.
+- Strings: `t("contextMenu.explain")`, `t("contextMenu.quote")`.
+
+**`src/pages/Reader.tsx`**
+
+- Add an `explain` popover state mirroring the existing `lookup` state:
+  ```ts
+  const [explain, setExplain] = useState<{
+    x: number; y: number; text: string; sentence: string;
+    bookTitle?: string; chapter?: string; cfi?: string;
+  } | null>(null);
+  ```
+- In the `<ReaderContextMenu>` usage (~line 1394), replace `onAskAI` with:
+  - `onExplain={() => { setExplain({ x, y, text, sentence, bookTitle, chapter, cfi }); setContextMenu(null); }}` — derive `chapter`/`bookTitle` exactly like the `onLookup` handler does.
+  - `onQuote={() => { setAiContext({ text: contextMenu.text, cfi: contextMenu.cfiRange }); setSidePanel("ai"); setContextMenu(null); }}` — same payload the old `onAskAI` set; the behavior change lives entirely in `AiPanel` (Phase 3).
+- Render `<ExplainPopover …>` next to `<LookupPopover>` (Phase 2), wired to `explain` state with `onClose={() => setExplain(null)}`.
+
+**i18n** (`src/i18n/en.json`, `src/i18n/zh.json`)
+
+- Rename `contextMenu.askAI` → `contextMenu.explain` (en: `"Explain"`, zh: `"解释"`).
+- Add `contextMenu.quote` (en: `"Quote"`, zh: `"引用"`).
+
+## Phase 2 — Explain popover
+
+**`src-tauri/src/commands/ai.rs`** — **new `ai_explain` command** (separate from `ai_lookup`; see discovery #4 for why).
+
+- Signature:
+  ```rust
+  #[tauri::command]
+  pub async fn ai_explain(
+      passage: String,            // the selected sentence/passage
+      surrounding: Option<String>,// optional wider paragraph for context
+      book_title: Option<String>,
+      chapter: Option<String>,
+      request_id: String,
+      app: AppHandle, db: State<'_, Db>, secrets: State<'_, Secrets>,
+  ) -> AppResult<()>
+  ```
+- Reuse `ai_lookup`'s provider-settings read block and the OAuth/`AI_NOT_CONFIGURED` handling verbatim. Stream a **single** response on `ai-lookup-chunk-{request_id}` (same channel convention `LookupPopover` listens on), spawned the same way (anthropic / responses-api / openai-compat match).
+- **Keep it short — via the prompt, not a token cap.** This is the key difference from `ai_lookup`. The prompt must produce a tight 2–3 sentence explanation, not an essay:
+  > You are a reading assistant embedded in an ebook reader. The user selected a sentence or passage and wants to understand it **in context**. In **2–3 sentences**, explain what it means and why it matters here — clarify any difficult phrasing, allusion, or tone. Be direct and concise. Do **not** restate the passage, add headers/labels, or pad with preamble. Plain prose only.
+- **Pass `max_tokens: None`** (like `ai_chat` does) — don't impose an output-token ceiling; a hard cap would truncate mid-sentence. Brevity is the prompt's job. Temperature `0.3`, matching the other commands.
+- **Language:** apply only the *response-language* half of `ai_lookup`'s logic — if `lookup_language` (falling back to system `language`) is non-English, prepend `"Respond entirely in {lang}."`. **No translation-gloss branch** (that's a word-level concept; irrelevant for a passage). So `show_translation` / `native_language` are not read here.
+
+**`src/components/ExplainPopover.tsx`** — new, modeled on `LookupPopover` but simplified to a single stream.
+
+- Props: `{ x, y, text, sentence, bookTitle?, chapter?, bookId, cfi?, onClose }`.
+- One streaming hook (adapt `LookupPopover`'s `useStreamingLookup` into a single-stream `useExplainStream`) calling `invoke("ai_explain", { passage: text, surrounding: sentence, bookTitle, chapter, requestId })` and listening on `ai-lookup-chunk-{requestId}`.
+- Layout reuses the Look Up popover chrome: same `w-[440px]`, `bg-bg-surface`, `rounded-xl`, `shadow-context`; same position-clamping `ResizeObserver` effect; same Escape + click-outside dismissal; same `LOOKUP_PROSE` markdown styling.
+  - Header: `WandSparkles` icon + `t("explain.title")` ("Explain") in the `accent-bg` bar with the `X` close button.
+  - Body: a truncated quote of the selected passage (2–3 lines, `line-clamp`, muted) as the subject, then the streaming explanation. Loading state: `t("explain.thinking")`.
+  - Footer (when `!streaming && content`): a **Copy** button (mirror Look Up's). **No Save-to-Dict** — Explain is passage-level, not a vocab word. (Spec open-question "save as note" is deferred to v2; do not build it now.)
+- Reuse the `AI_NOT_CONFIGURED` handling from `LookupPopover` verbatim (open-settings affordance).
+
+**Register the command:** add `ai_explain` to the `invoke_handler!`/`generate_handler!` list (alongside `ai_lookup`) in `src-tauri/src/lib.rs`.
+
+**i18n**: `explain.title` ("Explain" / "解释"), `explain.thinking` ("Explaining…" / "正在解释…"), `explain.copy`/`explain.copied` (or reuse `lookup.copy`/`lookup.copied`).
+
+## Phase 3 — Quote chip in the AI panel
+
+This is where session reuse is enforced. **No backend changes.**
+
+**`src/components/AiPanel.tsx`**
+
+- **Replace** the auto-send context effect (current lines ~63–73). New behavior: when `context` arrives, set a local `pendingQuote` state and **do not** `reset()` or `send()`:
+  ```ts
+  const [pendingQuote, setPendingQuote] = useState<{ text: string; cfi?: string } | undefined>();
+  useEffect(() => {
+    if (!context) return;
+    setPendingQuote(context);
+    onContextConsumed?.();   // clear Reader's aiContext so re-quoting the same passage re-triggers
+  }, [context, onContextConsumed]);
+  ```
+- **Remove the `if (context) return;` guard** in the mount/initialize effect (lines ~46–49). With the auto-send flow gone, the race it guarded against no longer exists, and we *want* `initialize()` to run so the existing session chat loads (or empty-state when none) before the chip is attached. This is the core of "reuse existing chat; create only if none exists" — `send()`'s lazy-create path handles the no-chat case automatically.
+- Render the **quote chip** as the first child of the input container (above the textarea row), only when `pendingQuote`:
+  - Left-border (`#c084fc`/lavender) + faint lavender background, rounded, small padding.
+  - 2-line clamped italic muted preview of `pendingQuote.text`.
+  - A dismiss `X` button → `setPendingQuote(undefined)`.
+- **Send wiring:** `handleSend` and the suggested-prompt buttons pass the quote through and clear it:
+  ```ts
+  const handleSend = () => {
+    if (!input.trim() || streaming) return;
+    send(input.trim(), pendingQuote?.text, pendingQuote?.cfi);
+    setPendingQuote(undefined);
+    setInput("");
+  };
+  ```
+  The block-quote rendering in the user turn and the inlined model context are already handled by `MessageBubble` + `useAiChat` — no change there.
+- **Esc clears the chip** when the composer is focused (Phase 4).
+
+**`src/hooks/useAiChat.ts`** — audit only; expected **no change**. `send(content, context, contextCfi)` already: persists `context` + `{cfi}` metadata, renders via `MessageBubble`, and inlines `[Selected passage: "…"]` into `apiMessages`. The auto-title path already prefers `context || content`, so a quoted first message still titles sensibly. Confirm the `deriveTitle` regex (strips `"Explain this passage:"`) still produces reasonable fallbacks; tweak only if needed.
+
+### Session-reuse behavior matrix (verification-driving)
+
+| Existing session chat? | Panel state | Quote action result |
+|---|---|---|
+| Yes (has turns) | open or closed | Panel opens to that chat, prior turns intact, chip attached. **No new chat.** |
+| No chat yet | n/a | Empty state shown, chip attached; first send lazily creates the chat. |
+| In-flight stream | open | Chip attaches without interrupting the stream (no reset). Send is disabled until stream completes (existing `streaming` guard). |
+
+## Phase 4 — Polish
+
+- **Keyboard:** `ExplainPopover` closes on `Esc` (same handler as Look Up). In `AiPanel`, `Esc` in the textarea clears `pendingQuote` (and only the chip — don't also blur/close the panel).
+- **Hover/active states** match existing popovers and the user-context block-quote (`MessageBubble` `qL8wm` styling: left border lavender, italic muted).
+- **i18n — all new strings in both `en.json` and `zh.json`:**
+  - `contextMenu.explain`, `contextMenu.quote`
+  - `explain.title`, `explain.thinking`, (`explain.copy`/`explain.copied` or reuse lookup)
+  - `aiPanel.quoteChip.dismiss` (tooltip/aria for the chip's X), optionally `aiPanel.quoteChip.label`.
+- Remove dead code: unused `Bot` import in `ReaderContextMenu`; if `ai.explain` is now unreferenced, leave it (harmless) or remove in the same PR.
+
+## Backend tests
+
+Per project convention (test new backend commands first). The `ai_explain` stream hits a network provider and isn't unit-testable directly, so extract the pure prompt-building into a small helper (e.g. `explain_system_prompt(language: &str) -> String`) and test that:
+
+- The base prompt asks for a **2–3 sentence**, context-aware, no-headers explanation (assert on the key constraints, not the exact wording).
+- A non-English `language` prepends `"Respond entirely in {lang}."`; English prepends nothing.
+- **No** translation-gloss preamble appears (guards against accidentally copying `ai_lookup`'s word-level logic).
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/components/ReaderContextMenu.tsx` | `onAskAI` → `onExplain` + `onQuote`; icons; order |
+| `src/components/ExplainPopover.tsx` | **new** — inline one-shot explanation popover |
+| `src/components/AiPanel.tsx` | pending-quote chip; drop auto-send/reset; let initialize run |
+| `src/pages/Reader.tsx` | `explain` state; wire `onExplain`/`onQuote`; render `ExplainPopover` |
+| `src-tauri/src/commands/ai.rs` | **new `ai_explain` command** — single short stream, own brevity-tuned prompt |
+| `src-tauri/src/lib.rs` | register `ai_explain` in the command handler list |
+| `src/i18n/en.json`, `src/i18n/zh.json` | rename `contextMenu.askAI`→`.explain`; add `.quote`, `explain.*` |
+
+## Out of scope (deferred)
+
+- Save-Explain-as-note (spec open question) — v2.
+- "Quote → send immediately" setting — not in v1.
+
+## Design
+
+Pencil source: `design/quill-desktop.pen`. Frames added for this feature:
+
+- **Reader — Context Menu + Explain (215):** reader with the selection context menu open (Look Up · **Explain** · **Quote** · Translate · Highlight · Copy) and the **Explain popover** streaming a passage explanation.
+- **Reader — Quote chip (215):** the AI side panel with a dismissable **quote chip** above the composer and a sent user turn showing the quote as a block-quote citation.
+
+### Figma/design prompt (text-based, intent-level)
+
+> **Explain popover** — Reuse the Look Up popover shell exactly (440-wide card, rounded-xl, soft shadow, accent-tinted header bar). Header: a wand-sparkles icon + "Explain". Body: show the selected sentence as a short, italic, muted 2–3 line quote at the top, then the AI explanation as flowing prose that reads like a knowledgeable friend clarifying the passage in its context. Footer: a single quiet "Copy" action (no Save-to-Dict — this isn't a vocab word). One-shot, dismissible; same loading shimmer/spinner language as Look Up.
+>
+> **Quote chip** — Above the chat composer, a compact dismissable chip representing the passage the user is about to ask about: a lavender left-rule, faint lavender wash, 2-line-clamped italic preview of the quoted text, and a small × to remove it. It should feel like an attachment pinned to the next message — clearly pending, not yet sent. On send it migrates into the user's message bubble as the existing block-quote citation. The chip must not look like it reset or replaced the conversation: the prior turns stay visible behind/above it.
+>
+> **Context menu** — Replace the single "Ask AI Assistant" row with two rows, "Explain" (wand-sparkles) then "Quote" (quote glyph), keeping the existing row height, spacing, hover wash, and dividers. "Look Up" still only appears for short (≤5-word) selections; "Explain" and "Quote" appear for any selection.

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -169,6 +169,143 @@ pub async fn ai_lookup(
     Ok(())
 }
 
+/// Build the system prompt for sentence/passage explanation.
+///
+/// Brevity is enforced by the prompt itself (2–3 sentences, no preamble) —
+/// deliberately no `max_tokens` cap, which would truncate mid-sentence.
+/// Unlike `ai_lookup`, there is no translation-gloss branch: that is a
+/// word-level concept and makes no sense for a whole passage. The only
+/// language handling is the response-language directive.
+fn explain_system_prompt(language: &str) -> String {
+    let language_prefix = if language != "en" {
+        let lang_name = match language {
+            "zh" => "Chinese (Simplified)",
+            other => other,
+        };
+        format!("Respond entirely in {}.\n\n", lang_name)
+    } else {
+        String::new()
+    };
+
+    format!(
+        "{}You are a reading assistant embedded in an ebook reader. The user selected a sentence or passage and wants to understand it in context.\n\nIn 2–3 sentences, explain what it means and why it matters here — clarify any difficult phrasing, allusion, or tone. Be direct and concise. Do not restate the passage, add headers or labels, or pad with preamble. Plain prose only.",
+        language_prefix
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub async fn ai_explain(
+    passage: String,
+    surrounding: Option<String>,
+    book_title: Option<String>,
+    chapter: Option<String>,
+    request_id: String,
+    app: AppHandle,
+    db: State<'_, Db>,
+    secrets: State<'_, Secrets>,
+) -> AppResult<()> {
+    // Read provider settings
+    let (provider, model, base_url, keep_alive, auth_mode, language) = {
+        let conn = db.reader();
+        let get = |key: &str| -> Option<String> {
+            conn.query_row(
+                "SELECT value FROM settings WHERE key = ?1",
+                rusqlite::params![key],
+                |row| row.get(0),
+            )
+            .ok()
+        };
+        let sys_language = get("language").unwrap_or_else(|| "en".to_string());
+        // lookup_language overrides system language for reading-assistant prompts
+        let lookup_language = get("lookup_language").unwrap_or(sys_language);
+        (
+            get("ai_provider").unwrap_or_else(|| "ollama".to_string()),
+            get("ai_model").unwrap_or_else(|| "llama3.2".to_string()),
+            get("ai_base_url"),
+            get("ai_keep_alive").unwrap_or_else(|| "30m".to_string()),
+            get("ai_auth_mode").unwrap_or_else(|| "api_key".to_string()),
+            lookup_language,
+        )
+    };
+
+    // Read API key from secrets store
+    let api_key = secrets.get("ai_api_key").unwrap_or_default();
+
+    let (api_key, oauth_account_id) = if auth_mode == "oauth" && provider == "openai" {
+        let (token, acct_id) = crate::ai::oauth::get_valid_token(&secrets).await?;
+        (token, acct_id)
+    } else {
+        if api_key.is_empty() && provider != "ollama" {
+            log::warn!("ai_explain: AI_NOT_CONFIGURED provider={provider}");
+            return Err(AppError::Other("AI_NOT_CONFIGURED".to_string()));
+        }
+        (api_key, None)
+    };
+
+    let mut user_content = format!("Passage: \"{}\"", passage);
+    if let Some(ref ctx) = surrounding {
+        if !ctx.is_empty() && ctx != &passage {
+            user_content.push_str(&format!("\nSurrounding text: \"{}\"", ctx));
+        }
+    }
+    if let Some(ref title) = book_title {
+        user_content.push_str(&format!("\nBook: \"{}\"", title));
+    }
+    if let Some(ref ch) = chapter {
+        user_content.push_str(&format!("\nChapter: \"{}\"", ch));
+    }
+
+    let messages = vec![
+        ChatMessage {
+            role: "system".to_string(),
+            content: explain_system_prompt(&language),
+        },
+        ChatMessage {
+            role: "user".to_string(),
+            content: user_content,
+        },
+    ];
+
+    let event_name = format!("ai-lookup-chunk-{}", request_id);
+
+    log::info!("ai_explain: spawn provider={provider} model={model}");
+
+    let use_responses_api = auth_mode == "oauth" && provider == "openai";
+    let app_clone = app.clone();
+    let log_provider = provider.clone();
+    tauri::async_runtime::spawn(async move {
+        let result = match provider.as_str() {
+            "anthropic" => {
+                let url = base_url.unwrap_or_else(|| "https://api.anthropic.com".to_string());
+                crate::ai::anthropic::stream_chat(&app_clone, &url, &api_key, &model, 0.3, &messages, false, &event_name, None).await
+            }
+            _ if use_responses_api => {
+                let url = "https://chatgpt.com/backend-api/codex".to_string();
+                crate::ai::openai_responses::stream_chat(&app_clone, &url, &api_key, &model, &messages, oauth_account_id.as_deref(), &event_name).await
+            }
+            _ => {
+                let url = base_url.unwrap_or_else(|| "http://localhost:11434".to_string());
+                let ka = if provider == "ollama" { Some(keep_alive.clone()) } else { None };
+                crate::ai::openai_compat::stream_chat(&app_clone, &url, &api_key, &model, 0.3, &messages, ka.as_deref(), &event_name, None).await
+            }
+        };
+        if let Err(e) = result {
+            log::error!("ai_explain: provider={log_provider} streaming failed: {e}");
+            let _ = app_clone.emit(&event_name, AiStreamChunk {
+                delta: format!("Error: {}", e),
+                done: false,
+            });
+            let _ = app_clone.emit(&event_name, AiStreamChunk {
+                delta: String::new(),
+                done: true,
+            });
+        }
+    });
+
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn ai_generate_title(
     user_message: String,
@@ -363,4 +500,45 @@ pub async fn ai_chat(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explain_prompt_asks_for_brevity_and_no_headers() {
+        let p = explain_system_prompt("en");
+        assert!(p.contains("2–3 sentences"), "must request a short answer");
+        assert!(p.contains("headers or labels"), "must forbid headers/labels");
+        assert!(p.contains("in context"), "must be context-aware");
+    }
+
+    #[test]
+    fn explain_prompt_english_has_no_language_directive() {
+        let p = explain_system_prompt("en");
+        assert!(!p.contains("Respond entirely in"));
+    }
+
+    #[test]
+    fn explain_prompt_non_english_prepends_response_language() {
+        let zh = explain_system_prompt("zh");
+        assert!(zh.starts_with("Respond entirely in Chinese (Simplified)."));
+
+        let fr = explain_system_prompt("fr");
+        assert!(fr.starts_with("Respond entirely in fr."));
+    }
+
+    #[test]
+    fn explain_prompt_never_has_translation_gloss() {
+        // The word-level "brief translation of the word/phrase" preamble from
+        // ai_lookup must not leak into the passage-level explain prompt.
+        for lang in ["en", "zh", "fr"] {
+            let p = explain_system_prompt(lang);
+            assert!(
+                !p.to_lowercase().contains("translation of the"),
+                "explain must not carry ai_lookup's word-gloss logic (lang={lang})"
+            );
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -652,6 +652,7 @@ pub fn run() {
             // AI
             commands::ai::ai_chat,
             commands::ai::ai_lookup,
+            commands::ai::ai_explain,
             commands::ai::ai_generate_title,
             // OAuth
             commands::oauth::openai_oauth_login,

--- a/src/components/AiPanel.tsx
+++ b/src/components/AiPanel.tsx
@@ -237,10 +237,12 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
                 <button
                   key={prompt}
                   onClick={() => {
+                    if (initializing) return;
                     send(prompt, pendingQuote?.text, pendingQuote?.cfi);
                     setPendingQuote(undefined);
                   }}
-                  className="px-3 py-1.5 rounded-full text-[12px] font-medium text-accent-text bg-accent-bg border border-accent/30 hover:opacity-80 cursor-pointer transition-colors"
+                  disabled={initializing}
+                  className="px-3 py-1.5 rounded-full text-[12px] font-medium text-accent-text bg-accent-bg border border-accent/30 hover:opacity-80 cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-default"
                 >
                   {prompt}
                 </button>

--- a/src/components/AiPanel.tsx
+++ b/src/components/AiPanel.tsx
@@ -26,7 +26,7 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
   ];
   const {
     messages, streaming, send, initialize,
-    chatId, chats, titling, loadChat, deleteChat, renameChat, reset,
+    chatId, chats, titling, initializing, loadChat, deleteChat, renameChat, reset,
   } = useAiChat(bookId, { title: bookTitle, author: bookAuthor, chapter: currentChapter });
 
   const [input, setInput] = useState("");
@@ -78,7 +78,7 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
   }, [editingTitle]);
 
   const handleSend = () => {
-    if (!input.trim() || streaming) return;
+    if (!input.trim() || streaming || initializing) return;
     send(input.trim(), pendingQuote?.text, pendingQuote?.cfi);
     setPendingQuote(undefined);
     setInput("");
@@ -288,9 +288,9 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
           />
           <button
             onClick={handleSend}
-            disabled={!input.trim() || streaming}
+            disabled={!input.trim() || streaming || initializing}
             className={`size-[60px] shrink-0 rounded-lg flex items-center justify-center cursor-pointer bg-accent text-white ${
-              !input.trim() || streaming ? "opacity-50" : ""
+              !input.trim() || streaming || initializing ? "opacity-50" : ""
             }`}
           >
             {streaming ? (

--- a/src/components/AiPanel.tsx
+++ b/src/components/AiPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { Sparkles, Send, Loader2, Plus, ChevronDown, ChevronUp, Trash2 } from "lucide-react";
+import { Sparkles, Send, Loader2, Plus, ChevronDown, ChevronUp, Trash2, X } from "lucide-react";
 import { useAiChat } from "../hooks/useAiChat";
 import { timeAgo } from "../utils/timeAgo";
 import MessageBubble from "./MessageBubble";
@@ -30,6 +30,7 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
   } = useAiChat(bookId, { title: bookTitle, author: bookAuthor, chapter: currentChapter });
 
   const [input, setInput] = useState("");
+  const [pendingQuote, setPendingQuote] = useState<{ text: string; cfi?: string } | undefined>();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
@@ -39,14 +40,12 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
 
   const currentChat = chats.find((c) => c.id === chatId);
 
-  // Initialize on mount / bookId change.
-  // Skip when an incoming context is pending — the context effect below will
-  // create a new chat for it, and we don't want a racing initialize() to load
-  // a stale chat and cancel the stream.
+  // Initialize on mount / bookId change. Always loads the existing session
+  // chat (or empty state when none) — Quote attaches to that chat rather than
+  // starting a fresh one.
   useEffect(() => {
-    if (context) return;
     initialize();
-  }, [initialize, context]);
+  }, [initialize]);
 
   // Load specific chat when navigating from ChatsPage
   useEffect(() => {
@@ -60,17 +59,15 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  // Handle context from "Ask AI" context menu — always start a new chat.
-  // reset() clears chatId so send()'s lazy-create path fires; that path is
-  // also what marks the message as belonging to a new chat (drives title gen).
+  // Handle context from the "Quote" context-menu action — pin it as a pending
+  // quote chip above the composer. Does NOT reset the chat or auto-send: the
+  // quote attaches to the existing session conversation and rides along with
+  // the user's next message.
   useEffect(() => {
-    if (!context || streaming || !bookId) return;
-    (async () => {
-      await reset();
-      send(t("ai.explain"), context.text, context.cfi);
-    })();
+    if (!context) return;
+    setPendingQuote(context);
     onContextConsumed?.();
-  }, [context, bookId, onContextConsumed, reset, send, streaming, t]);
+  }, [context, onContextConsumed]);
 
   // Focus title input when editing
   useEffect(() => {
@@ -82,7 +79,8 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
 
   const handleSend = () => {
     if (!input.trim() || streaming) return;
-    send(input.trim());
+    send(input.trim(), pendingQuote?.text, pendingQuote?.cfi);
+    setPendingQuote(undefined);
     setInput("");
   };
 
@@ -90,6 +88,9 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
+    } else if (e.key === "Escape" && pendingQuote) {
+      e.preventDefault();
+      setPendingQuote(undefined);
     }
   };
 
@@ -234,7 +235,10 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
               {SUGGESTED_PROMPTS.map((prompt) => (
                 <button
                   key={prompt}
-                  onClick={() => send(prompt)}
+                  onClick={() => {
+                    send(prompt, pendingQuote?.text, pendingQuote?.cfi);
+                    setPendingQuote(undefined);
+                  }}
                   className="px-3 py-1.5 rounded-full text-[12px] font-medium text-accent-text bg-accent-bg border border-accent/30 hover:opacity-80 cursor-pointer transition-colors"
                 >
                   {prompt}
@@ -254,12 +258,31 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
 
       {/* Input */}
       <div className="border-t border-border px-4 pt-[17px] pb-4 flex flex-col gap-2">
+        {/* Pending quote chip — passage to attach to the next message */}
+        {pendingQuote && (
+          <div className="flex items-start gap-2 px-2.5 py-2 rounded-lg bg-[rgba(192,132,252,0.12)] border-l-2 border-[#c084fc]">
+            <p className="flex-1 text-[12px] italic text-text-muted line-clamp-2 tracking-[-0.08px]">
+              {pendingQuote.text}
+            </p>
+            <button
+              onClick={() => setPendingQuote(undefined)}
+              title={t("aiPanel.quoteChip.dismiss")}
+              aria-label={t("aiPanel.quoteChip.dismiss")}
+              className="shrink-0 size-[18px] flex items-center justify-center rounded hover:bg-bg-input cursor-pointer"
+            >
+              <X size={13} className="text-text-muted" />
+            </button>
+          </div>
+        )}
         <div className="flex gap-2 items-start">
           <textarea
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={t("ai.placeholder")}
+            spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="off"
             rows={2}
             className="flex-1 h-[60px] bg-bg-input rounded-lg px-3 py-2 text-[14px] text-text-primary placeholder:text-text-placeholder tracking-[-0.15px] leading-5 outline-none border border-transparent focus:border-accent resize-none"
           />

--- a/src/components/AiPanel.tsx
+++ b/src/components/AiPanel.tsx
@@ -140,6 +140,7 @@ export default function AiPanel({ bookId, bookTitle, bookAuthor, currentChapter,
             <button
               onClick={() => setPickerOpen(!pickerOpen)}
               onDoubleClick={() => {
+                if (titling) return;
                 setTitleDraft(currentChat?.title || t("ai.newChat"));
                 setEditingTitle(true);
               }}

--- a/src/components/ChatDetailView.tsx
+++ b/src/components/ChatDetailView.tsx
@@ -17,7 +17,7 @@ export default function ChatDetailView({ chat, onBack, onChatDeleted }: ChatDeta
   const { t } = useTranslation();
   const {
     messages, streaming, send, initialize,
-    chatId, chats, titling, loadChat, deleteChat, renameChat,
+    chatId, chats, titling, initializing, loadChat, deleteChat, renameChat,
   } = useAiChat(chat.book_id, { title: chat.book_title ?? undefined });
 
   const [input, setInput] = useState("");
@@ -45,7 +45,7 @@ export default function ChatDetailView({ chat, onBack, onChatDeleted }: ChatDeta
   }, [editingTitle]);
 
   const handleSend = () => {
-    if (!input.trim() || streaming) return;
+    if (!input.trim() || streaming || initializing) return;
     send(input.trim());
     setInput("");
   };
@@ -175,9 +175,9 @@ export default function ChatDetailView({ chat, onBack, onChatDeleted }: ChatDeta
           />
           <button
             onClick={handleSend}
-            disabled={!input.trim() || streaming}
+            disabled={!input.trim() || streaming || initializing}
             className={`size-[60px] shrink-0 rounded-lg flex items-center justify-center cursor-pointer bg-accent text-white ${
-              !input.trim() || streaming ? "opacity-50" : ""
+              !input.trim() || streaming || initializing ? "opacity-50" : ""
             }`}
           >
             {streaming ? (

--- a/src/components/ChatDetailView.tsx
+++ b/src/components/ChatDetailView.tsx
@@ -99,6 +99,7 @@ export default function ChatDetailView({ chat, onBack, onChatDeleted }: ChatDeta
               <span
                 className="text-[15px] font-semibold text-text-primary tracking-[-0.23px] truncate cursor-default"
                 onDoubleClick={() => {
+                  if (titling) return;
                   setTitleDraft(currentTitle);
                   setEditingTitle(true);
                 }}

--- a/src/components/ChatDetailView.tsx
+++ b/src/components/ChatDetailView.tsx
@@ -167,6 +167,9 @@ export default function ChatDetailView({ chat, onBack, onChatDeleted }: ChatDeta
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={t("ai.placeholder")}
+            spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="off"
             rows={2}
             className="flex-1 h-[60px] bg-bg-input rounded-lg px-3 py-2 text-[14px] text-text-primary placeholder:text-text-placeholder tracking-[-0.15px] leading-5 outline-none border border-transparent focus:border-accent resize-none"
           />

--- a/src/components/ExplainPopover.tsx
+++ b/src/components/ExplainPopover.tsx
@@ -1,0 +1,242 @@
+import { useState, useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { X, Loader2, WandSparkles, Check, Copy, Settings } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import Markdown from "react-markdown";
+import { LOOKUP_PROSE } from "./lookup-prose";
+
+interface ExplainPopoverProps {
+  x: number;
+  y: number;
+  text: string;
+  sentence: string;
+  bookTitle?: string;
+  chapter?: string;
+  bookId: string;
+  cfi?: string;
+  onClose: () => void;
+}
+
+function useExplainStream(
+  passage: string,
+  surrounding: string | undefined,
+  bookTitle: string | undefined,
+  chapter: string | undefined
+) {
+  const contentRef = useRef("");
+  const [content, setContent] = useState("");
+  const [streaming, setStreaming] = useState(true);
+  const [notConfigured, setNotConfigured] = useState(false);
+  const unlistenRef = useRef<UnlistenFn | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    contentRef.current = "";
+
+    const run = async () => {
+      const requestId = crypto.randomUUID();
+
+      unlistenRef.current = await listen<{ delta: string; done: boolean }>(
+        `ai-lookup-chunk-${requestId}`,
+        (event) => {
+          if (cancelled) return;
+          if (event.payload.done) {
+            setStreaming(false);
+            unlistenRef.current?.();
+            unlistenRef.current = null;
+            return;
+          }
+          contentRef.current += event.payload.delta;
+          setContent(contentRef.current);
+        }
+      );
+
+      try {
+        await invoke("ai_explain", {
+          passage,
+          surrounding: surrounding || null,
+          bookTitle: bookTitle || null,
+          chapter: chapter || null,
+          requestId,
+        });
+      } catch (err) {
+        if (!cancelled) {
+          const msg = String(err);
+          if (msg.includes("AI_NOT_CONFIGURED")) {
+            setNotConfigured(true);
+          } else {
+            setContent(`Error: ${msg}`);
+          }
+          setStreaming(false);
+        }
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      unlistenRef.current?.();
+      unlistenRef.current = null;
+    };
+  }, [passage, surrounding, bookTitle, chapter]);
+
+  return { content, contentRef, streaming, notConfigured };
+}
+
+export default function ExplainPopover({
+  x,
+  y,
+  text,
+  sentence,
+  bookTitle,
+  chapter,
+  onClose,
+}: ExplainPopoverProps) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const { content, contentRef, streaming, notConfigured } = useExplainStream(
+    text,
+    sentence,
+    bookTitle,
+    chapter
+  );
+
+  // Position clamping — re-run whenever the popover resizes (e.g. as content streams in)
+  const [pos, setPos] = useState({ left: x, top: y });
+
+  useEffect(() => {
+    const el = popoverRef.current;
+    if (!el) return;
+    const clamp = () => {
+      const rect = el.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      let left = x;
+      let top = y;
+      if (left + rect.width > vw - 16) left = vw - rect.width - 16;
+      if (left < 16) left = 16;
+      if (top + rect.height > vh - 16) top = y - rect.height - 8;
+      if (top < 16) top = 16;
+      setPos({ left, top });
+    };
+    const observer = new ResizeObserver(clamp);
+    observer.observe(el);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(contentRef.current);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  // Dismiss on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  // Dismiss on click outside — delay registration to avoid catching the
+  // context-menu click that opened us
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const id = requestAnimationFrame(() => {
+      document.addEventListener("mousedown", handler);
+    });
+    return () => {
+      cancelAnimationFrame(id);
+      document.removeEventListener("mousedown", handler);
+    };
+  }, [onClose]);
+
+  return (
+    <>
+    <div className="fixed inset-0 z-40" onClick={onClose} />
+    <div
+      ref={popoverRef}
+      className="fixed z-50 w-[440px] bg-bg-surface border border-border/80 rounded-xl shadow-context"
+      style={{ left: pos.left, top: pos.top }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 pt-3 pb-2.5 bg-accent-bg rounded-t-xl border-b border-border/40">
+        <div className="flex items-center gap-2">
+          <WandSparkles size={16} className="text-accent-text" />
+          <span className="text-[14px] font-medium text-accent-text tracking-[-0.15px]">
+            {t("explain.title")}
+          </span>
+        </div>
+        <button
+          onClick={onClose}
+          className="size-6 flex items-center justify-center rounded hover:bg-bg-surface/60 cursor-pointer"
+        >
+          <X size={14} className="text-text-muted" />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="px-4 pb-2 max-h-[360px] overflow-auto">
+        {/* Selected passage */}
+        <div className="border-l-2 border-[#c084fc] pl-3 pt-3 pb-1">
+          <p className="text-[12px] italic text-text-muted line-clamp-3">{text}</p>
+        </div>
+
+        {notConfigured ? (
+          <div className="flex flex-col items-center gap-2 py-4 text-center">
+            <p className="text-[13px] text-text-muted">{t("ai.notConfigured")}</p>
+            <button
+              onClick={async () => {
+                onClose();
+                await invoke("open_settings_on_main", { section: "ai" });
+                const main = await WebviewWindow.getByLabel("main");
+                await main?.setFocus();
+              }}
+              className="flex items-center gap-1.5 text-[13px] font-medium text-accent-text hover:opacity-70 cursor-pointer"
+            >
+              <Settings size={14} />
+              {t("ai.openSettings")}
+            </button>
+          </div>
+        ) : streaming && !content ? (
+          <div className="flex items-center gap-1.5 py-3">
+            <Loader2 size={14} className="animate-spin text-text-muted" />
+            <span className="text-[13px] text-text-muted">{t("explain.thinking")}</span>
+          </div>
+        ) : (
+          <div className={`${LOOKUP_PROSE} text-[13px] text-text-primary pt-2.5`}>
+            <Markdown>{content}</Markdown>
+            {streaming && (
+              <Loader2 size={12} className="inline-block ml-0.5 animate-spin text-text-muted" />
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Footer — Copy */}
+      {!streaming && content && !notConfigured && (
+        <div className="flex items-center justify-end px-4 py-2.5 border-t border-border/40">
+          <button
+            onClick={handleCopy}
+            className="flex items-center gap-1.5 text-[13px] font-medium cursor-pointer text-text-muted hover:opacity-70"
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+            {copied ? t("explain.copied") : t("explain.copy")}
+          </button>
+        </div>
+      )}
+    </div>
+    </>
+  );
+}

--- a/src/components/ReaderContextMenu.tsx
+++ b/src/components/ReaderContextMenu.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from "react";
 import {
   Copy,
-  Bot,
+  WandSparkles,
+  Quote,
   Sparkles,
   Highlighter,
   Languages,
@@ -22,7 +23,8 @@ interface ReaderContextMenuProps {
   text: string;
   onClose: () => void;
   onCopy: () => void;
-  onAskAI: () => void;
+  onExplain: () => void;
+  onQuote: () => void;
   onLookup: () => void;
   onTranslate: () => void;
   onHighlight?: (color: string) => void;
@@ -34,7 +36,8 @@ export default function ReaderContextMenu({
   text,
   onClose,
   onCopy,
-  onAskAI,
+  onExplain,
+  onQuote,
   onLookup,
   onTranslate,
   onHighlight,
@@ -94,14 +97,25 @@ export default function ReaderContextMenu({
         </button>
       )}
 
-      {/* Ask AI Assistant */}
+      {/* Explain */}
       <button
-        onClick={onAskAI}
+        onClick={onExplain}
         className="flex items-center gap-3 w-[calc(100%-8px)] mx-1 px-3 h-[31.5px] rounded-sm text-left cursor-pointer hover:bg-accent-bg transition-colors"
       >
-        <Bot size={16} className="text-text-muted" />
+        <WandSparkles size={16} className="text-text-muted" />
         <span className="flex-1 text-[13px] font-medium text-text-primary tracking-[-0.08px]">
-          {t("contextMenu.askAI")}
+          {t("contextMenu.explain")}
+        </span>
+      </button>
+
+      {/* Quote */}
+      <button
+        onClick={onQuote}
+        className="flex items-center gap-3 w-[calc(100%-8px)] mx-1 px-3 h-[31.5px] rounded-sm text-left cursor-pointer hover:bg-accent-bg transition-colors"
+      >
+        <Quote size={16} className="text-text-muted" />
+        <span className="flex-1 text-[13px] font-medium text-text-primary tracking-[-0.08px]">
+          {t("contextMenu.quote")}
         </span>
       </button>
 

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -15,6 +15,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         )}
         <input
           ref={ref}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
           className={`w-full h-9 bg-bg-surface rounded-lg text-[14px] tracking-[-0.15px] text-text-primary placeholder:text-text-placeholder outline-none border border-border focus:border-accent ${
             icon ? "pl-9 pr-3" : "px-3"
           }`}

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -254,14 +254,20 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
         const titleSource = context || content;
         setTitling(true);
         generateAiTitle(titleSource).then(async (aiTitle) => {
-          const title = aiTitle || deriveTitle(titleSource);
-          if (title) {
-            try {
-              await invoke("rename_chat", { chatId: currentChatId, title });
-              await refreshChats(currentBookId);
-            } catch { /* ignore */ }
+          try {
+            // Only auto-title if the chat is still untitled — the user (or a
+            // synced rename) may have renamed it while generation was pending.
+            const chat = await invoke<ChatRecord>("get_chat", { chatId: currentChatId });
+            if (chat.title === "New chat") {
+              const title = aiTitle || deriveTitle(titleSource);
+              if (title) {
+                await invoke("rename_chat", { chatId: currentChatId, title });
+                await refreshChats(currentBookId);
+              }
+            }
+          } catch { /* ignore */ } finally {
+            setTitling(false);
           }
-          setTitling(false);
         });
       }
 

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -117,6 +117,10 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [streaming, setStreaming] = useState(false);
   const [titling, setTitling] = useState(false);
+  // True from mount until the first initialize() resolves. Consumers gate
+  // sending on this so a message can't be sent (and lazily create a *new*
+  // chat) before the existing session chat has loaded.
+  const [initializing, setInitializing] = useState(true);
   const [chatId, setChatId] = useState<string | null>(null);
   const [chats, setChats] = useState<ChatRecord[]>([]);
 
@@ -216,19 +220,24 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
 
   const initialize = useCallback(async (bid?: string) => {
     const targetBook = bid || bookId;
-    if (!targetBook) return;
-    if (initializedBookRef.current === targetBook) return;
+    if (!targetBook) { setInitializing(false); return; }
+    if (initializedBookRef.current === targetBook) { setInitializing(false); return; }
     initializedBookRef.current = targetBook;
+    setInitializing(true);
 
-    const chatList = await refreshChats(targetBook);
-    if (chatList.length > 0) {
-      await loadChat(chatList[0].id);
-    } else {
-      // No chats yet — show empty state without creating a DB record.
-      // A chat will be created lazily on first send.
-      setChatId(null);
-      chatIdRef.current = null;
-      updateMessages([]);
+    try {
+      const chatList = await refreshChats(targetBook);
+      if (chatList.length > 0) {
+        await loadChat(chatList[0].id);
+      } else {
+        // No chats yet — show empty state without creating a DB record.
+        // A chat will be created lazily on first send.
+        setChatId(null);
+        chatIdRef.current = null;
+        updateMessages([]);
+      }
+    } finally {
+      setInitializing(false);
     }
   }, [bookId, refreshChats, loadChat]);
 
@@ -436,6 +445,7 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
     messages,
     streaming,
     titling,
+    initializing,
     send,
     reset,
     initialize,

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -129,6 +129,14 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
   const messagesRef = useRef<ChatMessage[]>([]);
   const chatIdRef = useRef<string | null>(null);
   const streamingRef = useRef(false);
+  const initializingRef = useRef(true);
+
+  // Keep the ref in lockstep with the state so send() (which reads refs to
+  // avoid stale closures) can refuse while initialization is in flight.
+  const setInitializingSynced = (v: boolean) => {
+    initializingRef.current = v;
+    setInitializing(v);
+  };
 
   // Cleanup stream listener on unmount
   useEffect(() => {
@@ -220,10 +228,10 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
 
   const initialize = useCallback(async (bid?: string) => {
     const targetBook = bid || bookId;
-    if (!targetBook) { setInitializing(false); return; }
-    if (initializedBookRef.current === targetBook) { setInitializing(false); return; }
+    if (!targetBook) { setInitializingSynced(false); return; }
+    if (initializedBookRef.current === targetBook) { setInitializingSynced(false); return; }
     initializedBookRef.current = targetBook;
-    setInitializing(true);
+    setInitializingSynced(true);
 
     try {
       const chatList = await refreshChats(targetBook);
@@ -237,13 +245,18 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
         updateMessages([]);
       }
     } finally {
-      setInitializing(false);
+      setInitializingSynced(false);
     }
   }, [bookId, refreshChats, loadChat]);
 
   /* eslint-disable react-hooks/preserve-manual-memoization */
   const send = useCallback(
     async (content: string, context?: string, contextCfi?: string) => {
+      // Refuse while the session chat is still loading — otherwise the lazy
+      // chat-creation path below would spawn a *new* chat and miss the
+      // existing one. Belt-and-suspenders alongside the UI gate.
+      if (initializingRef.current) return;
+
       let currentChatId = chatIdRef.current;
       const currentBookId = bookId;
 

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -48,10 +48,11 @@ function deriveTitle(userMsg: string): string {
   return title;
 }
 
-/** Generate a chat title using a dedicated AI call with per-request event channel. */
+/** Generate a chat title using a dedicated AI call with per-request event channel.
+ *  Titles from the user's first message alone so it can run concurrently with
+ *  the response stream instead of waiting for it to finish. */
 async function generateAiTitle(
   userMsg: string,
-  assistantMsg: string,
 ): Promise<string | null> {
   const requestId = `title-${Date.now()}`;
   const eventName = `ai-title-chunk-${requestId}`;
@@ -91,7 +92,7 @@ async function generateAiTitle(
   // Fire the command (returns immediately, streaming happens in background)
   invoke("ai_generate_title", {
     userMessage: userMsg,
-    assistantMessage: assistantMsg,
+    assistantMessage: "",
     requestId,
   }).catch(() => {
     unlisten();
@@ -246,8 +247,23 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
       }
       if (!currentChatId) return;
 
-      // Show title loading immediately for new chats
-      if (isNewChat) setTitling(true);
+      // New chat: generate the title from the user's message, concurrently with
+      // the response stream (not after it), showing a loading state until it
+      // lands. Falls back to a truncated title if the AI call fails.
+      if (isNewChat && currentBookId) {
+        const titleSource = context || content;
+        setTitling(true);
+        generateAiTitle(titleSource).then(async (aiTitle) => {
+          const title = aiTitle || deriveTitle(titleSource);
+          if (title) {
+            try {
+              await invoke("rename_chat", { chatId: currentChatId, title });
+              await refreshChats(currentBookId);
+            } catch { /* ignore */ }
+          }
+          setTitling(false);
+        });
+      }
 
       const userMessage: ChatMessage = {
         id: nextMsgId(),
@@ -308,25 +324,6 @@ export function useAiChat(bookId?: string, bookContext?: BookContext) {
               } catch (err) {
                 console.error("Failed to save assistant message:", err);
               }
-            }
-
-            // Auto-title: use AI with per-request channel, fallback to truncation
-            if (currentBookId && isNewChat) {
-              try {
-                const chat = await invoke<ChatRecord>("get_chat", { chatId: currentChatId });
-                if (chat.title === "New chat") {
-                  const userText = context || content;
-                  const aiTitle = await generateAiTitle(userText, fullContent);
-                  const title = aiTitle || deriveTitle(userText);
-                  if (title) {
-                    await invoke("rename_chat", { chatId: currentChatId, title });
-                    await refreshChats(currentBookId);
-                  }
-                }
-              } catch {
-                // Ignore auto-title errors
-              }
-              setTitling(false);
             }
 
             return;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -53,7 +53,6 @@
   "ai.placeholder": "Ask me anything about what you're reading...",
   "ai.sendHint": "Press Enter to send, Shift+Enter for new line",
   "ai.thinking": "Thinking...",
-  "ai.explain": "Explain",
   "ai.prompt.summarize": "Summarize this chapter",
   "ai.prompt.themes": "Explain the main themes",
   "ai.prompt.characters": "Who are the key characters?",
@@ -124,8 +123,16 @@
   "lookup.copy": "Copy",
   "lookup.copied": "Copied",
 
+  "explain.title": "Explain",
+  "explain.thinking": "Explaining...",
+  "explain.copy": "Copy",
+  "explain.copied": "Copied",
+
+  "aiPanel.quoteChip.dismiss": "Remove quote",
+
   "contextMenu.lookUp": "Look Up",
-  "contextMenu.askAI": "Ask AI Assistant",
+  "contextMenu.explain": "Explain",
+  "contextMenu.quote": "Quote",
   "contextMenu.translate": "Translate",
   "contextMenu.highlight": "Highlight",
   "contextMenu.copy": "Copy",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -53,7 +53,6 @@
   "ai.placeholder": "关于正在阅读的内容，随便问我...",
   "ai.sendHint": "按 Enter 发送，Shift+Enter 换行",
   "ai.thinking": "思考中...",
-  "ai.explain": "解释",
   "ai.prompt.summarize": "总结这一章",
   "ai.prompt.themes": "解释主要主题",
   "ai.prompt.characters": "主要人物有哪些？",
@@ -124,8 +123,16 @@
   "lookup.copy": "复制",
   "lookup.copied": "已复制",
 
+  "explain.title": "解释",
+  "explain.thinking": "正在解释...",
+  "explain.copy": "复制",
+  "explain.copied": "已复制",
+
+  "aiPanel.quoteChip.dismiss": "移除引用",
+
   "contextMenu.lookUp": "查词",
-  "contextMenu.askAI": "询问 AI 助手",
+  "contextMenu.explain": "解释",
+  "contextMenu.quote": "引用",
   "contextMenu.translate": "翻译",
   "contextMenu.highlight": "高亮",
   "contextMenu.copy": "复制",

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -21,6 +21,7 @@ import ReaderSettings, { type ReaderSettingsState, getFontFamily, getThemeStyles
 import ReaderContextMenu from "../components/ReaderContextMenu";
 import HighlightToolbar from "../components/HighlightToolbar";
 import LookupPopover from "../components/LookupPopover";
+import ExplainPopover from "../components/ExplainPopover";
 import DictionaryPanel from "../components/DictionaryPanel";
 import TranslationPopover from "../components/TranslationPopover";
 import TableOfContents from "../components/TableOfContents";
@@ -258,6 +259,15 @@ export default function Reader() {
     x: number;
     y: number;
     word: string;
+    sentence: string;
+    bookTitle?: string;
+    chapter?: string;
+    cfi?: string;
+  } | null>(null);
+  const [explain, setExplain] = useState<{
+    x: number;
+    y: number;
+    text: string;
     sentence: string;
     bookTitle?: string;
     chapter?: string;
@@ -1391,7 +1401,22 @@ export default function Reader() {
             navigator.clipboard.writeText(contextMenu.text);
             setContextMenu(null);
           }}
-          onAskAI={() => {
+          onExplain={() => {
+            const chapterTitle = currentChapterIndex >= 0 && currentChapterIndex < chapters.length
+              ? chapters[currentChapterIndex].title
+              : undefined;
+            setExplain({
+              x: contextMenu.x,
+              y: contextMenu.y,
+              text: contextMenu.text,
+              sentence: contextMenu.sentence,
+              bookTitle: book?.title,
+              chapter: chapterTitle,
+              cfi: contextMenu.cfiRange,
+            });
+            setContextMenu(null);
+          }}
+          onQuote={() => {
             setAiContext({
               text: contextMenu.text,
               cfi: contextMenu.cfiRange,
@@ -1452,6 +1477,20 @@ export default function Reader() {
           bookId={bookId!}
           cfi={lookup.cfi}
           onClose={() => setLookup(null)}
+        />
+      )}
+
+      {explain && (
+        <ExplainPopover
+          x={explain.x}
+          y={explain.y}
+          text={explain.text}
+          sentence={explain.sentence}
+          bookTitle={explain.bookTitle}
+          chapter={explain.chapter}
+          bookId={bookId!}
+          cfi={explain.cfi}
+          onClose={() => setExplain(null)}
         />
       )}
 


### PR DESCRIPTION
Closes #215.

Replaces the reader selection menu's single **Ask AI Assistant** entry with two distinct intents.

## Explain
- Inline one-shot popover (`ExplainPopover`), modeled on `LookupPopover`, that streams a concise, in-context explanation of the selected passage.
- New `ai_explain` backend command — single stream, its own brevity-tuned prompt (2–3 sentences, no headers, no token cap), response-language aware. Separate from `ai_lookup` (which is word-shaped and runs two concurrent streams). Includes unit tests for the prompt builder.

## Quote
- Pins the selected passage as a dismissable **chip above the AI composer**; on send it rides along as the message's citation (rendered as a block-quote in the user turn).
- **Attaches to the existing per-book chat instead of resetting it** — the old flow always reset + auto-sent. Only creates a chat when none exists for the session.

## Also in this branch
- **Chat titles** now generate concurrently from the first message with a loading state, instead of blocking until the full response finishes streaming.
- **Disable spellcheck/autocorrect** on the chat composers and search inputs (per-component, via `ui/Input` + the raw fields).
- **Docs:** #215 impl plan (`docs/impls/215-explain-and-quote.md`); #257 persist-explanations follow-up spec.
- **Design:** Explain popover, selection-menu split, and quote-chip frames in `quill-desktop.pen`.

## Test plan
- `cargo test --lib` → 244 passed (incl. 4 new `ai_explain` prompt tests).
- `npm run build` (tsc + vite) clean; eslint clean on touched files.
- ⚠️ Not yet runtime-verified — recommend a manual pass: Explain stream, Quote into an existing chat (prior turns preserved), chip dismiss, title loading → swap, no spellcheck squiggles.

## Follow-up
- #257 — persist explanations + Explanations tools page (deferred v2; spec included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)