### PR TITLE
fix: vocab list/card view toggle leaving mixed layout content

### DIFF
--- a/src/components/DictionaryContent.tsx
+++ b/src/components/DictionaryContent.tsx
@@ -60,7 +60,7 @@ export default function DictionaryContent() {
       }
       map.get(w.book_id)!.words.push(w);
     }
-    return Array.from(map.values());
+    return Array.from(map.entries()).map(([id, group]) => ({ id, ...group }));
   }, [sorted, t]);
 
   const groupedByLetter = useMemo(() => {
@@ -203,7 +203,7 @@ export default function DictionaryContent() {
             </p>
           </div>
         ) : view === "list" ? (
-          <div>
+          <div key="list">
             {groupedByLetter.map(([letter, letterWords]) => (
               <div key={letter} className="mb-6">
                 <div className="flex items-center gap-3 mb-2">
@@ -260,9 +260,9 @@ export default function DictionaryContent() {
             ))}
           </div>
         ) : (
-          <div className="max-w-[525px] space-y-6">
+          <div key="card" className="max-w-[525px] space-y-6">
             {groupedByBook.map((group) => (
-              <div key={group.title}>
+              <div key={group.id}>
                 <div className="flex items-center gap-2 mb-3">
                   <BookOpen size={14} className="text-text-muted" />
                   <span className="text-[12px] font-semibold uppercase text-text-muted tracking-[0.3px]">

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -67,7 +67,7 @@ export default function DictionaryPage() {
       }
       map.get(key)!.words.push(w);
     }
-    return Array.from(map.values());
+    return Array.from(map.entries()).map(([id, group]) => ({ id, ...group }));
   }, [sorted]);
 
   // Group by letter for list view
@@ -250,7 +250,7 @@ export default function DictionaryPage() {
           </div>
         ) : view === "list" ? (
           /* A-Z list view */
-          <div>
+          <div key="list">
             {groupedByLetter.map(([letter, letterWords]) => (
               <div key={letter} className="mb-6">
                 {/* Letter header */}
@@ -308,9 +308,9 @@ export default function DictionaryPage() {
           </div>
         ) : (
           /* Card view — grouped by book */
-          <div className="max-w-[525px] space-y-6">
+          <div key="card" className="max-w-[525px] space-y-6">
             {groupedByBook.map((group) => (
-              <div key={group.title}>
+              <div key={group.id}>
                 {/* Book section header */}
                 <div className="flex items-center gap-2 mb-3">
                   <BookOpen size={14} className="text-text-muted" />


### PR DESCRIPTION
## Summary

Fixes #272 — toggling between list and grid/card view on the Vocab page could leave card-style content mixed into the A-Z list layout.

Two keying bugs caused this:

1. **Duplicate keys in card view.** Card groups were rendered with `key={group.title}` while grouping is by `book_id`. Two books with the same title (or multiple untitled books falling back to "Unknown Book") produced duplicate React keys — when React unmounts a keyed list containing duplicates, one entry is silently dropped from its internal bookkeeping and that group's DOM is never removed, leaving an orphaned card above the list rows.
2. **Cross-view key matching.** Both view branches rendered an unkeyed `<div>` container in the same JSX slot, so React reused the container and diffed card groups against letter groups instead of replacing the whole layout (e.g. a book titled "A" could key-match the letter-"A" group).

## Changes

- Key each view's container distinctly (`key="list"` / `key="card"`) so toggling fully unmounts one layout and mounts the other.
- Key card groups by `book_id` (unique) instead of book title.
- Applied identically to `DictionaryContent.tsx` (active Vocab page) and `DictionaryPage.tsx` (unrouted legacy page, kept in sync per the issue's drift note).

## Test plan

- [x] `tsc --noEmit` and `eslint` pass
- [ ] Manual: open Vocab page with words from multiple books (including same/missing titles), toggle list ↔ card repeatedly — each view renders only its own layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)