### PR TITLE
fix(reader): surface error when iCloud book file is unreadable

### DIFF
--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -201,6 +201,11 @@ fn default_true() -> bool {
 /// Resolve relative paths in a Book to absolute using data_dir,
 /// and check whether the book file is locally available.
 fn resolve_book_paths(book: &mut Book, db: &Db) {
+    resolve_paths(book, db);
+    book.available = icloud::is_file_downloaded(std::path::Path::new(&book.file_path));
+}
+
+fn resolve_paths(book: &mut Book, db: &Db) {
     if !std::path::Path::new(&book.file_path).is_absolute() {
         book.file_path = db
             .resolve_path(&book.file_path)
@@ -216,7 +221,6 @@ fn resolve_book_paths(book: &mut Book, db: &Db) {
             );
         }
     }
-    book.available = icloud::is_file_downloaded(std::path::Path::new(&book.file_path));
 }
 
 pub(crate) fn do_import_epub(
@@ -702,7 +706,22 @@ pub fn list_books(
         page_size,
     )?;
     for book in &mut page.books {
-        resolve_book_paths(book, &db);
+        resolve_paths(book, &db);
+    }
+    // The availability check probes readability with a bounded wait
+    // (unhealthy iCloud files exist but hang on read), so run the probes
+    // concurrently — a page of unreadable books costs one deadline, not
+    // one per book.
+    let probes: Vec<_> = page
+        .books
+        .iter()
+        .map(|book| {
+            let path = std::path::PathBuf::from(&book.file_path);
+            std::thread::spawn(move || icloud::is_file_downloaded(&path))
+        })
+        .collect();
+    for (book, probe) in page.books.iter_mut().zip(probes) {
+        book.available = probe.join().unwrap_or(false);
     }
     Ok(page)
 }

--- a/src-tauri/src/icloud.rs
+++ b/src-tauri/src/icloud.rs
@@ -7,7 +7,11 @@
 //!   `trigger_download_file`) for book and cover binaries that live in
 //!   iCloud Documents and may be evicted.
 
+use std::collections::HashSet;
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::{mpsc, Mutex};
+use std::time::Duration;
 
 #[cfg(target_os = "macos")]
 use objc2_foundation::{NSFileManager, NSString};
@@ -53,16 +57,71 @@ pub fn is_icloud_available() -> bool {
     false
 }
 
-/// Check whether a file is locally available (not an iCloud placeholder).
-///
-/// iCloud evicts files by replacing `foo.epub` with `.foo.epub.icloud`.
-/// Returns `true` if the real file exists on disk.
-pub fn is_file_downloaded(path: &Path) -> bool {
-    if path.exists() {
-        return true;
+const READ_PROBE_TIMEOUT: Duration = Duration::from_millis(300);
+
+/// Paths with a probe worker still blocked inside `open`/`read`.
+/// Checked before spawning: while the previous worker is stuck the path
+/// is reported unavailable immediately, so repeated availability checks
+/// (the reader polls every 2s; every library refresh probes each book)
+/// hold at most one blocked OS thread per path instead of accumulating
+/// one per call. The worker clears its entry when the read returns —
+/// on any outcome — so probing resumes once the kernel gives up. Same
+/// bound as `sync::replay`'s IN_FLIGHT; the stalled-backoff half of
+/// that pattern isn't needed for a 1-byte probe, which is cheap to
+/// retry once it actually returns.
+static PROBES_IN_FLIGHT: Mutex<Option<HashSet<PathBuf>>> = Mutex::new(None);
+
+/// Atomically mark `path` in-flight. Returns `false` if a probe worker
+/// is already blocked on it.
+fn try_mark_probe(path: &Path) -> bool {
+    let mut guard = PROBES_IN_FLIGHT.lock().unwrap_or_else(|e| e.into_inner());
+    guard
+        .get_or_insert_with(HashSet::new)
+        .insert(path.to_path_buf())
+}
+
+fn clear_probe(path: &Path) {
+    let mut guard = PROBES_IN_FLIGHT.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(set) = guard.as_mut() {
+        set.remove(path);
     }
-    // If the real file doesn't exist, it might be an iCloud placeholder — either way, not available.
-    false
+}
+
+#[cfg(test)]
+fn probe_in_flight(path: &Path) -> bool {
+    let guard = PROBES_IN_FLIGHT.lock().unwrap_or_else(|e| e.into_inner());
+    guard.as_ref().is_some_and(|set| set.contains(path))
+}
+
+/// Check whether a file is locally available (not an iCloud placeholder)
+/// and actually readable.
+///
+/// iCloud evicts files by replacing `foo.epub` with `.foo.epub.icloud`,
+/// so a missing real file means "not available". But an unhealthy iCloud
+/// container can also leave the directory entry in place while reads
+/// block for a minute before failing ("Operation timed out"), so mere
+/// existence isn't enough: probe the first byte on a worker thread with
+/// a hard deadline. A probe that outlives the deadline is abandoned and
+/// the file treated as not available; the path stays marked in-flight
+/// until that worker's read returns, and further checks short-circuit
+/// to "not available" instead of stacking more blocked threads.
+pub fn is_file_downloaded(path: &Path) -> bool {
+    if !path.exists() {
+        return false;
+    }
+    if !try_mark_probe(path) {
+        return false;
+    }
+    let (tx, rx) = mpsc::channel();
+    let owned = path.to_path_buf();
+    std::thread::spawn(move || {
+        let readable = std::fs::File::open(&owned)
+            .and_then(|mut f| f.read(&mut [0u8; 1]))
+            .is_ok();
+        clear_probe(&owned);
+        let _ = tx.send(readable);
+    });
+    rx.recv_timeout(READ_PROBE_TIMEOUT).unwrap_or(false)
 }
 
 /// Returns the iCloud placeholder path for a given file.
@@ -107,6 +166,7 @@ mod tests {
         let file = dir.path().join("book.epub");
         fs::write(&file, "epub data").unwrap();
         assert!(is_file_downloaded(&file));
+        assert!(!probe_in_flight(&file));
     }
 
     #[test]
@@ -124,6 +184,51 @@ mod tests {
         fs::write(&placeholder, "placeholder").unwrap();
         let file = dir.path().join("book.epub");
         assert!(!is_file_downloaded(&file));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_is_file_downloaded_unreadable_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("book.epub");
+        fs::write(&file, "epub data").unwrap();
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o000)).unwrap();
+        assert!(!is_file_downloaded(&file));
+        // Worker failed fast and cleared its marker — probing can retry.
+        assert!(!probe_in_flight(&file));
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).unwrap();
+    }
+
+    /// A FIFO with no writer blocks `open()` forever — stands in for an
+    /// iCloud read that hangs when sync is unhealthy. The probe must give
+    /// up at its deadline instead of hanging the caller, and repeated
+    /// checks of the same hanging path must short-circuit on the
+    /// in-flight marker instead of stacking another blocked worker.
+    #[cfg(unix)]
+    #[test]
+    fn test_is_file_downloaded_hanging_read_times_out_and_probes_once() {
+        let dir = TempDir::new().unwrap();
+        let fifo = dir.path().join("book.epub");
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        let start = std::time::Instant::now();
+        assert!(!is_file_downloaded(&fifo));
+        assert!(start.elapsed() < Duration::from_secs(5));
+        // Worker is still blocked on open(); marker must persist.
+        assert!(probe_in_flight(&fifo));
+
+        // Simulates the reader's 2s availability poll: repeat checks must
+        // return immediately (no new worker waiting out a fresh deadline).
+        let start = std::time::Instant::now();
+        assert!(!is_file_downloaded(&fifo));
+        assert!(!is_file_downloaded(&fifo));
+        assert!(start.elapsed() < READ_PROBE_TIMEOUT);
+        assert!(probe_in_flight(&fifo));
     }
 
     // --- icloud_data_dir ---

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -49,6 +49,8 @@
   "reader.closeWindow": "Close",
   "reader.downloadingFromICloud": "Downloading from iCloud...",
   "reader.downloadTimeout": "Download is taking too long. Please check your internet connection.",
+  "reader.openFailed": "Couldn't open this book",
+  "reader.openFailedICloud": "The book file can't be read from iCloud. Check that iCloud Drive is syncing, then try again.",
   "reader.zoom.fit": "Fit",
   "reader.zoom.fitTooltip": "Fit to width",
 

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -49,6 +49,8 @@
   "reader.closeWindow": "关闭",
   "reader.downloadingFromICloud": "正在从 iCloud 下载...",
   "reader.downloadTimeout": "下载时间过长，请检查网络连接。",
+  "reader.openFailed": "无法打开这本书",
+  "reader.openFailedICloud": "无法从 iCloud 读取书籍文件，请检查 iCloud 云盘同步状态后重试。",
   "reader.zoom.fit": "适应",
   "reader.zoom.fitTooltip": "适应宽度",
 

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from "react-i18next";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
+  AlertCircle,
   ArrowLeft,
   BookOpen,
+  CloudOff,
   List,
   Bookmark,
   Bot,
@@ -247,6 +249,7 @@ export default function Reader() {
   const backButtonTimerRef = useRef<number | null>(null);
   const [icloudDownloading, setIcloudDownloading] = useState(false);
   const [icloudTimeout, setIcloudTimeout] = useState(false);
+  const [initError, setInitError] = useState<"icloud" | "generic" | null>(null);
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -439,6 +442,7 @@ export default function Reader() {
     const container = viewerRef.current;
     container.innerHTML = "";
     setBookReady(false);
+    setInitError(null);
 
     let cancelled = false;
 
@@ -767,9 +771,14 @@ export default function Reader() {
       setBookReady(true);
     };
 
-    initFoliate().catch((err) => {
+    initFoliate().catch(async (err) => {
       console.error("Failed to initialize foliate-js:", err);
-      setBookReady(true); // Remove loading overlay even on error
+      // Distinguish "file can't be read" (broken iCloud sync/download)
+      // from a parse/render failure — the probe also nudges iCloud to
+      // re-download when the file is unreadable.
+      const available = await checkBookAvailable(book.id).catch(() => true);
+      if (cancelled) return;
+      setInitError(available ? "generic" : "icloud");
     });
 
     return () => {
@@ -1351,7 +1360,22 @@ export default function Reader() {
                 />
               ));
             })()}
-            {!bookReady && (
+            {initError && (
+              <div className="absolute inset-0 z-20 bg-bg-surface flex items-center justify-center">
+                <div className="flex flex-col items-center gap-3 max-w-[420px] px-8 text-center">
+                  {initError === "icloud" ? (
+                    <CloudOff size={24} className="text-text-muted" />
+                  ) : (
+                    <AlertCircle size={24} className="text-text-muted" />
+                  )}
+                  <span className="text-[14px] text-text-primary">{t("reader.openFailed")}</span>
+                  {initError === "icloud" && (
+                    <span className="text-[13px] text-text-muted">{t("reader.openFailedICloud")}</span>
+                  )}
+                </div>
+              </div>
+            )}
+            {!bookReady && !initError && (
               <div className="absolute inset-0 z-20 bg-bg-surface flex items-center justify-center">
                 <div className="flex flex-col items-center gap-3">
                   <Loader2 size={24} className="animate-spin text-text-muted" />


### PR DESCRIPTION
Closes #288

## Problem

When iCloud sync is disabled/unhealthy on macOS, a book's iCloud-backed blob can exist as a directory entry while reads hang and eventually fail with "Operation timed out". `is_file_downloaded()` treated `path.exists()` as available, and `Reader.tsx` swallowed the foliate init failure (`console.error` + `setBookReady(true)`), leaving reader chrome around a blank content area.

## Fix

- **`icloud.rs`** — `is_file_downloaded()` now probes actual readability: after the existence check, it reads the first byte on a worker thread with a 300ms deadline. A hung probe is abandoned and the file reported unavailable. A per-path `PROBES_IN_FLIGHT` guard (same bound as `sync::replay`'s `IN_FLIGHT`) keeps repeated checks — the reader's 2s availability poll, library refreshes — from stacking blocked OS threads: at most one worker per path, cleared by the worker when the kernel read finally returns.
- **`commands/books.rs`** — `list_books` runs per-book probes concurrently, so a page of unreadable books costs one deadline, not one per book. `get_book` / `check_book_available` use the single-file path; `check_book_available` still triggers an iCloud re-download when unavailable.
- **`Reader.tsx`** — foliate init failure now sets a persistent error state instead of faking readiness: `checkBookAvailable` distinguishes an unreadable file (CloudOff icon + iCloud sync message, also nudges re-download) from a parse/render failure (generic message), rendered as a full-area overlay in place of the blank page.
- **i18n** — new `reader.openFailed` / `reader.openFailedICloud` keys in `en.json` and `zh.json`.

## Testing

- `cargo test` — 255 passed, including new unit tests: chmod-000 file unavailable; writerless FIFO (stands in for a hanging iCloud read) times out at the deadline; repeated checks of a hanging path short-circuit on the in-flight marker without spawning new workers.
- `cargo clippy -- -D warnings` clean, `tsc && vite build` pass, eslint 0 errors.
- Peer-reviewed working-tree diff; no remaining must-fix findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)