### PR TITLE
Fix blocking sync status on Library Sync tab

### DIFF
--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -141,59 +141,67 @@ impl From<CompactReport> for SyncCompactResult {
 }
 
 #[tauri::command]
-pub fn sync_status(
+pub async fn sync_status(
     local: State<'_, LocalDir>,
     db: State<'_, Db>,
     device: State<'_, DeviceIdentity>,
     sync_state: State<'_, SyncState>,
 ) -> AppResult<SyncStatus> {
-    let sync_enabled = sync::migration::is_sync_enabled(&local.0);
-    let shared_dir = sync::migration::recorded_data_dir(&local.0)
-        .or_else(icloud::icloud_data_dir);
-    let available = icloud::icloud_data_dir().is_some_and(|p| p.exists())
-        || icloud::is_icloud_available();
+    let local_dir = local.0.clone();
+    let db = db.inner().clone();
+    let device_uuid = device.device_uuid.clone();
     let enabled = sync_state.engine_snapshot()?.is_some();
 
-    // Peer list + outbox count when the user has sync enabled (even
-    // if the engine hasn't booted yet — e.g. during async boot or
-    // offline queue-only mode). Skip when fully disabled.
-    let (peer_infos, pending_events, last_replay_at) = if sync_enabled {
-        let peers = match shared_dir.as_ref() {
-            Some(dir) => peers::list_peers(dir, &device.device_uuid).unwrap_or_else(|e| {
-                log::warn!("sync_status: list_peers failed: {e}");
-                Vec::new()
-            }),
-            None => Vec::new(),
-        };
-        let infos: Vec<PeerInfo> = peers
-            .into_iter()
-            .map(|p| PeerInfo {
-                device_uuid: p.device_uuid,
-                name: p.name,
-                platform: p.platform,
-                app_version: p.app_version,
-                last_seen: p.last_seen,
-                pending_events: 0,
-            })
-            .collect();
-        let pending = count_local_outbox(&db).unwrap_or(0);
-        let last = read_last_replay_at(&db).unwrap_or(None);
-        (infos, pending, last)
-    } else {
-        (Vec::new(), 0, None)
-    };
+    tokio::task::spawn_blocking(move || {
+        let sync_enabled = sync::migration::is_sync_enabled(&local_dir);
+        let shared_dir = sync::migration::recorded_data_dir(&local_dir)
+            .or_else(icloud::icloud_data_dir);
+        let available = icloud::icloud_data_dir().is_some_and(|p| p.exists())
+            || icloud::is_icloud_available();
 
-    Ok(SyncStatus {
-        enabled,
-        available,
-        sync_enabled,
-        shared_dir: shared_dir.map(|p| p.to_string_lossy().into_owned()),
-        device_uuid: device.device_uuid.clone(),
-        device_name: peers::device_name(),
-        peers: peer_infos,
-        pending_events,
-        last_replay_at,
+        // Peer list + outbox count when the user has sync enabled (even
+        // if the engine hasn't booted yet — e.g. during async boot or
+        // offline queue-only mode). Skip when fully disabled.
+        let (peer_infos, pending_events, last_replay_at) = if sync_enabled {
+            let peers = match shared_dir.as_ref() {
+                Some(dir) => peers::list_peers(dir, &device_uuid).unwrap_or_else(|e| {
+                    log::warn!("sync_status: list_peers failed: {e}");
+                    Vec::new()
+                }),
+                None => Vec::new(),
+            };
+            let infos: Vec<PeerInfo> = peers
+                .into_iter()
+                .map(|p| PeerInfo {
+                    device_uuid: p.device_uuid,
+                    name: p.name,
+                    platform: p.platform,
+                    app_version: p.app_version,
+                    last_seen: p.last_seen,
+                    pending_events: 0,
+                })
+                .collect();
+            let pending = count_local_outbox(&db).unwrap_or(0);
+            let last = read_last_replay_at(&db).unwrap_or(None);
+            (infos, pending, last)
+        } else {
+            (Vec::new(), 0, None)
+        };
+
+        Ok(SyncStatus {
+            enabled,
+            available,
+            sync_enabled,
+            shared_dir: shared_dir.map(|p| p.to_string_lossy().into_owned()),
+            device_uuid,
+            device_name: peers::device_name(),
+            peers: peer_infos,
+            pending_events,
+            last_replay_at,
+        })
     })
+    .await
+    .map_err(|e| AppError::Other(format!("sync_status worker failed: {e}")))?
 }
 
 #[tauri::command]

--- a/src/components/settings/LibrarySyncSettings.tsx
+++ b/src/components/settings/LibrarySyncSettings.tsx
@@ -231,6 +231,7 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
   const available = status?.available ?? false;
   const peers = status?.peers ?? [];
   const initialStatusLoading = loadingStatus && !status;
+  const showPeerStatus = syncOn || initialStatusLoading;
 
   return (
     <>
@@ -273,14 +274,21 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
             files on disk, not from the running engine, so it's still
             meaningful offline. The empty state still renders so a
             single-device user understands why the list is empty. */}
-        {syncOn && (
+        {showPeerStatus && (
           <>
             <div className="h-px bg-black/10" />
             <div className="pt-4 pb-2">
               <p className="text-[11px] font-semibold text-text-muted tracking-[0.6px]">
                 {t("settings.librarySync.otherDevices").toUpperCase()}
               </p>
-              {peers.length === 0 ? (
+              {initialStatusLoading ? (
+                <div className="flex items-center gap-2 mt-2">
+                  <Loader2 size={14} className="text-text-muted animate-spin" />
+                  <p className="text-[12px] text-text-muted">
+                    {t("settings.librarySync.working")}
+                  </p>
+                </div>
+              ) : peers.length === 0 ? (
                 <p className="text-[12px] text-text-muted mt-2 leading-[1.5]">
                   {t("settings.librarySync.noPeers")}
                 </p>
@@ -325,40 +333,44 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
                 </div>
               )}
             </div>
-            <div className="h-px bg-black/10 mt-3" />
+            {syncOn && (
+              <>
+                <div className="h-px bg-black/10 mt-3" />
 
-            {/* Actions row. Sync now / Compact log both require the
-                engine to be running this session — disable them when
-                we're in queue-only mode so the user isn't confused by
-                an error toast. The "Last sync" caption still renders
-                whatever the backend reports. */}
-            <div className="flex items-center justify-between pt-4 pb-2">
-              <div className="flex items-center gap-4">
-                <button
-                  type="button"
-                  onClick={syncing ? () => invoke("sync_cancel") : onSyncNow}
-                  disabled={(!syncing && busy) || !engineRunning}
-                  title={!engineRunning ? t("settings.librarySync.paused") : undefined}
-                  className="text-[13px] font-medium text-[#7c3aed] hover:underline disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-                >
-                  {syncing ? t("settings.librarySync.cancelSync") : t("settings.librarySync.syncNow")}
-                </button>
-                <button
-                  type="button"
-                  onClick={onCompact}
-                  disabled={busy || !engineRunning}
-                  title={!engineRunning ? t("settings.librarySync.paused") : undefined}
-                  className="text-[13px] font-medium text-[#7c3aed] hover:underline disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-                >
-                  {t("settings.librarySync.compact")}
-                </button>
-              </div>
-              <p className="text-[12px] text-text-muted">
-                {t("settings.librarySync.lastSyncAt", {
-                  time: formatRelative(status?.last_replay_at ?? null, now),
-                })}
-              </p>
-            </div>
+                {/* Actions row. Sync now / Compact log both require the
+                    engine to be running this session — disable them when
+                    we're in queue-only mode so the user isn't confused by
+                    an error toast. The "Last sync" caption still renders
+                    whatever the backend reports. */}
+                <div className="flex items-center justify-between pt-4 pb-2">
+                  <div className="flex items-center gap-4">
+                    <button
+                      type="button"
+                      onClick={syncing ? () => invoke("sync_cancel") : onSyncNow}
+                      disabled={(!syncing && busy) || !engineRunning}
+                      title={!engineRunning ? t("settings.librarySync.paused") : undefined}
+                      className="text-[13px] font-medium text-[#7c3aed] hover:underline disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                    >
+                      {syncing ? t("settings.librarySync.cancelSync") : t("settings.librarySync.syncNow")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={onCompact}
+                      disabled={busy || !engineRunning}
+                      title={!engineRunning ? t("settings.librarySync.paused") : undefined}
+                      className="text-[13px] font-medium text-[#7c3aed] hover:underline disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                    >
+                      {t("settings.librarySync.compact")}
+                    </button>
+                  </div>
+                  <p className="text-[12px] text-text-muted">
+                    {t("settings.librarySync.lastSyncAt", {
+                      time: formatRelative(status?.last_replay_at ?? null, now),
+                    })}
+                  </p>
+                </div>
+              </>
+            )}
           </>
         )}
 

--- a/src/components/settings/LibrarySyncSettings.tsx
+++ b/src/components/settings/LibrarySyncSettings.tsx
@@ -231,7 +231,6 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
   const available = status?.available ?? false;
   const peers = status?.peers ?? [];
   const initialStatusLoading = loadingStatus && !status;
-  const showPeerStatus = syncOn || initialStatusLoading;
 
   return (
     <>
@@ -274,21 +273,14 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
             files on disk, not from the running engine, so it's still
             meaningful offline. The empty state still renders so a
             single-device user understands why the list is empty. */}
-        {showPeerStatus && (
+        {syncOn && (
           <>
             <div className="h-px bg-black/10" />
             <div className="pt-4 pb-2">
               <p className="text-[11px] font-semibold text-text-muted tracking-[0.6px]">
                 {t("settings.librarySync.otherDevices").toUpperCase()}
               </p>
-              {initialStatusLoading ? (
-                <div className="flex items-center gap-2 mt-2">
-                  <Loader2 size={14} className="text-text-muted animate-spin" />
-                  <p className="text-[12px] text-text-muted">
-                    {t("settings.librarySync.working")}
-                  </p>
-                </div>
-              ) : peers.length === 0 ? (
+              {peers.length === 0 ? (
                 <p className="text-[12px] text-text-muted mt-2 leading-[1.5]">
                   {t("settings.librarySync.noPeers")}
                 </p>
@@ -333,44 +325,40 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
                 </div>
               )}
             </div>
-            {syncOn && (
-              <>
-                <div className="h-px bg-black/10 mt-3" />
+            <div className="h-px bg-black/10 mt-3" />
 
-                {/* Actions row. Sync now / Compact log both require the
-                    engine to be running this session — disable them when
-                    we're in queue-only mode so the user isn't confused by
-                    an error toast. The "Last sync" caption still renders
-                    whatever the backend reports. */}
-                <div className="flex items-center justify-between pt-4 pb-2">
-                  <div className="flex items-center gap-4">
-                    <button
-                      type="button"
-                      onClick={syncing ? () => invoke("sync_cancel") : onSyncNow}
-                      disabled={(!syncing && busy) || !engineRunning}
-                      title={!engineRunning ? t("settings.librarySync.paused") : undefined}
-                      className="text-[13px] font-medium text-[#7c3aed] hover:underline disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-                    >
-                      {syncing ? t("settings.librarySync.cancelSync") : t("settings.librarySync.syncNow")}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={onCompact}
-                      disabled={busy || !engineRunning}
-                      title={!engineRunning ? t("settings.librarySync.paused") : undefined}
-                      className="text-[13px] font-medium text-[#7c3aed] hover:underline disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-                    >
-                      {t("settings.librarySync.compact")}
-                    </button>
-                  </div>
-                  <p className="text-[12px] text-text-muted">
-                    {t("settings.librarySync.lastSyncAt", {
-                      time: formatRelative(status?.last_replay_at ?? null, now),
-                    })}
-                  </p>
-                </div>
-              </>
-            )}
+            {/* Actions row. Sync now / Compact log both require the
+                engine to be running this session — disable them when
+                we're in queue-only mode so the user isn't confused by
+                an error toast. The "Last sync" caption still renders
+                whatever the backend reports. */}
+            <div className="flex items-center justify-between pt-4 pb-2">
+              <div className="flex items-center gap-4">
+                <button
+                  type="button"
+                  onClick={syncing ? () => invoke("sync_cancel") : onSyncNow}
+                  disabled={(!syncing && busy) || !engineRunning}
+                  title={!engineRunning ? t("settings.librarySync.paused") : undefined}
+                  className="text-[13px] font-medium text-[#7c3aed] hover:underline disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                >
+                  {syncing ? t("settings.librarySync.cancelSync") : t("settings.librarySync.syncNow")}
+                </button>
+                <button
+                  type="button"
+                  onClick={onCompact}
+                  disabled={busy || !engineRunning}
+                  title={!engineRunning ? t("settings.librarySync.paused") : undefined}
+                  className="text-[13px] font-medium text-[#7c3aed] hover:underline disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                >
+                  {t("settings.librarySync.compact")}
+                </button>
+              </div>
+              <p className="text-[12px] text-text-muted">
+                {t("settings.librarySync.lastSyncAt", {
+                  time: formatRelative(status?.last_replay_at ?? null, now),
+                })}
+              </p>
+            </div>
           </>
         )}
 

--- a/src/components/settings/LibrarySyncSettings.tsx
+++ b/src/components/settings/LibrarySyncSettings.tsx
@@ -63,6 +63,7 @@ function platformIcon(platform: string) {
 export default function LibrarySyncSettings(_props: SettingsProps) {
   const { t } = useTranslation();
   const [status, setStatus] = useState<SyncStatus | null>(null);
+  const [loadingStatus, setLoadingStatus] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirm, setConfirm] = useState<"enable" | "disable" | null>(null);
@@ -81,11 +82,14 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
   const [syncing, setSyncing] = useState(false);
 
   const refresh = useCallback(async () => {
+    setLoadingStatus(true);
     try {
       const next = await invoke<SyncStatus>("sync_status");
       setStatus(next);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoadingStatus(false);
     }
   }, []);
 
@@ -226,13 +230,14 @@ export default function LibrarySyncSettings(_props: SettingsProps) {
   const engineRunning = status?.enabled ?? false;
   const available = status?.available ?? false;
   const peers = status?.peers ?? [];
+  const initialStatusLoading = loadingStatus && !status;
 
   return (
     <>
       <div>
         {/* Sync toggle */}
         <div className="flex items-center justify-between h-[73px]">
-          {busy ? (
+          {busy || initialStatusLoading ? (
             <div className="flex items-center gap-2">
               <Loader2 size={16} className="text-text-muted animate-spin" />
               <p className="text-[13px] text-text-muted">


### PR DESCRIPTION
## Summary
- make `sync_status` async and move the iCloud peer/status snapshot onto a blocking worker thread
- keep a single initial loading state while Library Sync status loads on tab mount

Closes #261.

## Validation
- `pnpm exec tsc --noEmit`
- `cargo check`
- `pnpm run lint` (passes with existing warnings)
- `cargo test sync`
- `git diff --check`