### PR TITLE
fix(library): decide book availability from metadata, not read probes

### DIFF
--- a/src-tauri/src/commands/books.rs
+++ b/src-tauri/src/commands/books.rs
@@ -706,22 +706,7 @@ pub fn list_books(
         page_size,
     )?;
     for book in &mut page.books {
-        resolve_paths(book, &db);
-    }
-    // The availability check probes readability with a bounded wait
-    // (unhealthy iCloud files exist but hang on read), so run the probes
-    // concurrently — a page of unreadable books costs one deadline, not
-    // one per book.
-    let probes: Vec<_> = page
-        .books
-        .iter()
-        .map(|book| {
-            let path = std::path::PathBuf::from(&book.file_path);
-            std::thread::spawn(move || icloud::is_file_downloaded(&path))
-        })
-        .collect();
-    for (book, probe) in page.books.iter_mut().zip(probes) {
-        book.available = probe.join().unwrap_or(false);
+        resolve_book_paths(book, &db);
     }
     Ok(page)
 }
@@ -771,6 +756,28 @@ pub fn check_book_available(id: String, db: State<'_, Db>) -> AppResult<bool> {
     }
 
     Ok(available)
+}
+
+/// Probe whether a book's file contents can actually be read. Used by
+/// the reader after a load failure to distinguish a broken book from
+/// broken iCloud sync; nudges iCloud to re-download when unreadable.
+#[tauri::command]
+pub fn check_book_readable(id: String, db: State<'_, Db>) -> AppResult<bool> {
+    let conn = db.reader();
+    let file_path: String = conn.query_row(
+        "SELECT file_path FROM books WHERE id = ?1",
+        params![id],
+        |row| row.get(0),
+    )?;
+
+    let abs_path = db.resolve_path(&file_path);
+    let readable = icloud::is_file_readable(&abs_path);
+
+    if !readable {
+        icloud::trigger_download_file(&abs_path);
+    }
+
+    Ok(readable)
 }
 
 pub(crate) fn do_delete_book(id: &str, db: &Db, sync: &SyncWriter) -> AppResult<()> {

--- a/src-tauri/src/icloud.rs
+++ b/src-tauri/src/icloud.rs
@@ -2,7 +2,7 @@
 //!
 //! - **Path helper** (`icloud_data_dir`) resolves the ubiquity
 //!   Documents directory using a deterministic path — no daemon query.
-//! - **Eviction handling** (`is_file_downloaded`,
+//! - **Eviction handling** (`is_file_downloaded`, `is_file_readable`,
 //!   `icloud_placeholder_path`, `has_icloud_placeholder`,
 //!   `trigger_download_file`) for book and cover binaries that live in
 //!   iCloud Documents and may be evicted.
@@ -61,14 +61,13 @@ const READ_PROBE_TIMEOUT: Duration = Duration::from_millis(300);
 
 /// Paths with a probe worker still blocked inside `open`/`read`.
 /// Checked before spawning: while the previous worker is stuck the path
-/// is reported unavailable immediately, so repeated availability checks
-/// (the reader polls every 2s; every library refresh probes each book)
-/// hold at most one blocked OS thread per path instead of accumulating
-/// one per call. The worker clears its entry when the read returns —
-/// on any outcome — so probing resumes once the kernel gives up. Same
-/// bound as `sync::replay`'s IN_FLIGHT; the stalled-backoff half of
-/// that pattern isn't needed for a 1-byte probe, which is cheap to
-/// retry once it actually returns.
+/// is reported unreadable immediately, so repeated probes hold at most
+/// one blocked OS thread per path instead of accumulating one per call.
+/// The worker clears its entry when the read returns — on any outcome —
+/// so probing resumes once the kernel gives up. Same bound as
+/// `sync::replay`'s IN_FLIGHT; the stalled-backoff half of that pattern
+/// isn't needed for a 1-byte probe, which is cheap to retry once it
+/// actually returns.
 static PROBES_IN_FLIGHT: Mutex<Option<HashSet<PathBuf>>> = Mutex::new(None);
 
 /// Atomically mark `path` in-flight. Returns `false` if a probe worker
@@ -93,17 +92,37 @@ fn probe_in_flight(path: &Path) -> bool {
     guard.as_ref().is_some_and(|set| set.contains(path))
 }
 
+/// `chflags(2)` flag marking a file whose contents are not local —
+/// FileProvider sets it on evicted files.
 #[cfg(any(target_os = "macos", test))]
-fn is_dataless_metadata(blocks: u64, len: u64) -> bool {
-    blocks == 0 && len > 0
+const SF_DATALESS: u32 = 0x4000_0000;
+
+/// Pure decision for FileProvider-style eviction, from stat fields
+/// alone. Either signal counts: `SF_DATALESS` is the explicit
+/// "contents not local" flag, and zero allocated blocks despite a
+/// nonzero length is the observed shape of evicted files where the
+/// flag is absent.
+#[cfg(any(target_os = "macos", test))]
+fn is_dataless_metadata(flags: u32, blocks: u64, len: u64) -> bool {
+    flags & SF_DATALESS != 0 || (blocks == 0 && len > 0)
+}
+
+#[cfg(target_os = "macos")]
+fn is_dataless(metadata: &std::fs::Metadata) -> bool {
+    use std::os::macos::fs::MetadataExt as _;
+    use std::os::unix::fs::MetadataExt as _;
+
+    is_dataless_metadata(metadata.st_flags(), metadata.blocks(), metadata.len())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn is_dataless(_metadata: &std::fs::Metadata) -> bool {
+    false
 }
 
 #[cfg(target_os = "macos")]
 pub(crate) fn is_dataless_file(path: &Path) -> bool {
-    use std::os::unix::fs::MetadataExt;
-
-    std::fs::metadata(path)
-        .is_ok_and(|metadata| is_dataless_metadata(metadata.blocks(), metadata.len()))
+    std::fs::metadata(path).is_ok_and(|metadata| is_dataless(&metadata))
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -111,19 +130,45 @@ pub(crate) fn is_dataless_file(_path: &Path) -> bool {
     false
 }
 
-/// Check whether a file is locally available (not an iCloud placeholder)
-/// and actually readable.
+/// Check whether a file's contents are materialized on disk — present
+/// and not evicted by iCloud.
 ///
-/// iCloud evicts files by replacing `foo.epub` with `.foo.epub.icloud`,
-/// so a missing real file means "not available". But an unhealthy iCloud
-/// container can also leave the directory entry in place while reads
-/// block for a minute before failing ("Operation timed out"), so mere
-/// existence isn't enough: probe the first byte on a worker thread with
-/// a hard deadline. A probe that outlives the deadline is abandoned and
-/// the file treated as not available; the path stays marked in-flight
-/// until that worker's read returns, and further checks short-circuit
-/// to "not available" instead of stacking more blocked threads.
+/// Metadata-only by design: every library refresh checks each book, and
+/// the file-read path through fileproviderd is slow even for healthy
+/// downloaded files (cold first-byte reads of 1–8s are routine), so
+/// availability must never touch contents. Eviction is visible in
+/// metadata alone:
+/// - legacy bird: `foo.epub` is renamed to `.foo.epub.icloud`, so the
+///   real path has no metadata at all;
+/// - FileProvider: the file stays in place but its stat reads as
+///   dataless (see `is_dataless_metadata`).
+///
+/// Whether the contents can actually be *read* (an unhealthy container
+/// can hang reads for a minute before failing) is a separate, more
+/// expensive question answered by `is_file_readable`.
 pub fn is_file_downloaded(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(metadata) => !is_dataless(&metadata),
+        Err(_) => false,
+    }
+}
+
+/// Check whether a file's first byte can actually be read within a
+/// bounded wait.
+///
+/// An unhealthy iCloud container can leave a fully materialized file in
+/// place while reads block for a minute before failing ("Operation
+/// timed out"), so after a load failure the reader uses this to tell
+/// broken sync from a broken book. The read runs on a worker thread
+/// with a hard deadline; a probe that outlives the deadline is
+/// abandoned and the file treated as unreadable. The path stays marked
+/// in-flight until that worker's read returns, and further checks
+/// short-circuit to "unreadable" instead of stacking blocked threads.
+///
+/// Not for routine availability checks — cold first-byte reads through
+/// fileproviderd routinely exceed the deadline on healthy files (see
+/// `is_file_downloaded`).
+pub fn is_file_readable(path: &Path) -> bool {
     if !path.exists() {
         return false;
     }
@@ -178,9 +223,15 @@ mod tests {
 
     #[test]
     fn test_is_dataless_metadata() {
-        assert!(is_dataless_metadata(0, 1));
-        assert!(!is_dataless_metadata(0, 0));
-        assert!(!is_dataless_metadata(8, 1));
+        // Blocks heuristic: zero blocks despite a nonzero length.
+        assert!(is_dataless_metadata(0, 0, 1));
+        assert!(!is_dataless_metadata(0, 0, 0));
+        assert!(!is_dataless_metadata(0, 8, 1));
+        // Explicit SF_DATALESS flag counts even with blocks allocated.
+        assert!(is_dataless_metadata(SF_DATALESS, 8, 1));
+        assert!(is_dataless_metadata(SF_DATALESS, 0, 0));
+        // Unrelated flag bits don't.
+        assert!(!is_dataless_metadata(0x1, 8, 1));
     }
 
     // --- is_file_downloaded ---
@@ -191,7 +242,6 @@ mod tests {
         let file = dir.path().join("book.epub");
         fs::write(&file, "epub data").unwrap();
         assert!(is_file_downloaded(&file));
-        assert!(!probe_in_flight(&file));
     }
 
     #[test]
@@ -211,15 +261,26 @@ mod tests {
         assert!(!is_file_downloaded(&file));
     }
 
+    // --- is_file_readable ---
+
+    #[test]
+    fn test_is_file_readable_real_file() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("book.epub");
+        fs::write(&file, "epub data").unwrap();
+        assert!(is_file_readable(&file));
+        assert!(!probe_in_flight(&file));
+    }
+
     #[cfg(unix)]
     #[test]
-    fn test_is_file_downloaded_unreadable_file() {
+    fn test_is_file_readable_unreadable_file() {
         use std::os::unix::fs::PermissionsExt;
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("book.epub");
         fs::write(&file, "epub data").unwrap();
         fs::set_permissions(&file, fs::Permissions::from_mode(0o000)).unwrap();
-        assert!(!is_file_downloaded(&file));
+        assert!(!is_file_readable(&file));
         // Worker failed fast and cleared its marker — probing can retry.
         assert!(!probe_in_flight(&file));
         fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).unwrap();
@@ -232,7 +293,7 @@ mod tests {
     /// in-flight marker instead of stacking another blocked worker.
     #[cfg(unix)]
     #[test]
-    fn test_is_file_downloaded_hanging_read_times_out_and_probes_once() {
+    fn test_is_file_readable_hanging_read_times_out_and_probes_once() {
         let dir = TempDir::new().unwrap();
         let fifo = dir.path().join("book.epub");
         let status = std::process::Command::new("mkfifo")
@@ -241,17 +302,21 @@ mod tests {
             .unwrap();
         assert!(status.success());
 
+        // Availability is metadata-only, so a hanging path still counts
+        // as downloaded — readability is the probe's job.
+        assert!(is_file_downloaded(&fifo));
+
         let start = std::time::Instant::now();
-        assert!(!is_file_downloaded(&fifo));
+        assert!(!is_file_readable(&fifo));
         assert!(start.elapsed() < Duration::from_secs(5));
         // Worker is still blocked on open(); marker must persist.
         assert!(probe_in_flight(&fifo));
 
-        // Simulates the reader's 2s availability poll: repeat checks must
-        // return immediately (no new worker waiting out a fresh deadline).
+        // Repeat probes of the hanging path must return immediately (no
+        // new worker waiting out a fresh deadline).
         let start = std::time::Instant::now();
-        assert!(!is_file_downloaded(&fifo));
-        assert!(!is_file_downloaded(&fifo));
+        assert!(!is_file_readable(&fifo));
+        assert!(!is_file_readable(&fifo));
         assert!(start.elapsed() < READ_PROBE_TIMEOUT);
         assert!(probe_in_flight(&fifo));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -623,6 +623,7 @@ pub fn run() {
             commands::books::update_book_status,
             commands::books::update_book_pages,
             commands::books::check_book_available,
+            commands::books::check_book_readable,
             commands::books::update_book_metadata,
             // Settings
             commands::settings::get_all_settings,

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -136,3 +136,7 @@ export async function updateBookMetadata(
 export async function checkBookAvailable(id: string): Promise<boolean> {
   return invoke<boolean>("check_book_available", { id });
 }
+
+export async function checkBookReadable(id: string): Promise<boolean> {
+  return invoke<boolean>("check_book_readable", { id });
+}

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -27,7 +27,7 @@ import ExplainPopover from "../components/ExplainPopover";
 import DictionaryPanel from "../components/DictionaryPanel";
 import TranslationPopover from "../components/TranslationPopover";
 import TableOfContents from "../components/TableOfContents";
-import { getBook, updateReadingProgress, checkBookAvailable, type Book } from "../hooks/useBooks";
+import { getBook, updateReadingProgress, checkBookAvailable, checkBookReadable, type Book } from "../hooks/useBooks";
 import { getAllSettings } from "../hooks/useSettings";
 import type { Highlight } from "../hooks/useBookmarks";
 import { handleAppZoomShortcut } from "../lib/appZoom";
@@ -787,9 +787,9 @@ export default function Reader() {
       // Distinguish "file can't be read" (broken iCloud sync/download)
       // from a parse/render failure — the probe also nudges iCloud to
       // re-download when the file is unreadable.
-      const available = await checkBookAvailable(book.id).catch(() => true);
+      const readable = await checkBookReadable(book.id).catch(() => true);
       if (cancelled) return;
-      setInitError(available ? "generic" : "icloud");
+      setInitError(readable ? "generic" : "icloud");
     });
 
     return () => {


### PR DESCRIPTION
## Problem

Every book in the library shows the iCloud download overlay even though all files are fully materialized on disk and open fine in the reader.

## Cause

#289 made availability a first-byte read probe with a 300ms deadline. Measured against a real 357-book library, that breaks two ways:

1. **Cold reads are slow on healthy files.** A cold first-byte read through fileproviderd takes 0.7–8s per file — 72% of the library exceeds 100ms and virtually everything exceeds the 300ms deadline. `list_books` therefore marks the whole page unavailable. (Warm reads are fast, which is why the reader still opens books after a beat.)
2. **Concurrent probes poison each other.** The `PROBES_IN_FLIGHT` guard reports "unavailable" for any path already being probed. Home triggers `list_books` from several event listeners; in a two-sweep race over warm files, one call reported 323/357 unavailable and the other 34.

## Fix

- `is_file_downloaded` is now **metadata-only**: the file has metadata (legacy `.icloud`-rename eviction leaves none at the real path) and doesn't carry `SF_DATALESS` (FileProvider-style eviction). No reads, no deadline, and `list_books` drops its per-book probe threads.
- The read probe survives as `is_file_readable` behind a new `check_book_readable` command, used only where #289 needed it: after a reader load failure, to distinguish broken iCloud sync from a broken book (and nudge a re-download). Same bounded-wait and in-flight guarantees.

## Testing

- All 256 backend tests pass; probe tests moved to `is_file_readable`, plus a new test pinning that a hanging path counts as downloaded but not readable
- `tsc --noEmit` and `cargo clippy` clean
- Repro harness run against the real library: metadata checks report 0/357 unavailable; old probe logic reported nearly all books unavailable when cold or raced

🤖 Generated with [Claude Code](https://claude.com/claude-code)