### PR TITLE
Fix settings toast styling

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import ToolsSettings from "./settings/ToolsSettings";
 import LibrarySyncSettings from "./settings/LibrarySyncSettings";
 import McpSettings from "./settings/McpSettings";
 import AboutSettings from "./settings/AboutSettings";
+import Toast from "./ui/Toast";
 import { useSettings } from "../hooks/useSettings";
 
 export type SettingsSection = "general" | "appearance" | "reading" | "ai" | "tools" | "librarySync" | "mcp" | "about";
@@ -193,14 +194,7 @@ export default function SettingsModal({ open, onClose, initialSection = "general
 
       {/* Toast */}
       {showToast && (
-        <div className="fixed top-6 left-1/2 -translate-x-1/2 bg-white dark:bg-bg-surface border border-border px-4 py-2.5 rounded-xl text-[13px] font-medium shadow-lg z-[60] flex items-center gap-2">
-          <div className="size-5 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center shrink-0">
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-              <path d="M2.5 6L5 8.5L9.5 3.5" stroke="#22c55e" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          </div>
-          <span className="text-text-primary">{toastMessage}</span>
-        </div>
+        <Toast>{toastMessage}</Toast>
       )}
     </div>
   );

--- a/src/components/settings/AiSettings.tsx
+++ b/src/components/settings/AiSettings.tsx
@@ -30,7 +30,6 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
   const [oauthStatus, setOauthStatus] = useState<{ connected: boolean; account_id: string | null }>({ connected: false, account_id: null });
   const [oauthLoading, setOauthLoading] = useState(false);
   const [oauthError, setOauthError] = useState<string | null>(null);
-  const [oauthToast, setOauthToast] = useState(false);
 
   // Load saved settings
   useEffect(() => {
@@ -87,8 +86,6 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
     try {
       const result = await invoke<{ connected: boolean; account_id: string | null }>("openai_oauth_login");
       setOauthStatus(result);
-      setOauthToast(true);
-      setTimeout(() => setOauthToast(false), 2000);
       // Auto-save AI configuration after successful OAuth login
       await saveBulk({
         ai_provider: provider,
@@ -100,6 +97,7 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
         ai_auth_mode: authMode,
       });
       setAiDirty(false);
+      showSavedToast(t("settings.ai.oauthSuccess"));
     } catch (err) {
       setOauthError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -323,14 +321,6 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
           <p className="text-[12px] text-text-muted mt-1.5">
             {t("settings.ai.keepAliveHint")}
           </p>
-        </div>
-      )}
-
-
-      {/* OAuth success toast */}
-      {oauthToast && (
-        <div className="fixed top-6 left-1/2 -translate-x-1/2 z-50 bg-accent text-white text-[13px] font-medium px-4 py-2 rounded-lg shadow-popover flex items-center gap-2">
-          {t("settings.ai.oauthSuccess")}
         </div>
       )}
     </div>

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { Check } from "lucide-react";
+
+interface ToastProps {
+  children: ReactNode;
+  icon?: ReactNode;
+  className?: string;
+}
+
+export default function Toast({ children, icon, className = "" }: ToastProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`fixed top-5 left-1/2 z-[60] -translate-x-1/2 ${className}`}
+    >
+      <div className="flex min-w-[260px] items-center gap-3 rounded-[14px] border border-border bg-white py-2.5 pl-4 pr-3 shadow-popover dark:bg-bg-surface">
+        {icon ?? <Check size={14} className="shrink-0 text-success-text" />}
+        <span className="flex-1 whitespace-nowrap text-[13px] font-normal tracking-[-0.08px] text-text-secondary">
+          {children}
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable Toast surface matching the update toast styling
- use the shared toast for settings save confirmations
- route AI OAuth success through the same settings toast path

Fixes #269

## Test plan
- npm run build
- npm run lint