### PR TITLE
fix(library): let clicks on evicted books trigger iCloud download

### DIFF
--- a/src/components/BookGrid.tsx
+++ b/src/components/BookGrid.tsx
@@ -56,7 +56,7 @@ export default function BookGrid({ books, hasMore, loadMore, loadingMore, active
         {books.map((book) => (
           <button
             key={book.id}
-            onClick={() => book.available !== false && openReaderWindow(book.id)}
+            onClick={() => openReaderWindow(book.id)}
             onContextMenu={(e) => handleContextMenu(e, book)}
             className={`text-left cursor-pointer group ${book.available === false ? "opacity-60" : ""}`}
           >

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -53,7 +53,7 @@ export default function BookList({ books, hasMore, loadMore, loadingMore, active
         {books.map((book) => (
           <button
             key={book.id}
-            onClick={() => book.available !== false && openReaderWindow(book.id)}
+            onClick={() => openReaderWindow(book.id)}
             onContextMenu={(e) => handleContextMenu(e, book)}
             className={`flex items-start gap-4 p-4 border border-border rounded-lg text-left cursor-pointer hover:bg-bg-muted transition-colors ${book.available === false ? "opacity-60" : ""}`}
           >


### PR DESCRIPTION
## Problem

Clicking a book showing the cloud-download indicator in the library did nothing — the iCloud download never started, so evicted books could never be re-downloaded from the library view.

## Cause

The only code path that triggers an iCloud download is the `check_book_available` command, called from the Reader's 2s polling loop while it shows the "Downloading from iCloud…" wait state. But `BookGrid`/`BookList` blocked clicks on unavailable books (`book.available !== false && openReaderWindow(...)`), so the Reader never opened and the trigger was unreachable. The click guard shipped in the same commit as the download flow (#120), so this path was dead on arrival — only books evicted while a reader window was already open would ever download.

## Fix

Remove the click guard in `BookGrid.tsx` and `BookList.tsx`. Clicking an evicted book now opens the Reader, which enters its existing downloading state, fires `startDownloadingUbiquitousItemAtURL` via the poll, and opens the book once the file lands (60s timeout message if iCloud stalls). The dimmed cover + cloud icon affordance is unchanged.

## Testing

- `npx tsc --noEmit` clean
- Manual: click a faded book in the library → reader window opens with the downloading spinner, file materializes in the iCloud container, book opens when ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)