### PR TITLE
Fix lookup translation parsing

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -21,6 +21,7 @@ const LOOKUP_TRANSLATION_MARKER: &str = "[[QUILL_TRANSLATION]]";
 
 fn language_name(code: &str) -> String {
     match code {
+        "en" => "English",
         "zh" => "Chinese (Simplified)",
         "ja" => "Japanese",
         "ko" => "Korean",
@@ -587,7 +588,8 @@ mod tests {
 
         let non_english_lookup = lookup_system_prompt("definition", "zh", "en", true);
         assert!(non_english_lookup.contains(LOOKUP_TRANSLATION_MARKER));
-        assert!(non_english_lookup.contains("English"));
+        assert!(non_english_lookup
+            .contains("brief translation of the word/phrase in English"));
         assert!(non_english_lookup
             .contains("After that first line, respond entirely in Chinese (Simplified)."));
 

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -17,6 +17,49 @@ pub struct AiStreamChunk {
     pub done: bool,
 }
 
+const LOOKUP_TRANSLATION_MARKER: &str = "[[QUILL_TRANSLATION]]";
+
+fn language_name(code: &str) -> String {
+    match code {
+        "zh" => "Chinese (Simplified)",
+        "ja" => "Japanese",
+        "ko" => "Korean",
+        "es" => "Spanish",
+        "fr" => "French",
+        "de" => "German",
+        _ => code,
+    }
+    .to_string()
+}
+
+fn lookup_system_prompt(
+    kind: &str,
+    language: &str,
+    native_language: &str,
+    show_translation: bool,
+) -> String {
+    let language_prefix = if language != "en" {
+        format!("Respond entirely in {}.\n\n", language_name(language))
+    } else if show_translation && native_language != "en" {
+        format!(
+            "Before the definition, provide a brief translation of the word/phrase in {}. The first line MUST be exactly `{}` followed immediately by the brief translation, then a newline. This marker is required machine-readable metadata, not a header. Keep the translation to a few words — no explanation, just the meaning. After that first line, proceed with the definition as usual. Do not put the marker anywhere except the first line.\n\n",
+            language_name(native_language),
+            LOOKUP_TRANSLATION_MARKER,
+        )
+    } else {
+        String::new()
+    };
+
+    let def_prefix = &language_prefix;
+    let ctx_prefix = if language != "en" { &language_prefix } else { "" };
+
+    match kind {
+        "definition" => format!("{}You are a reading assistant embedded in an ebook reader. The user selected a word or phrase and wants a dictionary-style definition.\n\nGive: pronunciation in IPA (if English), part of speech, and a concise definition in 1–2 sentences.\n\nIf the selection is a proper noun (person, place, historical event), give a brief factual identification instead.\n\nBe concise. No headers or labels.", def_prefix),
+        "context" => format!("{}You are a reading assistant embedded in an ebook reader. The user selected a word or phrase and wants to understand how it's used in the surrounding passage.\n\nExplain how the word is used in context. Consider the author's intent, tone, or any literary/idiomatic significance. Keep it to 2–3 sentences.\n\nBe concise. No headers or labels.", ctx_prefix),
+        _ => format!("{}You are a reading assistant embedded in an ebook reader. The user selected a word or phrase and wants to understand it.\n\nRespond in two parts:\n\n1. **Definition** — Give a dictionary-style entry: the word, pronunciation in IPA (if it's an English word), part of speech, and a concise definition in one sentence.\n\n2. **In context** — Explain how the word is used in the given passage. Consider the author's intent, tone, or any literary/idiomatic significance. Keep it to 2–3 sentences.\n\nIf the selection is a proper noun (person, place, historical event), replace the dictionary definition with a brief factual identification, then explain its relevance in context.\n\nDo not use headers or labels like \"Definition:\" or \"In context:\". Separate the two parts with a line break. Be concise.", def_prefix),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn ai_lookup(
@@ -81,37 +124,12 @@ pub async fn ai_lookup(
 
     let kind = kind.unwrap_or_else(|| "full".to_string());
 
-    // Language-aware lookup (uses lookup_language, falling back to system language):
-    // 1. When lookup language is non-English, respond entirely in that language
-    // 2. When English but translation is enabled, prepend a native translation
-    let language_prefix = if language != "en" {
-        let lang_name = match language.as_str() {
-            "zh" => "Chinese (Simplified)",
-            _ => &language,
-        };
-        format!("Respond entirely in {}.\n\n", lang_name)
-    } else if show_translation == "true" && native_language != "en" {
-        let lang_name = match native_language.as_str() {
-            "zh" => "Chinese (Simplified)",
-            _ => "the user's language",
-        };
-        format!(
-            "Before the definition, provide a brief translation of the word/phrase in {}. Keep the translation to a few words — no explanation, just the meaning. Then proceed with the definition as usual.\n\n",
-            lang_name
-        )
-    } else {
-        String::new()
-    };
-
-    // Only apply translation prefix to definition, not context
-    let def_prefix = &language_prefix;
-    let ctx_prefix = if language != "en" { &language_prefix } else { "" };
-
-    let system_prompt = match kind.as_str() {
-        "definition" => format!("{}You are a reading assistant embedded in an ebook reader. The user selected a word or phrase and wants a dictionary-style definition.\n\nGive: pronunciation in IPA (if English), part of speech, and a concise definition in 1–2 sentences.\n\nIf the selection is a proper noun (person, place, historical event), give a brief factual identification instead.\n\nBe concise. No headers or labels.", def_prefix),
-        "context" => format!("{}You are a reading assistant embedded in an ebook reader. The user selected a word or phrase and wants to understand how it's used in the surrounding passage.\n\nExplain how the word is used in context. Consider the author's intent, tone, or any literary/idiomatic significance. Keep it to 2–3 sentences.\n\nBe concise. No headers or labels.", ctx_prefix),
-        _ => format!("{}You are a reading assistant embedded in an ebook reader. The user selected a word or phrase and wants to understand it.\n\nRespond in two parts:\n\n1. **Definition** — Give a dictionary-style entry: the word, pronunciation in IPA (if it's an English word), part of speech, and a concise definition in one sentence.\n\n2. **In context** — Explain how the word is used in the given passage. Consider the author's intent, tone, or any literary/idiomatic significance. Keep it to 2–3 sentences.\n\nIf the selection is a proper noun (person, place, historical event), replace the dictionary definition with a brief factual identification, then explain its relevance in context.\n\nDo not use headers or labels like \"Definition:\" or \"In context:\". Separate the two parts with a line break. Be concise.", def_prefix),
-    };
+    let system_prompt = lookup_system_prompt(
+        kind.as_str(),
+        &language,
+        &native_language,
+        show_translation == "true",
+    );
 
     let max_tokens = match kind.as_str() {
         "definition" => Some(128),
@@ -540,5 +558,38 @@ mod tests {
                 "explain must not carry ai_lookup's word-gloss logic (lang={lang})"
             );
         }
+    }
+
+    #[test]
+    fn lookup_definition_prompt_marks_translation_only_for_english_lookup() {
+        let p = lookup_system_prompt("definition", "en", "zh", true);
+        assert!(p.contains(LOOKUP_TRANSLATION_MARKER));
+        assert!(p.contains("Chinese (Simplified)"));
+
+        let non_english_lookup = lookup_system_prompt("definition", "zh", "ja", true);
+        assert!(non_english_lookup.starts_with("Respond entirely in Chinese (Simplified)."));
+        assert!(!non_english_lookup.contains(LOOKUP_TRANSLATION_MARKER));
+
+        let native_english = lookup_system_prompt("definition", "en", "en", true);
+        assert!(!native_english.contains(LOOKUP_TRANSLATION_MARKER));
+
+        let disabled = lookup_system_prompt("definition", "en", "zh", false);
+        assert!(!disabled.contains(LOOKUP_TRANSLATION_MARKER));
+    }
+
+    #[test]
+    fn lookup_context_prompt_never_marks_english_translation() {
+        let p = lookup_system_prompt("context", "en", "zh", true);
+        assert!(!p.contains(LOOKUP_TRANSLATION_MARKER));
+        assert!(!p.to_lowercase().contains("brief translation"));
+    }
+
+    #[test]
+    fn lookup_prompt_uses_lookup_language_names() {
+        let ja = lookup_system_prompt("definition", "ja", "zh", true);
+        assert!(ja.starts_with("Respond entirely in Japanese."));
+
+        let es_translation = lookup_system_prompt("definition", "en", "es", true);
+        assert!(es_translation.contains("Spanish"));
     }
 }

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -35,23 +35,38 @@ fn language_name(code: &str) -> String {
 fn lookup_system_prompt(
     kind: &str,
     language: &str,
-    native_language: &str,
+    lookup_translation_language: &str,
     show_translation: bool,
 ) -> String {
-    let language_prefix = if language != "en" {
-        format!("Respond entirely in {}.\n\n", language_name(language))
-    } else if show_translation && native_language != "en" {
+    let should_show_translation = show_translation
+        && !lookup_translation_language.is_empty()
+        && lookup_translation_language != language;
+    let translation_prefix = if should_show_translation {
         format!(
             "Before the definition, provide a brief translation of the word/phrase in {}. The first line MUST be exactly `{}` followed immediately by the brief translation, then a newline. This marker is required machine-readable metadata, not a header. Keep the translation to a few words — no explanation, just the meaning. After that first line, proceed with the definition as usual. Do not put the marker anywhere except the first line.\n\n",
-            language_name(native_language),
+            language_name(lookup_translation_language),
             LOOKUP_TRANSLATION_MARKER,
         )
     } else {
         String::new()
     };
+    let definition_language_prefix = if language != "en" {
+        if should_show_translation {
+            format!("After that first line, respond entirely in {}.\n\n", language_name(language))
+        } else {
+            format!("Respond entirely in {}.\n\n", language_name(language))
+        }
+    } else {
+        String::new()
+    };
+    let context_language_prefix = if language != "en" {
+        format!("Respond entirely in {}.\n\n", language_name(language))
+    } else {
+        String::new()
+    };
 
-    let def_prefix = &language_prefix;
-    let ctx_prefix = if language != "en" { &language_prefix } else { "" };
+    let def_prefix = format!("{translation_prefix}{definition_language_prefix}");
+    let ctx_prefix = if language != "en" { &context_language_prefix } else { "" };
 
     match kind {
         "definition" => format!("{}You are a reading assistant embedded in an ebook reader. The user selected a word or phrase and wants a dictionary-style definition.\n\nGive: pronunciation in IPA (if English), part of speech, and a concise definition in 1–2 sentences.\n\nIf the selection is a proper noun (person, place, historical event), give a brief factual identification instead.\n\nBe concise. No headers or labels.", def_prefix),
@@ -74,7 +89,7 @@ pub async fn ai_lookup(
     secrets: State<'_, Secrets>,
 ) -> AppResult<()> {
     // Read provider settings
-    let (provider, model, base_url, keep_alive, auth_mode, language, native_language, show_translation) = {
+    let (provider, model, base_url, keep_alive, auth_mode, language, lookup_translation_language, show_translation) = {
         let conn = db.reader();
         let get = |key: &str| -> Option<String> {
             conn.query_row(
@@ -94,10 +109,16 @@ pub async fn ai_lookup(
             get("ai_keep_alive").unwrap_or_else(|| "30m".to_string()),
             get("ai_auth_mode").unwrap_or_else(|| "api_key".to_string()),
             lookup_language,
-            get("native_language").unwrap_or_else(|| "en".to_string()),
+            get("lookup_translation_language").unwrap_or_default(),
             get("show_translation").unwrap_or_else(|| "false".to_string()),
         )
     };
+
+    if show_translation == "true" && lookup_translation_language.trim().is_empty() {
+        return Err(AppError::Other(
+            "LOOKUP_TRANSLATION_LANGUAGE_NOT_CONFIGURED".to_string(),
+        ));
+    }
 
     // Read API key from secrets store
     let api_key = secrets.get("ai_api_key").unwrap_or_default();
@@ -127,7 +148,7 @@ pub async fn ai_lookup(
     let system_prompt = lookup_system_prompt(
         kind.as_str(),
         &language,
-        &native_language,
+        lookup_translation_language.trim(),
         show_translation == "true",
     );
 
@@ -561,17 +582,19 @@ mod tests {
     }
 
     #[test]
-    fn lookup_definition_prompt_marks_translation_only_for_english_lookup() {
+    fn lookup_definition_prompt_marks_translation_when_target_differs() {
         let p = lookup_system_prompt("definition", "en", "zh", true);
         assert!(p.contains(LOOKUP_TRANSLATION_MARKER));
         assert!(p.contains("Chinese (Simplified)"));
 
-        let non_english_lookup = lookup_system_prompt("definition", "zh", "ja", true);
-        assert!(non_english_lookup.starts_with("Respond entirely in Chinese (Simplified)."));
-        assert!(!non_english_lookup.contains(LOOKUP_TRANSLATION_MARKER));
+        let non_english_lookup = lookup_system_prompt("definition", "zh", "en", true);
+        assert!(non_english_lookup.contains(LOOKUP_TRANSLATION_MARKER));
+        assert!(non_english_lookup.contains("English"));
+        assert!(non_english_lookup
+            .contains("After that first line, respond entirely in Chinese (Simplified)."));
 
-        let native_english = lookup_system_prompt("definition", "en", "en", true);
-        assert!(!native_english.contains(LOOKUP_TRANSLATION_MARKER));
+        let same_language = lookup_system_prompt("definition", "en", "en", true);
+        assert!(!same_language.contains(LOOKUP_TRANSLATION_MARKER));
 
         let disabled = lookup_system_prompt("definition", "en", "zh", false);
         assert!(!disabled.contains(LOOKUP_TRANSLATION_MARKER));
@@ -586,10 +609,7 @@ mod tests {
 
     #[test]
     fn lookup_prompt_uses_lookup_language_names() {
-        let ja = lookup_system_prompt("definition", "ja", "zh", true);
-        assert!(ja.starts_with("Respond entirely in Japanese."));
-
-        let es_translation = lookup_system_prompt("definition", "en", "es", true);
-        assert!(es_translation.contains("Spanish"));
+        let zh = lookup_system_prompt("definition", "zh", "en", true);
+        assert!(zh.contains("respond entirely in Chinese (Simplified)."));
     }
 }

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -102,6 +102,10 @@ pub async fn ai_lookup(
         let sys_language = get("language").unwrap_or_else(|| "en".to_string());
         // lookup_language overrides system language for lookup prompts
         let lookup_language = get("lookup_language").unwrap_or(sys_language.clone());
+        let lookup_translation_language = get("lookup_translation_language")
+            .map(|lang| lang.trim().to_string())
+            .filter(|lang| !lang.is_empty())
+            .unwrap_or_else(|| sys_language.clone());
         (
             get("ai_provider").unwrap_or_else(|| "ollama".to_string()),
             get("ai_model").unwrap_or_else(|| "llama3.2".to_string()),
@@ -109,16 +113,10 @@ pub async fn ai_lookup(
             get("ai_keep_alive").unwrap_or_else(|| "30m".to_string()),
             get("ai_auth_mode").unwrap_or_else(|| "api_key".to_string()),
             lookup_language,
-            get("lookup_translation_language").unwrap_or_default(),
+            lookup_translation_language,
             get("show_translation").unwrap_or_else(|| "false".to_string()),
         )
     };
-
-    if show_translation == "true" && lookup_translation_language.trim().is_empty() {
-        return Err(AppError::Other(
-            "LOOKUP_TRANSLATION_LANGUAGE_NOT_CONFIGURED".to_string(),
-        ));
-    }
 
     // Read API key from secrets store
     let api_key = secrets.get("ai_api_key").unwrap_or_default();

--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -245,9 +245,7 @@ pub(crate) fn do_import_epub(
 
     let now = chrono::Utc::now().timestamp_millis();
     let rel_file_path = format!("books/{}", filename);
-    let cover_data_b64 = metadata.cover_data.as_deref().map(|b| {
-        cover_blob_to_data_uri(b)
-    });
+    let cover_data_b64 = metadata.cover_data.as_deref().map(cover_blob_to_data_uri);
 
     let book = Book {
         id: book_id,

--- a/src-tauri/src/commands/translation.rs
+++ b/src-tauri/src/commands/translation.rs
@@ -41,11 +41,13 @@ fn lang_display_name(code: &str) -> &str {
 fn configured_translation_language(
     target_language: Option<String>,
     saved_language: Option<String>,
+    ui_language: Option<String>,
 ) -> AppResult<String> {
-    target_language
-        .or(saved_language)
+    [target_language, saved_language, ui_language]
+        .into_iter()
+        .flatten()
         .map(|lang| lang.trim().to_string())
-        .filter(|lang| !lang.is_empty())
+        .find(|lang| !lang.is_empty())
         .ok_or_else(|| AppError::Other("TRANSLATION_LANGUAGE_NOT_CONFIGURED".to_string()))
 }
 
@@ -74,7 +76,11 @@ pub async fn ai_translate_passage(
             )
             .ok()
         };
-        let tl = configured_translation_language(target_language, get("translation_language"))?;
+        let tl = configured_translation_language(
+            target_language,
+            get("translation_language"),
+            get("language").or_else(|| Some("en".to_string())),
+        )?;
         (
             tl,
             get("ai_provider").unwrap_or_else(|| "ollama".to_string()),
@@ -266,20 +272,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn configured_translation_language_requires_explicit_language() {
-        let err = configured_translation_language(None, None).unwrap_err();
+    fn configured_translation_language_defaults_to_ui_language() {
+        let lang = configured_translation_language(None, None, Some("zh".to_string())).unwrap();
+        assert_eq!(lang, "zh");
+
+        let err = configured_translation_language(None, None, None).unwrap_err();
         assert_eq!(err.to_string(), "TRANSLATION_LANGUAGE_NOT_CONFIGURED");
 
-        let blank = configured_translation_language(None, Some("  ".to_string())).unwrap_err();
+        let blank = configured_translation_language(None, Some("  ".to_string()), Some("  ".to_string())).unwrap_err();
         assert_eq!(blank.to_string(), "TRANSLATION_LANGUAGE_NOT_CONFIGURED");
+
+        let blank_saved = configured_translation_language(None, Some("  ".to_string()), Some("zh".to_string())).unwrap();
+        assert_eq!(blank_saved, "zh");
     }
 
     #[test]
-    fn configured_translation_language_prefers_command_target() {
-        let lang = configured_translation_language(Some("zh".to_string()), Some("en".to_string())).unwrap();
+    fn configured_translation_language_prefers_command_target_then_saved_target() {
+        let lang = configured_translation_language(
+            Some("zh".to_string()),
+            Some("en".to_string()),
+            Some("en".to_string()),
+        )
+        .unwrap();
         assert_eq!(lang, "zh");
 
-        let saved = configured_translation_language(None, Some(" en ".to_string())).unwrap();
+        let saved = configured_translation_language(None, Some(" en ".to_string()), Some("zh".to_string())).unwrap();
         assert_eq!(saved, "en");
     }
 }

--- a/src-tauri/src/commands/translation.rs
+++ b/src-tauri/src/commands/translation.rs
@@ -38,6 +38,17 @@ fn lang_display_name(code: &str) -> &str {
     }
 }
 
+fn configured_translation_language(
+    target_language: Option<String>,
+    saved_language: Option<String>,
+) -> AppResult<String> {
+    target_language
+        .or(saved_language)
+        .map(|lang| lang.trim().to_string())
+        .filter(|lang| !lang.is_empty())
+        .ok_or_else(|| AppError::Other("TRANSLATION_LANGUAGE_NOT_CONFIGURED".to_string()))
+}
+
 /// Stream a translation from the AI provider. Does NOT persist — the frontend
 /// calls `save_translation` explicitly when the user clicks Save.
 #[allow(clippy::too_many_arguments)]
@@ -53,7 +64,6 @@ pub async fn ai_translate_passage(
     db: State<'_, Db>,
     secrets: State<'_, Secrets>,
 ) -> AppResult<()> {
-    // Read target language setting
     let (target_lang, provider, model, base_url, keep_alive, auth_mode) = {
         let conn = db.reader();
         let get = |key: &str| -> Option<String> {
@@ -64,9 +74,7 @@ pub async fn ai_translate_passage(
             )
             .ok()
         };
-        let tl = target_language.unwrap_or_else(|| {
-            get("native_language").unwrap_or_else(|| "en".to_string())
-        });
+        let tl = configured_translation_language(target_language, get("translation_language"))?;
         (
             tl,
             get("ai_provider").unwrap_or_else(|| "ollama".to_string()),
@@ -251,4 +259,27 @@ pub fn list_translations(
     db: State<'_, Db>,
 ) -> AppResult<Vec<Translation>> {
     query_translations(&db, book_id.as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configured_translation_language_requires_explicit_language() {
+        let err = configured_translation_language(None, None).unwrap_err();
+        assert_eq!(err.to_string(), "TRANSLATION_LANGUAGE_NOT_CONFIGURED");
+
+        let blank = configured_translation_language(None, Some("  ".to_string())).unwrap_err();
+        assert_eq!(blank.to_string(), "TRANSLATION_LANGUAGE_NOT_CONFIGURED");
+    }
+
+    #[test]
+    fn configured_translation_language_prefers_command_target() {
+        let lang = configured_translation_language(Some("zh".to_string()), Some("en".to_string())).unwrap();
+        assert_eq!(lang, "zh");
+
+        let saved = configured_translation_language(None, Some(" en ".to_string())).unwrap();
+        assert_eq!(saved, "en");
+    }
 }

--- a/src/components/LookupPopover.tsx
+++ b/src/components/LookupPopover.tsx
@@ -7,6 +7,8 @@ import { useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
 import { LOOKUP_PROSE } from "./lookup-prose";
 
+const TRANSLATION_MARKER = "[[QUILL_TRANSLATION]]";
+
 interface LookupPopoverProps {
   x: number;
   y: number;
@@ -88,6 +90,37 @@ function useStreamingLookup(
   return { content, contentRef, streaming, notConfigured };
 }
 
+function splitDefinitionContent(content: string, streaming: boolean): {
+  translationLine: string | null;
+  definitionText: string;
+} {
+  if (content.startsWith(TRANSLATION_MARKER)) {
+    const newline = content.indexOf("\n");
+    if (newline === -1) {
+      return {
+        translationLine: null,
+        definitionText: streaming ? "" : content.slice(TRANSLATION_MARKER.length).trimStart(),
+      };
+    }
+    const translationLine = content.slice(TRANSLATION_MARKER.length, newline).trim();
+    return {
+      translationLine: translationLine || null,
+      definitionText: content.slice(newline + 1).trimStart(),
+    };
+  }
+
+  if (TRANSLATION_MARKER.startsWith(content)) {
+    return { translationLine: null, definitionText: "" };
+  }
+
+  return { translationLine: null, definitionText: content };
+}
+
+function displayedDefinitionContent(content: string): string {
+  const split = splitDefinitionContent(content, false);
+  return [split.translationLine, split.definitionText].filter(Boolean).join("\n");
+}
+
 export default function LookupPopover({
   x,
   y,
@@ -102,28 +135,14 @@ export default function LookupPopover({
   const { t } = useTranslation();
   const [saved, setSaved] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [showTranslation, setShowTranslation] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
-
-  // Check if translation is enabled
-  useEffect(() => {
-    invoke<Record<string, string>>("get_all_settings").then((s) => {
-      const isEn = (s.language ?? "en") === "en";
-      setShowTranslation(isEn && s.show_translation === "true" && (s.native_language ?? "en") !== "en");
-    }).catch(() => {});
-  }, []);
 
   // Two concurrent AI streams
   const definition = useStreamingLookup(word, sentence, bookTitle, chapter, "definition");
   const context = useStreamingLookup(word, sentence, bookTitle, chapter, "context");
 
-  // Split translation from definition when translation is enabled
-  const translationLine = showTranslation && definition.content.includes("\n")
-    ? definition.content.split("\n")[0].trim()
-    : null;
-  const definitionText = translationLine
-    ? definition.content.slice(definition.content.indexOf("\n") + 1).trim()
-    : definition.content;
+  // Split the backend-marked translation from the definition stream.
+  const { translationLine, definitionText } = splitDefinitionContent(definition.content, definition.streaming);
 
   const aiNotConfigured = definition.notConfigured || context.notConfigured;
   const allDone = !definition.streaming && !context.streaming;
@@ -165,7 +184,7 @@ export default function LookupPopover({
       await invoke("add_vocab_word", {
         bookId,
         word,
-        definition: definition.contentRef.current ?? "",
+        definition: displayedDefinitionContent(definition.contentRef.current ?? ""),
         contextSentence: sentence || null,
         contextExplanation: context.contentRef.current || null,
         cfi: cfi || null,
@@ -177,7 +196,10 @@ export default function LookupPopover({
   };
 
   const handleCopy = () => {
-    const fullText = [definition.contentRef.current, context.contentRef.current]
+    const fullText = [
+      displayedDefinitionContent(definition.contentRef.current),
+      context.contentRef.current,
+    ]
       .filter(Boolean)
       .join("\n\n");
     navigator.clipboard.writeText(fullText);

--- a/src/components/LookupPopover.tsx
+++ b/src/components/LookupPopover.tsx
@@ -32,11 +32,16 @@ function useStreamingLookup(
   const [content, setContent] = useState("");
   const [streaming, setStreaming] = useState(true);
   const [notConfigured, setNotConfigured] = useState(false);
+  const [translationLanguageNotConfigured, setTranslationLanguageNotConfigured] = useState(false);
   const unlistenRef = useRef<UnlistenFn | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     contentRef.current = "";
+    setContent("");
+    setStreaming(true);
+    setNotConfigured(false);
+    setTranslationLanguageNotConfigured(false);
 
     const run = async () => {
       const requestId = crypto.randomUUID();
@@ -70,6 +75,8 @@ function useStreamingLookup(
           const msg = String(err);
           if (msg.includes("AI_NOT_CONFIGURED")) {
             setNotConfigured(true);
+          } else if (msg.includes("LOOKUP_TRANSLATION_LANGUAGE_NOT_CONFIGURED")) {
+            setTranslationLanguageNotConfigured(true);
           } else {
             setContent(`Error: ${msg}`);
           }
@@ -87,7 +94,7 @@ function useStreamingLookup(
     };
   }, [word, sentence, bookTitle, chapter, kind]);
 
-  return { content, contentRef, streaming, notConfigured };
+  return { content, contentRef, streaming, notConfigured, translationLanguageNotConfigured };
 }
 
 function splitDefinitionContent(content: string, streaming: boolean): {
@@ -145,6 +152,9 @@ export default function LookupPopover({
   const { translationLine, definitionText } = splitDefinitionContent(definition.content, definition.streaming);
 
   const aiNotConfigured = definition.notConfigured || context.notConfigured;
+  const translationLanguageNotConfigured =
+    definition.translationLanguageNotConfigured || context.translationLanguageNotConfigured;
+  const hasConfigurationError = aiNotConfigured || translationLanguageNotConfigured;
   const allDone = !definition.streaming && !context.streaming;
   const hasContent = definition.content || context.content;
 
@@ -264,26 +274,28 @@ export default function LookupPopover({
           <h3 className="text-[20px] font-bold text-text-primary leading-6">{word}</h3>
         </div>
 
-        {aiNotConfigured ? (
+        {hasConfigurationError ? (
           <div className="flex flex-col items-center gap-2 py-4 text-center">
-            <p className="text-[13px] text-text-muted">{t("ai.notConfigured")}</p>
+            <p className="text-[13px] text-text-muted">
+              {translationLanguageNotConfigured ? t("lookup.translationLanguageNotConfigured") : t("ai.notConfigured")}
+            </p>
             <button
               onClick={async () => {
                 onClose();
-                await invoke("open_settings_on_main", { section: "ai" });
+                await invoke("open_settings_on_main", { section: translationLanguageNotConfigured ? "lookup" : "ai" });
                 const main = await WebviewWindow.getByLabel("main");
                 await main?.setFocus();
               }}
               className="flex items-center gap-1.5 text-[13px] font-medium text-accent-text hover:opacity-70 cursor-pointer"
             >
               <Settings size={14} />
-              {t("ai.openSettings")}
+              {translationLanguageNotConfigured ? t("lookup.openSettings") : t("ai.openSettings")}
             </button>
           </div>
         ) : null}
 
         {/* Definition section */}
-        {!aiNotConfigured && (definition.streaming && !definition.content ? (
+        {!hasConfigurationError && (definition.streaming && !definition.content ? (
           <div className="flex items-center gap-1.5 py-1">
             <Loader2 size={14} className="animate-spin text-text-muted" />
             <span className="text-[13px] text-text-muted">{t("lookup.lookingUp")}</span>
@@ -303,7 +315,7 @@ export default function LookupPopover({
         ))}
 
         {/* In this context — card */}
-        {!aiNotConfigured && (context.content || context.streaming) && (
+        {!hasConfigurationError && (context.content || context.streaming) && (
           <div className="mt-3 mb-1 p-3 rounded-lg bg-bg-muted border border-border/50">
             <span className="block text-[12px] font-medium text-text-muted mb-1">
               {t("lookup.inContext")}
@@ -326,7 +338,7 @@ export default function LookupPopover({
       </div>
 
       {/* Footer — Save & Copy */}
-      {allDone && hasContent && (
+      {allDone && hasContent && !hasConfigurationError && (
         <div className="flex items-center justify-between px-4 py-2.5 border-t border-border/40">
           <button
             onClick={handleSave}

--- a/src/components/TranslationPopover.tsx
+++ b/src/components/TranslationPopover.tsx
@@ -49,17 +49,23 @@ function useStreamingTranslation(
   const [content, setContent] = useState("");
   const [streaming, setStreaming] = useState(true);
   const [notConfigured, setNotConfigured] = useState(false);
+  const [languageNotConfigured, setLanguageNotConfigured] = useState(false);
   const [targetLang, setTargetLang] = useState("");
   const unlistenRef = useRef<UnlistenFn | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     contentRef.current = "";
+    setContent("");
+    setStreaming(true);
+    setNotConfigured(false);
+    setLanguageNotConfigured(false);
+    setTargetLang("");
 
     // Fetch target language for display
     invoke<Record<string, string>>("get_all_settings").then((s) => {
       if (cancelled) return;
-      const lang = s.native_language || "en";
+      const lang = s.translation_language || "";
       setTargetLang(lang);
     }).catch(() => {});
 
@@ -94,6 +100,8 @@ function useStreamingTranslation(
           const msg = String(err);
           if (msg.includes("AI_NOT_CONFIGURED")) {
             setNotConfigured(true);
+          } else if (msg.includes("TRANSLATION_LANGUAGE_NOT_CONFIGURED")) {
+            setLanguageNotConfigured(true);
           } else {
             setContent(`Error: ${msg}`);
           }
@@ -111,7 +119,7 @@ function useStreamingTranslation(
     };
   }, [text, context, bookId, cfi]);
 
-  return { content, contentRef, streaming, notConfigured, targetLang };
+  return { content, contentRef, streaming, notConfigured, languageNotConfigured, targetLang };
 }
 
 export default function TranslationPopover({
@@ -129,11 +137,12 @@ export default function TranslationPopover({
   const [expanded, setExpanded] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
 
-  const { content, contentRef, streaming, notConfigured, targetLang } =
+  const { content, contentRef, streaming, notConfigured, languageNotConfigured, targetLang } =
     useStreamingTranslation(text, context, bookId, cfi);
 
   const allDone = !streaming;
   const hasContent = !!content;
+  const hasConfigurationError = notConfigured || languageNotConfigured;
 
   // Position clamping
   const [pos, setPos] = useState({ left: x, top: y });
@@ -165,7 +174,7 @@ export default function TranslationPopover({
         bookId,
         sourceText: text,
         translatedText: contentRef.current,
-        targetLanguage: targetLang || "en",
+        targetLanguage: targetLang,
         cfi: cfi || null,
       });
       setSaved(true);
@@ -264,26 +273,28 @@ export default function TranslationPopover({
         <div className="h-px bg-border/60 mb-3" />
 
         {/* Not configured state */}
-        {notConfigured ? (
+        {hasConfigurationError ? (
           <div className="flex flex-col items-center gap-2 py-4 text-center">
-            <p className="text-[13px] text-text-muted">{t("ai.notConfigured")}</p>
+            <p className="text-[13px] text-text-muted">
+              {languageNotConfigured ? t("translation.languageNotConfigured") : t("ai.notConfigured")}
+            </p>
             <button
               onClick={async () => {
                 onClose();
-                await invoke("open_settings_on_main", { section: "ai" });
+                await invoke("open_settings_on_main", { section: languageNotConfigured ? "translation" : "ai" });
                 const main = await WebviewWindow.getByLabel("main");
                 await main?.setFocus();
               }}
               className="flex items-center gap-1.5 text-[13px] font-medium text-accent-text hover:opacity-70 cursor-pointer"
             >
               <Settings size={14} />
-              {t("ai.openSettings")}
+              {languageNotConfigured ? t("translation.openSettings") : t("ai.openSettings")}
             </button>
           </div>
         ) : null}
 
         {/* Translation body */}
-        {!notConfigured &&
+        {!hasConfigurationError &&
           (streaming && !content ? (
             <div className="flex items-center gap-1.5 py-1">
               <Loader2 size={14} className="animate-spin text-text-muted" />
@@ -305,7 +316,7 @@ export default function TranslationPopover({
       </div>
 
       {/* Footer — Save & Copy */}
-      {allDone && hasContent && (
+      {allDone && hasContent && !hasConfigurationError && (
         <div className="flex items-center justify-between px-4 py-2.5 border-t border-border/40">
           <button
             onClick={handleSave}

--- a/src/components/TranslationPopover.tsx
+++ b/src/components/TranslationPopover.tsx
@@ -65,7 +65,7 @@ function useStreamingTranslation(
     // Fetch target language for display
     invoke<Record<string, string>>("get_all_settings").then((s) => {
       if (cancelled) return;
-      const lang = s.translation_language || "";
+      const lang = s.translation_language || s.language || "en";
       setTargetLang(lang);
     }).catch(() => {});
 

--- a/src/components/settings/GeneralSettings.tsx
+++ b/src/components/settings/GeneralSettings.tsx
@@ -5,6 +5,7 @@ import i18n from "../../i18n";
 import Select from "../ui/Select";
 import Toggle from "../ui/Toggle";
 import type { SettingsProps } from "./types";
+import { LANGUAGE_OPTIONS } from "./languageOptions";
 
 export default function GeneralSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
   const { t } = useTranslation();
@@ -57,10 +58,7 @@ export default function GeneralSettings({ settings, loading, save, showSavedToas
             i18n.changeLanguage(lang);
             showSavedToast();
           }}
-          options={[
-            { value: "en", label: "English" },
-            { value: "zh", label: "简体中文" },
-          ]}
+          options={LANGUAGE_OPTIONS}
         />
       </div>
 

--- a/src/components/settings/LookupSettings.tsx
+++ b/src/components/settings/LookupSettings.tsx
@@ -4,21 +4,30 @@ import { Sparkles, X } from "lucide-react";
 import Toggle from "../ui/Toggle";
 import Select from "../ui/Select";
 import type { SettingsProps } from "./types";
+import { LANGUAGE_OPTIONS } from "./languageOptions";
+
+const SAMPLE_TRANSLATIONS: Record<string, string> = {
+  en: "interfaces",
+  zh: "界面；接口",
+};
 
 export default function LookupSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
   const { t } = useTranslation();
   const [lookupLanguage, setLookupLanguage] = useState("en");
   const [showTranslation, setShowTranslation] = useState(false);
-
-  const nativeLanguage = settings.native_language || "en";
+  const [lookupTranslationLanguage, setLookupTranslationLanguage] = useState("");
 
   useEffect(() => {
     if (loading) return;
-    if (settings.lookup_language) setLookupLanguage(settings.lookup_language);
-    if (settings.show_translation) setShowTranslation(settings.show_translation === "true");
+    setLookupLanguage(settings.lookup_language || "en");
+    setLookupTranslationLanguage(settings.lookup_translation_language || "");
+    setShowTranslation(settings.show_translation === "true");
   }, [settings, loading]);
 
   if (loading) return null;
+
+  const shouldShowTranslation =
+    showTranslation && lookupTranslationLanguage !== "" && lookupTranslationLanguage !== lookupLanguage;
 
   return (
     <div>
@@ -40,15 +49,7 @@ export default function LookupSettings({ settings, loading, save, showSavedToast
             save("lookup_language", lang);
             showSavedToast();
           }}
-          options={[
-            { value: "en", label: "English" },
-            { value: "zh", label: "简体中文" },
-            { value: "ja", label: "日本語" },
-            { value: "ko", label: "한국어" },
-            { value: "es", label: "Español" },
-            { value: "fr", label: "Français" },
-            { value: "de", label: "Deutsch" },
-          ]}
+          options={LANGUAGE_OPTIONS}
         />
       </div>
       {/* Show Translation */}
@@ -70,6 +71,28 @@ export default function LookupSettings({ settings, loading, save, showSavedToast
           }}
         />
       </div>
+      {/* Lookup Translation Language */}
+      <div className="flex items-center justify-between h-[73px]">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">
+            {t("settings.lookup.translationLanguage")}
+          </p>
+          <p className="text-[12px] text-text-muted mt-0.5">
+            {t("settings.lookup.translationLanguageHint")}
+          </p>
+        </div>
+        <Select
+          className="w-[130px] shrink-0"
+          value={lookupTranslationLanguage}
+          placeholder={t("settings.languageUnset")}
+          onChange={(lang) => {
+            setLookupTranslationLanguage(lang);
+            save("lookup_translation_language", lang);
+            showSavedToast();
+          }}
+          options={LANGUAGE_OPTIONS}
+        />
+      </div>
       {/* Preview */}
       <div className="mt-5">
         <p className="text-[12px] font-medium text-text-muted mb-2 uppercase tracking-[0.3px]">Preview</p>
@@ -83,6 +106,11 @@ export default function LookupSettings({ settings, loading, save, showSavedToast
           </div>
           <div className="px-3 py-2.5">
             <p className="text-[15px] font-bold text-text-primary mb-0.5">interfaces</p>
+            {shouldShowTranslation && (
+              <p className="text-[12px] text-accent-text mb-1">
+                {SAMPLE_TRANSLATIONS[lookupTranslationLanguage] || "interfaces"}
+              </p>
+            )}
             {lookupLanguage !== "en" ? (
               <>
                 <p className="text-[12px] text-text-secondary leading-[1.5] mb-2">
@@ -101,11 +129,6 @@ export default function LookupSettings({ settings, loading, save, showSavedToast
               </>
             ) : (
               <>
-                {showTranslation && nativeLanguage !== "en" && (
-                  <p className="text-[12px] text-accent-text mb-1">
-                    {nativeLanguage === "zh" ? "\u754c\u9762\uff1b\u63a5\u53e3" : "interfaces"}
-                  </p>
-                )}
                 <p className="text-[11px] text-text-secondary leading-[1.5] mb-2">
                   A term used in this passage to convey a specific quality relevant to themes of technological advancement.
                 </p>

--- a/src/components/settings/LookupSettings.tsx
+++ b/src/components/settings/LookupSettings.tsx
@@ -20,7 +20,7 @@ export default function LookupSettings({ settings, loading, save, showSavedToast
   useEffect(() => {
     if (loading) return;
     setLookupLanguage(settings.lookup_language || "en");
-    setLookupTranslationLanguage(settings.lookup_translation_language || "");
+    setLookupTranslationLanguage(settings.lookup_translation_language || settings.language || "en");
     setShowTranslation(settings.show_translation === "true");
   }, [settings, loading]);
 

--- a/src/components/settings/ReadingSettings.tsx
+++ b/src/components/settings/ReadingSettings.tsx
@@ -1,8 +1,41 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { Check } from "lucide-react";
 import Select from "../ui/Select";
-import { fonts, FONT_SIZE_MIN, FONT_SIZE_MAX } from "../ReaderSettings";
+import { fonts, FONT_SIZE_MIN, FONT_SIZE_MAX, getDefaultReaderTheme, type ReaderTheme } from "../ReaderSettings";
 import type { SettingsProps } from "./types";
+
+const READER_THEME_OPTIONS: {
+  value: ReaderTheme;
+  labelKey: string;
+  swatchClass: string;
+  checkClass: string;
+}[] = [
+  {
+    value: "original",
+    labelKey: "readerSettings.themeOriginal",
+    swatchClass: "bg-white border border-[#d4d4d8]",
+    checkClass: "text-accent",
+  },
+  {
+    value: "paper",
+    labelKey: "readerSettings.themeSepia",
+    swatchClass: "bg-[#F2E2C9]",
+    checkClass: "text-accent",
+  },
+  {
+    value: "quiet",
+    labelKey: "readerSettings.themeGray",
+    swatchClass: "bg-[#71717b]",
+    checkClass: "text-white",
+  },
+  {
+    value: "dark",
+    labelKey: "readerSettings.themeDark",
+    swatchClass: "bg-[#18181b] border border-[#3f3f46]",
+    checkClass: "text-white",
+  },
+];
 
 function NumberInput({ value, onChange, onBlur, suffix, min, max }: {
   value: number;
@@ -34,6 +67,7 @@ function NumberInput({ value, onChange, onBlur, suffix, min, max }: {
 
 export default function ReadingSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
   const { t } = useTranslation();
+  const [readerTheme, setReaderTheme] = useState<ReaderTheme>(getDefaultReaderTheme());
   const [fontFamily, setFontFamily] = useState("georgia");
   const [fontSize, setFontSize] = useState(26);
   const [lineSpacing, setLineSpacing] = useState(1.8);
@@ -42,6 +76,7 @@ export default function ReadingSettings({ settings, loading, save, showSavedToas
 
   useEffect(() => {
     if (loading) return;
+    setReaderTheme((settings.reader_theme as ReaderTheme) || getDefaultReaderTheme());
     if (settings.font_family) setFontFamily(settings.font_family);
     if (settings.font_size) setFontSize(parseInt(settings.font_size));
     if (settings.line_spacing) setLineSpacing(parseFloat(settings.line_spacing));
@@ -51,6 +86,36 @@ export default function ReadingSettings({ settings, loading, save, showSavedToas
 
   return (
     <div>
+      {/* Theme */}
+      <div className="flex items-center justify-between min-h-[88px] py-2">
+        <div>
+          <p className="text-[14px] font-medium text-text-primary tracking-[-0.15px]">{t("settings.layout.theme")}</p>
+          <p className="text-[12px] text-text-muted mt-0.5">{t("settings.layout.themeHint")}</p>
+        </div>
+        <div className="grid grid-cols-4 gap-2 shrink-0">
+          {READER_THEME_OPTIONS.map((theme) => (
+            <button
+              key={theme.value}
+              type="button"
+              onClick={() => {
+                setReaderTheme(theme.value);
+                save("reader_theme", theme.value);
+                showSavedToast();
+              }}
+              className="w-[48px] flex flex-col items-center gap-1.5 cursor-pointer"
+            >
+              <span
+                className={`size-8 rounded-full ${theme.swatchClass} flex items-center justify-center ${
+                  readerTheme === theme.value ? "ring-2 ring-accent ring-offset-2 ring-offset-bg-surface" : ""
+                }`}
+              >
+                {readerTheme === theme.value && <Check size={14} className={theme.checkClass} />}
+              </span>
+              <span className="text-[10px] font-medium text-text-muted leading-none">{t(theme.labelKey)}</span>
+            </button>
+          ))}
+        </div>
+      </div>
       {/* Font Family */}
       <div className="flex items-center justify-between h-[73px]">
         <div>

--- a/src/components/settings/TranslationSettings.tsx
+++ b/src/components/settings/TranslationSettings.tsx
@@ -10,7 +10,7 @@ export default function TranslationSettings({ settings, loading, save, showSaved
 
   useEffect(() => {
     if (loading) return;
-    setTranslationLanguage(settings.translation_language || "");
+    setTranslationLanguage(settings.translation_language || settings.language || "en");
   }, [settings, loading]);
 
   return (

--- a/src/components/settings/TranslationSettings.tsx
+++ b/src/components/settings/TranslationSettings.tsx
@@ -2,14 +2,15 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import Select from "../ui/Select";
 import type { SettingsProps } from "./types";
+import { LANGUAGE_OPTIONS } from "./languageOptions";
 
 export default function TranslationSettings({ settings, loading, save, showSavedToast }: SettingsProps) {
   const { t } = useTranslation();
-  const [nativeLanguage, setNativeLanguage] = useState("en");
+  const [translationLanguage, setTranslationLanguage] = useState("");
 
   useEffect(() => {
     if (loading) return;
-    if (settings.native_language) setNativeLanguage(settings.native_language);
+    setTranslationLanguage(settings.translation_language || "");
   }, [settings, loading]);
 
   return (
@@ -26,21 +27,14 @@ export default function TranslationSettings({ settings, loading, save, showSaved
         </div>
         <Select
           className="w-[130px] shrink-0"
-          value={nativeLanguage}
+          value={translationLanguage}
+          placeholder={t("settings.languageUnset")}
           onChange={(lang) => {
-            setNativeLanguage(lang);
-            save("native_language", lang);
+            setTranslationLanguage(lang);
+            save("translation_language", lang);
             showSavedToast();
           }}
-          options={[
-            { value: "en", label: "English" },
-            { value: "zh", label: "简体中文" },
-            { value: "ja", label: "日本語" },
-            { value: "ko", label: "한국어" },
-            { value: "es", label: "Español" },
-            { value: "fr", label: "Français" },
-            { value: "de", label: "Deutsch" },
-          ]}
+          options={LANGUAGE_OPTIONS}
         />
       </div>
     </div>

--- a/src/components/settings/languageOptions.ts
+++ b/src/components/settings/languageOptions.ts
@@ -1,0 +1,4 @@
+export const LANGUAGE_OPTIONS = [
+  { value: "en", label: "English" },
+  { value: "zh", label: "简体中文" },
+];

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -12,9 +12,10 @@ interface SelectProps {
   onChange: (value: string) => void;
   options: SelectOption[];
   className?: string;
+  placeholder?: string;
 }
 
-export default function Select({ label, value, onChange, options, className = "" }: SelectProps) {
+export default function Select({ label, value, onChange, options, className = "", placeholder = "" }: SelectProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -48,7 +49,7 @@ export default function Select({ label, value, onChange, options, className = ""
         onClick={() => setOpen((v) => !v)}
         className="w-full h-9 bg-bg-input rounded-lg px-3 text-[13px] font-medium text-text-primary flex items-center justify-between cursor-pointer border border-transparent hover:border-border transition-colors"
       >
-        <span>{selected?.label ?? ""}</span>
+        <span>{selected?.label ?? placeholder}</span>
         <ChevronDown size={16} className={`text-text-muted transition-transform ${open ? "rotate-180" : ""}`} />
       </button>
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -122,6 +122,8 @@
   "lookup.saved": "Saved",
   "lookup.copy": "Copy",
   "lookup.copied": "Copied",
+  "lookup.translationLanguageNotConfigured": "Set a lookup translation language in Settings first",
+  "lookup.openSettings": "Open Lookup Settings",
 
   "explain.title": "Explain",
   "explain.thinking": "Explaining...",
@@ -194,6 +196,7 @@
   "settings.updates.autoCheckHint": "Check on app launch",
 
   "settings.language": "Language",
+  "settings.languageUnset": "Choose",
   "settings.language.subtitle": "Interface language",
   "settings.languageSub": "Choose your preferred language",
 
@@ -241,12 +244,12 @@
   "settings.lookup.title": "Lookup",
   "settings.lookup.sub": "Customize how word lookups appear",
   "settings.lookup.shortSub": "Translation & dictionary",
-  "settings.lookup.nativeLanguage": "Native Language",
-  "settings.lookup.nativeLanguageHint": "Your native language for word translations",
   "settings.lookup.language": "Lookup Language",
   "settings.lookup.languageHint": "Language for word lookup",
   "settings.lookup.showTranslation": "Show Translation",
-  "settings.lookup.showTranslationHint": "Include a brief translation in your native language",
+  "settings.lookup.showTranslationHint": "Include a brief translation in the selected target language",
+  "settings.lookup.translationLanguage": "Translate To",
+  "settings.lookup.translationLanguageHint": "Target language for lookup translations",
 
   "settings.translation.title": "Translation",
   "settings.translation.subtitle": "Language & settings",
@@ -351,6 +354,8 @@
   "translation.title": "Translation",
   "translation.original": "Original",
   "translation.translating": "Translating...",
+  "translation.languageNotConfigured": "Set a translation language in Settings first",
+  "translation.openSettings": "Open Translation Settings",
   "translation.save": "Save",
   "translation.saved": "Saved",
   "translation.copy": "Copy",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -286,7 +286,9 @@
   "settings.ai.savedToast": "AI configuration saved",
 
   "settings.layout.title": "Default Layout",
-  "settings.layout.subtitle": "Set default font and spacing applied when opening books",
+  "settings.layout.subtitle": "Set default theme, font, and spacing applied when opening books",
+  "settings.layout.theme": "Theme",
+  "settings.layout.themeHint": "Default reading theme for newly opened books",
   "settings.layout.fontFamily": "Font Family",
   "settings.layout.fontFamilyHint": "Choose your preferred reading font",
   "settings.layout.fontSize": "Font Size",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -122,6 +122,8 @@
   "lookup.saved": "已保存",
   "lookup.copy": "复制",
   "lookup.copied": "已复制",
+  "lookup.translationLanguageNotConfigured": "请先在设置中选择查词翻译语言",
+  "lookup.openSettings": "打开查词设置",
 
   "explain.title": "解释",
   "explain.thinking": "正在解释...",
@@ -194,6 +196,7 @@
   "settings.updates.autoCheckHint": "启动时检查",
 
   "settings.language": "语言",
+  "settings.languageUnset": "选择",
   "settings.language.subtitle": "界面语言",
   "settings.languageSub": "选择你的首选语言",
 
@@ -241,12 +244,12 @@
   "settings.lookup.title": "查词",
   "settings.lookup.sub": "自定义查词显示方式",
   "settings.lookup.shortSub": "翻译与词典",
-  "settings.lookup.nativeLanguage": "母语",
-  "settings.lookup.nativeLanguageHint": "查词时的翻译语言",
   "settings.lookup.language": "查词语言",
   "settings.lookup.languageHint": "查词使用的语言",
   "settings.lookup.showTranslation": "显示翻译",
-  "settings.lookup.showTranslationHint": "在查词结果中显示母语翻译",
+  "settings.lookup.showTranslationHint": "在查词结果中显示所选目标语言的简短翻译",
+  "settings.lookup.translationLanguage": "翻译为",
+  "settings.lookup.translationLanguageHint": "查词翻译的目标语言",
 
   "settings.translation.title": "翻译",
   "settings.translation.subtitle": "语言与设置",
@@ -353,6 +356,8 @@
   "translation.title": "翻译",
   "translation.original": "原文",
   "translation.translating": "翻译中...",
+  "translation.languageNotConfigured": "请先在设置中选择翻译语言",
+  "translation.openSettings": "打开翻译设置",
   "translation.save": "保存",
   "translation.saved": "已保存",
   "translation.copy": "复制",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -286,7 +286,9 @@
   "settings.ai.savedToast": "AI 配置已保存",
 
   "settings.layout.title": "默认排版",
-  "settings.layout.subtitle": "设置打开书籍时的默认字体和间距",
+  "settings.layout.subtitle": "设置打开书籍时的默认主题、字体和间距",
+  "settings.layout.theme": "主题",
+  "settings.layout.themeHint": "新打开书籍的默认阅读主题",
   "settings.layout.fontFamily": "字体",
   "settings.layout.fontFamilyHint": "选择你偏好的阅读字体",
   "settings.layout.fontSize": "字号",

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -118,7 +118,7 @@ export default function SettingsPage() {
     if (settings.auto_save) setAutoSave(settings.auto_save === "true");
     if (settings.theme) setTheme(settings.theme);
     if (settings.language) setLanguage(settings.language);
-    setLookupTranslationLanguage(settings.lookup_translation_language || "");
+    setLookupTranslationLanguage(settings.lookup_translation_language || settings.language || "en");
     setShowTranslation(settings.show_translation === "true");
   }, [settings, loading]);
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { invoke } from "@tauri-apps/api/core";
-import { ArrowLeft, Bot, BookOpen, SlidersHorizontal, Palette, KeyRound, Shield, Cloud, Loader2, Globe, Sparkles, X } from "lucide-react";
+import { ArrowLeft, Bot, BookOpen, SlidersHorizontal, Palette, KeyRound, Shield, Cloud, Loader2, Globe, Sparkles, X, Check } from "lucide-react";
 import i18n from "../i18n";
 import Button from "../components/ui/Button";
 import Select from "../components/ui/Select";
@@ -9,8 +9,41 @@ import Input from "../components/ui/Input";
 import Toggle from "../components/ui/Toggle";
 import Slider from "../components/ui/Slider";
 import { LANGUAGE_OPTIONS } from "../components/settings/languageOptions";
+import { getDefaultReaderTheme, type ReaderTheme } from "../components/ReaderSettings";
 import { useSettings } from "../hooks/useSettings";
 import { useTranslation } from "react-i18next";
+
+const READER_THEME_OPTIONS: {
+  value: ReaderTheme;
+  labelKey: string;
+  swatchClass: string;
+  checkClass: string;
+}[] = [
+  {
+    value: "original",
+    labelKey: "readerSettings.themeOriginal",
+    swatchClass: "bg-white border border-[#d4d4d8]",
+    checkClass: "text-accent",
+  },
+  {
+    value: "paper",
+    labelKey: "readerSettings.themeSepia",
+    swatchClass: "bg-[#F2E2C9]",
+    checkClass: "text-accent",
+  },
+  {
+    value: "quiet",
+    labelKey: "readerSettings.themeGray",
+    swatchClass: "bg-[#71717b]",
+    checkClass: "text-white",
+  },
+  {
+    value: "dark",
+    labelKey: "readerSettings.themeDark",
+    swatchClass: "bg-[#18181b] border border-[#3f3f46]",
+    checkClass: "text-white",
+  },
+];
 
 export default function SettingsPage() {
   const navigate = useNavigate();
@@ -39,6 +72,7 @@ export default function SettingsPage() {
   const [autoSave, setAutoSave] = useState(true);
 
   // Default layout
+  const [readerTheme, setReaderTheme] = useState<ReaderTheme>(getDefaultReaderTheme());
   const [fontFamily, setFontFamily] = useState("georgia");
   const [fontSize, setFontSize] = useState(26);
   const [lineSpacing, setLineSpacing] = useState(1.8);
@@ -109,6 +143,7 @@ export default function SettingsPage() {
     if (settings.ai_temperature) setTemperature(parseFloat(settings.ai_temperature));
     if (settings.ai_keep_alive) setKeepAlive(settings.ai_keep_alive);
     if (settings.ai_auth_mode) setAuthMode(settings.ai_auth_mode as "api_key" | "oauth");
+    setReaderTheme((settings.reader_theme as ReaderTheme) || getDefaultReaderTheme());
     if (settings.font_size) setFontSize(parseInt(settings.font_size));
     if (settings.font_family) setFontFamily(settings.font_family);
     if (settings.line_spacing) setLineSpacing(parseFloat(settings.line_spacing));
@@ -481,6 +516,35 @@ export default function SettingsPage() {
             </p>
 
             <div className="space-y-5">
+              <div>
+                <label className="block text-[14px] font-semibold text-text-primary mb-1.5">
+                  {t("settings.layout.theme")}
+                </label>
+                <div className="flex gap-3">
+                  {READER_THEME_OPTIONS.map((themeOption) => (
+                    <button
+                      key={themeOption.value}
+                      type="button"
+                      onClick={() => {
+                        setReaderTheme(themeOption.value);
+                        autoSaveSetting("reader_theme", themeOption.value);
+                      }}
+                      className="w-[52px] flex flex-col items-center gap-1.5 cursor-pointer"
+                    >
+                      <span
+                        className={`size-9 rounded-full ${themeOption.swatchClass} flex items-center justify-center ${
+                          readerTheme === themeOption.value ? "ring-2 ring-accent ring-offset-2 ring-offset-bg-surface" : ""
+                        }`}
+                      >
+                        {readerTheme === themeOption.value && <Check size={14} className={themeOption.checkClass} />}
+                      </span>
+                      <span className="text-[11px] font-medium text-text-muted leading-none">{t(themeOption.labelKey)}</span>
+                    </button>
+                  ))}
+                </div>
+                <p className="text-[12px] text-text-muted mt-1.5">{t("settings.layout.themeHint")}</p>
+              </div>
+
               <Select
                 label={t("settings.layout.fontFamily")}
                 value={fontFamily}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import Select from "../components/ui/Select";
 import Input from "../components/ui/Input";
 import Toggle from "../components/ui/Toggle";
 import Slider from "../components/ui/Slider";
+import { LANGUAGE_OPTIONS } from "../components/settings/languageOptions";
 import { useSettings } from "../hooks/useSettings";
 import { useTranslation } from "react-i18next";
 
@@ -49,7 +50,7 @@ export default function SettingsPage() {
   const [language, setLanguage] = useState("en");
 
   // Lookup
-  const [nativeLanguage, setNativeLanguage] = useState("en");
+  const [lookupTranslationLanguage, setLookupTranslationLanguage] = useState("");
   const [showTranslation, setShowTranslation] = useState(false);
 
   // Appearance
@@ -117,8 +118,8 @@ export default function SettingsPage() {
     if (settings.auto_save) setAutoSave(settings.auto_save === "true");
     if (settings.theme) setTheme(settings.theme);
     if (settings.language) setLanguage(settings.language);
-    if (settings.native_language) setNativeLanguage(settings.native_language);
-    if (settings.show_translation) setShowTranslation(settings.show_translation === "true");
+    setLookupTranslationLanguage(settings.lookup_translation_language || "");
+    setShowTranslation(settings.show_translation === "true");
   }, [settings, loading]);
 
   // Fetch iCloud status on mount
@@ -672,10 +673,7 @@ export default function SettingsPage() {
                 i18n.changeLanguage(lang);
                 showSavedToast();
               }}
-              options={[
-                { value: "en", label: "English" },
-                { value: "zh", label: "简体中文" },
-              ]}
+              options={LANGUAGE_OPTIONS}
             />
           </section>
 
@@ -695,20 +693,18 @@ export default function SettingsPage() {
               {/* Left: controls */}
               <div className="flex-1 space-y-4">
                 <Select
-                  label={t("settings.lookup.nativeLanguage")}
-                  value={nativeLanguage}
+                  label={t("settings.lookup.translationLanguage")}
+                  value={lookupTranslationLanguage}
+                  placeholder={t("settings.languageUnset")}
                   onChange={(lang) => {
-                    setNativeLanguage(lang);
-                    save("native_language", lang);
+                    setLookupTranslationLanguage(lang);
+                    save("lookup_translation_language", lang);
                     showSavedToast();
                   }}
-                  options={[
-                    { value: "en", label: "English" },
-                    { value: "zh", label: "简体中文" },
-                  ]}
+                  options={LANGUAGE_OPTIONS}
                 />
                 <p className="text-[12px] text-text-muted -mt-2">
-                  {t("settings.lookup.nativeLanguageHint")}
+                  {t("settings.lookup.translationLanguageHint")}
                 </p>
 
                 <div className="border-t border-border pt-4">
@@ -763,9 +759,9 @@ export default function SettingsPage() {
                       </>
                     ) : (
                       <>
-                        {showTranslation && nativeLanguage !== "en" && (
+                        {showTranslation && lookupTranslationLanguage && lookupTranslationLanguage !== "en" && (
                           <p className="text-[13px] text-accent-text mb-2">
-                            {nativeLanguage === "zh" ? "界面；接口" : "interfaces"}
+                            {lookupTranslationLanguage === "zh" ? "界面；接口" : "interfaces"}
                           </p>
                         )}
                         <p className="text-[12px] text-text-primary leading-[1.5] mb-2">


### PR DESCRIPTION
## Summary
- make lookup translations use an explicit lookup translation target, stored as lookup_translation_language
- make passage translations use translation_language instead of native_language
- default unset translation targets to the current UI language, with explicit user choices taking priority
- remove native_language from active frontend/backend code paths
- consolidate visible language selectors to English and Simplified Chinese only
- surface the existing reader_theme default in Default Layout settings with the reader theme swatches
- keep backend lookup output machine-parseable with the translation marker and add prompt/settings tests
- fix English target rendering in lookup translation prompts
- fix a current clippy redundant-closure warning in books import code

Closes #262.

## Validation
- pnpm exec tsc --noEmit
- pnpm run lint (passes with existing warnings)
- cargo test lookup
- cargo test translation
- cargo clippy -- -D warnings
- git diff --check