### PR TITLE
fix: Translate language selector clipped in Tools settings

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
 import { ChevronDown, Check } from "lucide-react";
 
 interface SelectOption {
@@ -15,27 +16,63 @@ interface SelectProps {
   placeholder?: string;
 }
 
+const MENU_GAP = 4;
+const OPTION_HEIGHT = 40;
+const VIEWPORT_MARGIN = 8;
+
 export default function Select({ label, value, onChange, options, className = "", placeholder = "" }: SelectProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuStyle, setMenuStyle] = useState<CSSProperties>();
 
   const selected = options.find((o) => o.value === value);
 
   const handleClickOutside = useCallback(
     (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      const target = e.target as Node;
+      if (ref.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
     },
     [],
   );
 
   useEffect(() => {
-    if (open) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
-    }
+    if (!open) return;
+    const handleScroll = (e: Event) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    const handleResize = () => setOpen(false);
+    document.addEventListener("mousedown", handleClickOutside);
+    window.addEventListener("scroll", handleScroll, true);
+    window.addEventListener("resize", handleResize);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      window.removeEventListener("scroll", handleScroll, true);
+      window.removeEventListener("resize", handleResize);
+    };
   }, [open, handleClickOutside]);
+
+  // The menu is portaled to <body> so it can't be clipped by overflow
+  // containers (settings modal scroll area, accordion animations).
+  useLayoutEffect(() => {
+    if (!open || !buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    const menuHeight = options.length * OPTION_HEIGHT + 2;
+    const spaceBelow = window.innerHeight - rect.bottom - MENU_GAP - VIEWPORT_MARGIN;
+    const spaceAbove = rect.top - MENU_GAP - VIEWPORT_MARGIN;
+    const openUp = menuHeight > spaceBelow && spaceAbove > spaceBelow;
+    setMenuStyle({
+      left: rect.left,
+      width: rect.width,
+      maxHeight: Math.min(menuHeight, openUp ? spaceAbove : spaceBelow),
+      ...(openUp
+        ? { bottom: window.innerHeight - rect.top + MENU_GAP }
+        : { top: rect.bottom + MENU_GAP }),
+    });
+  }, [open, options.length]);
 
   return (
     <div className={`relative ${className}`} ref={ref}>
@@ -45,6 +82,7 @@ export default function Select({ label, value, onChange, options, className = ""
         </label>
       )}
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         className="w-full h-9 bg-bg-input rounded-lg px-3 text-[13px] font-medium text-text-primary flex items-center justify-between cursor-pointer border border-transparent hover:border-border transition-colors"
@@ -53,31 +91,42 @@ export default function Select({ label, value, onChange, options, className = ""
         <ChevronDown size={16} className={`text-text-muted transition-transform ${open ? "rotate-180" : ""}`} />
       </button>
 
-      {open && (
-        <div className="absolute z-50 mt-1 w-full bg-bg-surface border border-border rounded-xl shadow-popover overflow-hidden">
-          {options.map((option) => {
-            const isActive = option.value === value;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => {
-                  onChange(option.value);
-                  setOpen(false);
-                }}
-                className={`w-full flex items-center justify-between px-4 h-10 text-[14px] cursor-pointer transition-colors ${
-                  isActive
-                    ? "bg-accent-bg text-accent-text"
-                    : "text-text-primary hover:bg-bg-input"
-                }`}
-              >
-                <span>{option.label}</span>
-                {isActive && <Check size={16} className="text-accent-text" />}
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {open && menuStyle &&
+        createPortal(
+          <div
+            ref={menuRef}
+            style={menuStyle}
+            // The menu lives under document.body, so without this, pressing an
+            // option registers as an outside click for ancestor popovers
+            // (e.g. ReaderSettings) and closes them before the option's
+            // onClick fires.
+            onMouseDown={(e) => e.stopPropagation()}
+            className="fixed z-[70] bg-bg-surface border border-border rounded-xl shadow-popover overflow-y-auto"
+          >
+            {options.map((option) => {
+              const isActive = option.value === value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    onChange(option.value);
+                    setOpen(false);
+                  }}
+                  className={`w-full flex items-center justify-between px-4 h-10 text-[14px] cursor-pointer transition-colors ${
+                    isActive
+                      ? "bg-accent-bg text-accent-text"
+                      : "text-text-primary hover:bg-bg-input"
+                  }`}
+                >
+                  <span>{option.label}</span>
+                  {isActive && <Check size={16} className="text-accent-text" />}
+                </button>
+              );
+            })}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #271 — the "Translate to" language selector in Settings > Tools opened but its options were invisible.

**Root cause:** the `Select` menu was absolutely positioned inside its wrapper, so it was clipped by the `overflow-hidden` container that `AccordionBody` needs for its grid-rows expand animation, and by the settings modal's `overflow-y-scroll` content pane. The Lookup section's selects only appeared fine because the tall preview box below them left room inside the clipped area; the Translate section has a single row, so its dropdown had nowhere to render.

## Fix

`src/components/ui/Select.tsx` now renders the open menu through `createPortal` to `document.body` with fixed positioning computed from the trigger button's bounding rect, so no ancestor overflow can clip it. Also added:

- Flip-up placement when viewport space below the trigger is short, plus `max-height` with scrolling for long option lists
- Close on outer scroll (capture phase, ignoring scrolls inside the menu) and on resize, so the detached menu never drifts from its trigger
- Click-outside detection extended to the portaled menu
- `z-[70]`, above the settings modal and reader popover (both z-50)

Dark mode is unaffected — the `dark` class lives on `document.documentElement`, which the portaled menu inherits. The same latent clipping is fixed for every other `Select` usage (General, Reading, AI, Appearance settings, Reader popover).

## Test plan

- [x] `tsc --noEmit` and `eslint` pass (no new warnings)
- [x] Manually verified: Settings > Tools > Translate dropdown renders fully and is usable (confirmed by Jason)

🤖 Generated with [Claude Code](https://claude.com/claude-code)