### PR TITLE
fix(sync): show percent-based progress through the snapshot phase

### DIFF
--- a/src-tauri/src/sync/replay.rs
+++ b/src-tauri/src/sync/replay.rs
@@ -136,10 +136,85 @@ pub struct ReplayReport {
     pub peers_seen: usize,
 }
 
+/// Abstract work units for the sync chip — snapshot rows plus raw log
+/// events, not user-facing counts. The frontend renders `applied/total`
+/// as a percentage.
 #[derive(Clone, serde::Serialize)]
 struct SyncProgress {
     applied: usize,
     total: usize,
+}
+
+fn emit_progress(app_handle: Option<&tauri::AppHandle>, update: Option<(usize, usize)>) {
+    if let (Some(handle), Some((applied, total))) = (app_handle, update) {
+        let _ = handle.emit("sync-progress", SyncProgress { applied, total });
+    }
+}
+
+/// Emit `sync-progress` at most every this many snapshot rows, so a
+/// large snapshot doesn't flood the webview event loop.
+const PROGRESS_EMIT_EVERY: usize = 25;
+
+/// Work-unit bookkeeping for one tick's `sync-progress` stream. The
+/// denominator is fixed up front — every snapshot row plus every raw log
+/// event read in Phase A — so the reported fraction can only move
+/// forward; Phase B can never claim 100% while Phase C work remains.
+/// Log events the post-snapshot watermarks filter out are credited as
+/// completed work in `events_known` (the snapshot already covered them),
+/// and a short-circuited or failed peer snapshot is credited whole in
+/// `peer_done` — either way that share of the tick's work is behind us.
+/// Returned pairs are `(applied, total)` to emit; `None` means don't
+/// emit (throttled, or a tick with no work at all).
+struct SyncProgressLedger {
+    snapshot_units: usize,
+    raw_events: usize,
+    /// Completed units: finished peer snapshots + filtered/applied events.
+    done: usize,
+    /// Rows walked inside the current peer's snapshot apply.
+    in_flight: usize,
+    /// Rows since the last throttled emit.
+    since_emit: usize,
+}
+
+impl SyncProgressLedger {
+    fn new(snapshot_units: usize, raw_events: usize) -> Self {
+        Self { snapshot_units, raw_events, done: 0, in_flight: 0, since_emit: 0 }
+    }
+
+    fn total(&self) -> usize {
+        self.snapshot_units + self.raw_events
+    }
+
+    fn begin(&self) -> Option<(usize, usize)> {
+        (self.total() > 0).then(|| (0, self.total()))
+    }
+
+    fn snapshot_rows(&mut self, n: usize) -> Option<(usize, usize)> {
+        self.in_flight += n;
+        self.since_emit += n;
+        if self.since_emit < PROGRESS_EMIT_EVERY {
+            return None;
+        }
+        self.since_emit = 0;
+        Some((self.done + self.in_flight, self.total()))
+    }
+
+    fn peer_done(&mut self, units: usize) -> Option<(usize, usize)> {
+        self.done += units;
+        self.in_flight = 0;
+        self.since_emit = 0;
+        (self.total() > 0).then(|| (self.done, self.total()))
+    }
+
+    fn events_known(&mut self, surviving: usize) -> Option<(usize, usize)> {
+        self.done = self.snapshot_units + self.raw_events.saturating_sub(surviving);
+        (self.total() > 0).then(|| (self.done, self.total()))
+    }
+
+    fn event_applied(&mut self) -> Option<(usize, usize)> {
+        self.done += 1;
+        Some((self.done, self.total()))
+    }
 }
 
 pub struct ReplayEngine {
@@ -411,6 +486,10 @@ impl ReplayEngine {
         }
 
         // -- Phase B — apply snapshots (one write tx per peer). --
+        let snapshot_units: usize = snapshots.iter().map(|(_, s)| s.work_units()).sum();
+        let raw_events: usize = peer_logs.iter().map(|(_, events)| events.len()).sum();
+        let mut ledger = SyncProgressLedger::new(snapshot_units, raw_events);
+        emit_progress(app_handle, ledger.begin());
         let mut snapshots_applied = 0usize;
         for (device, snap) in &snapshots {
             let mut conn = db
@@ -418,7 +497,10 @@ impl ReplayEngine {
                 .lock()
                 .map_err(|e| AppError::Other(format!("db conn mutex: {e}")))?;
             let tx = conn.transaction()?;
-            match snap.apply_peer(&tx, device) {
+            let outcome = snap.apply_peer_with_progress(&tx, device, &mut |n| {
+                emit_progress(app_handle, ledger.snapshot_rows(n));
+            });
+            match outcome {
                 Ok(outcome) => {
                     tx.commit()?;
                     if matches!(
@@ -437,6 +519,7 @@ impl ReplayEngine {
                 }
             }
             drop(conn);
+            emit_progress(app_handle, ledger.peer_done(snap.work_units()));
         }
 
         // Read watermarks through the reader — no write lock needed.
@@ -459,12 +542,9 @@ impl ReplayEngine {
         all_events.sort_by(|a, b| (a.ts, &a.device).cmp(&(b.ts, &b.device)));
 
         let total_events = all_events.len();
+        emit_progress(app_handle, ledger.events_known(total_events));
         if total_events == 0 {
             return Ok((snapshots_applied, 0));
-        }
-
-        if let Some(handle) = app_handle {
-            let _ = handle.emit("sync-progress", SyncProgress { applied: 0, total: total_events });
         }
 
         // -- Phase C — apply events one at a time. --
@@ -490,12 +570,7 @@ impl ReplayEngine {
                     bump_event_watermark(&tx, &ev.device, &ev.id)?;
                     tx.commit()?;
                     events_applied += 1;
-                    if let Some(handle) = app_handle {
-                        let _ = handle.emit("sync-progress", SyncProgress {
-                            applied: events_applied,
-                            total: total_events,
-                        });
-                    }
+                    emit_progress(app_handle, ledger.event_applied());
                 }
                 Err(e) => {
                     ::log::warn!(
@@ -1500,6 +1575,75 @@ mod tests {
             .query_row("SELECT cover_data FROM books WHERE id = 'b1'", [], |r| r.get(0))
             .unwrap();
         assert!(blob.is_none(), "no bytes should be written from a placeholder");
+    }
+
+    /// Regression for #299: a tick with both snapshot rows and a log tail
+    /// must keep one fixed denominator across Phase B and Phase C, so the
+    /// fraction never hits 100% while events are still pending (a naive
+    /// per-phase denominator did, and the frontend's monotonic clamp then
+    /// pinned the chip at 100%).
+    #[test]
+    fn progress_ledger_holds_denominator_across_phases() {
+        // Issue-#299 shape: 382 snapshot rows, 300 raw log events of which
+        // 247 survive the post-snapshot watermark filter.
+        fn push(emits: &mut Vec<(usize, usize)>, update: Option<(usize, usize)>) {
+            if let Some(pair) = update {
+                emits.push(pair);
+            }
+        }
+        let mut ledger = SyncProgressLedger::new(382, 300);
+        let mut emits: Vec<(usize, usize)> = Vec::new();
+
+        push(&mut emits, ledger.begin());
+        for _ in 0..382 {
+            push(&mut emits, ledger.snapshot_rows(1));
+        }
+        push(&mut emits, ledger.peer_done(382));
+        let phase_b_emits = emits.len();
+        push(&mut emits, ledger.events_known(247));
+        for _ in 0..247 {
+            push(&mut emits, ledger.event_applied());
+        }
+
+        assert_eq!(emits.first(), Some(&(0, 682)));
+        assert_eq!(emits.last(), Some(&(682, 682)));
+        assert!(
+            emits[..phase_b_emits].iter().all(|(applied, _)| *applied < 682),
+            "Phase B alone must not reach 100%"
+        );
+        let mut prev = (0, 682);
+        for pair in &emits {
+            assert_eq!(pair.1, 682, "denominator must not move mid-tick");
+            assert!(pair.0 <= pair.1);
+            assert!(pair.0 >= prev.0, "applied must be monotonic: {prev:?} -> {pair:?}");
+            prev = *pair;
+        }
+    }
+
+    #[test]
+    fn progress_ledger_credits_short_circuits_and_filtered_events() {
+        let mut ledger = SyncProgressLedger::new(10, 5);
+        assert_eq!(ledger.begin(), Some((0, 15)));
+        // Peer snapshot short-circuits: no rows walked, whole credit on
+        // completion so the fraction doesn't stall.
+        assert_eq!(ledger.peer_done(10), Some((10, 15)));
+        // Every raw event is behind the watermark — credited as done.
+        assert_eq!(ledger.events_known(0), Some((15, 15)));
+    }
+
+    #[test]
+    fn progress_ledger_throttles_row_emits() {
+        let mut ledger = SyncProgressLedger::new(100, 0);
+        let emitted: Vec<_> = (0..100).filter_map(|_| ledger.snapshot_rows(1)).collect();
+        assert_eq!(emitted, vec![(25, 100), (50, 100), (75, 100), (100, 100)]);
+    }
+
+    #[test]
+    fn progress_ledger_no_work_emits_nothing() {
+        let ledger = SyncProgressLedger::new(0, 0);
+        assert_eq!(ledger.begin(), None);
+        assert_eq!(SyncProgressLedger::new(0, 0).peer_done(0), None);
+        assert_eq!(SyncProgressLedger::new(0, 0).events_known(0), None);
     }
 
 }

--- a/src-tauri/src/sync/snapshot.rs
+++ b/src-tauri/src/sync/snapshot.rs
@@ -377,6 +377,21 @@ impl Snapshot {
         }
     }
 
+    /// Number of rows a full apply of this snapshot walks — tombstones plus
+    /// every entity row. Sizes the sync-progress denominator in the replay
+    /// tick; matches the `on_rows` call count in `apply_peer_with_progress`.
+    pub fn work_units(&self) -> usize {
+        self.state.tombstones.values().map(Vec::len).sum::<usize>()
+            + self.state.books.len()
+            + self.state.highlights.len()
+            + self.state.bookmarks.len()
+            + self.state.vocab_words.len()
+            + self.state.collections.len()
+            + self.state.collection_books.len()
+            + self.state.chats.len()
+            + self.state.chat_messages.len()
+    }
+
     /// Apply this snapshot into local SQLite. Idempotent under repeated
     /// application; tombstones in `state.tombstones` are written first so
     /// the entity rows that follow can short-circuit on the local-tombstone
@@ -387,6 +402,18 @@ impl Snapshot {
     /// the migration apply-back case (where the snapshot's `device` is the
     /// migrating device but `_replay_state` still treats it as a peer).
     pub fn apply_peer(&self, tx: &Transaction, peer_device: &str) -> AppResult<ApplyOutcome> {
+        self.apply_peer_with_progress(tx, peer_device, &mut |_| {})
+    }
+
+    /// Like `apply_peer`, but calls `on_rows` with the number of rows walked
+    /// as the apply advances — `work_units()` in total on a full apply, zero
+    /// when the watermark check short-circuits.
+    pub fn apply_peer_with_progress(
+        &self,
+        tx: &Transaction,
+        peer_device: &str,
+        on_rows: &mut dyn FnMut(usize),
+    ) -> AppResult<ApplyOutcome> {
         let prior: Option<(Option<String>, Option<String>)> = tx
             .query_row(
                 "SELECT last_snapshot_id, last_event_id
@@ -422,54 +449,63 @@ impl Snapshot {
         // removed pair, etc.
         for (entity, list) in &self.state.tombstones {
             for t in list {
+                on_rows(1);
                 merge::cascade_delete(tx, entity, &t.id, t.ts)?;
                 merge::insert_tombstone(tx, entity, &t.id, t.ts)?;
             }
         }
 
         for (id, row) in &self.state.books {
+            on_rows(1);
             if merge::is_tombstoned(tx, merge::entity::BOOK, id)? {
                 continue;
             }
             upsert_book(tx, id, row)?;
         }
         for (id, row) in &self.state.highlights {
+            on_rows(1);
             if merge::is_tombstoned(tx, merge::entity::HIGHLIGHT, id)? {
                 continue;
             }
             upsert_highlight(tx, id, row)?;
         }
         for (id, row) in &self.state.bookmarks {
+            on_rows(1);
             if merge::is_tombstoned(tx, merge::entity::BOOKMARK, id)? {
                 continue;
             }
             insert_bookmark(tx, id, row)?;
         }
         for (id, row) in &self.state.vocab_words {
+            on_rows(1);
             if merge::is_tombstoned(tx, merge::entity::VOCAB, id)? {
                 continue;
             }
             upsert_vocab(tx, id, row)?;
         }
         for (id, row) in &self.state.collections {
+            on_rows(1);
             if merge::is_tombstoned(tx, merge::entity::COLLECTION, id)? {
                 continue;
             }
             upsert_collection(tx, id, row)?;
         }
         for (key, row) in &self.state.collection_books {
+            on_rows(1);
             if merge::is_tombstoned(tx, merge::entity::COLLECTION_BOOK, key)? {
                 continue;
             }
             upsert_collection_book(tx, row)?;
         }
         for (id, row) in &self.state.chats {
+            on_rows(1);
             if merge::is_tombstoned(tx, merge::entity::CHAT, id)? {
                 continue;
             }
             upsert_chat(tx, id, row)?;
         }
         for (id, row) in &self.state.chat_messages {
+            on_rows(1);
             if merge::is_tombstoned(tx, merge::entity::CHAT_MESSAGE, id)? {
                 continue;
             }
@@ -1349,6 +1385,76 @@ mod tests {
             o
         };
         assert_eq!(outcome, ApplyOutcome::AlreadyApplied);
+    }
+
+    #[test]
+    fn work_units_counts_entity_rows_and_tombstones() {
+        let events = vec![
+            ev(1000, "dev-A", import("b1")),
+            ev(1050, "dev-A", import("b2")),
+            ev(
+                1100,
+                "dev-A",
+                EventBody::HighlightAdd(HighlightPayload {
+                    id: "h1".into(),
+                    book_id: "b1".into(),
+                    cfi_range: "cfi".into(),
+                    color: "yellow".into(),
+                    note: None,
+                    text_content: None,
+                }),
+            ),
+        ];
+        let mut snap = Snapshot::from_events("dev-A", &events).unwrap();
+        assert_eq!(snap.work_units(), 3);
+
+        snap.state
+            .tombstones
+            .entry(merge::entity::BOOK.to_string())
+            .or_default()
+            .push(TombstoneRow { id: "b9".into(), ts: 900 });
+        assert_eq!(snap.work_units(), 4);
+    }
+
+    #[test]
+    fn apply_peer_progress_walks_work_units_once_then_zero() {
+        let events = vec![
+            ev(1000, "dev-A", import("b1")),
+            ev(
+                1100,
+                "dev-A",
+                EventBody::HighlightAdd(HighlightPayload {
+                    id: "h1".into(),
+                    book_id: "b1".into(),
+                    cfi_range: "cfi".into(),
+                    color: "yellow".into(),
+                    note: None,
+                    text_content: None,
+                }),
+            ),
+        ];
+        let snap = Snapshot::from_events("dev-A", &events).unwrap();
+
+        let mut local = open_db();
+        let mut walked = 0usize;
+        {
+            let tx = local.transaction().unwrap();
+            snap.apply_peer_with_progress(&tx, "dev-A", &mut |n| walked += n)
+                .unwrap();
+            tx.commit().unwrap();
+        }
+        assert_eq!(walked, snap.work_units());
+
+        walked = 0;
+        {
+            let tx = local.transaction().unwrap();
+            let o = snap
+                .apply_peer_with_progress(&tx, "dev-A", &mut |n| walked += n)
+                .unwrap();
+            tx.commit().unwrap();
+            assert_eq!(o, ApplyOutcome::AlreadyApplied);
+        }
+        assert_eq!(walked, 0, "short-circuit must report no rows walked");
     }
 
     #[test]

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,7 +24,7 @@ interface SidebarProps {
   };
   userName?: string;
   onOpenSettings?: () => void;
-  syncProgress?: { applied: number; total: number } | null;
+  syncProgress?: { percent: number | null } | null;
 }
 
 const SIDEBAR_MIN = 180;
@@ -187,9 +187,9 @@ export default function Sidebar({ activeFilter, onFilterChange, bookCounts, coll
         {syncProgress ? (
           <span className="ml-auto shrink-0 flex items-center gap-1.5 rounded-md bg-accent/10 px-2 py-1">
             <RefreshCw size={12} className="text-accent animate-spin" />
-            {syncProgress.total > 0 && (
+            {syncProgress.percent != null && (
               <span className="text-[11px] font-medium text-accent">
-                {syncProgress.applied}/{syncProgress.total}
+                {syncProgress.percent}%
               </span>
             )}
           </span>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,7 @@ export default function Home() {
   const [importing, setImporting] = useState(false);
   const [importSlow, setImportSlow] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
-  const [syncProgress, setSyncProgress] = useState<{ applied: number; total: number } | null>(null);
+  const [syncProgress, setSyncProgress] = useState<{ percent: number | null } | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<SettingsSection>("general");
   const [userName, setUserName] = useState("");
@@ -150,14 +150,26 @@ export default function Home() {
   }, [importing]);
 
   useEffect(() => {
+    // `sync-progress` carries abstract work units (snapshot rows + raw log
+    // events), not book counts. The backend keeps the denominator fixed
+    // within a tick; the monotonic clamp is defense so the chip's percent
+    // still never walks backwards within one sync session.
+    let maxPercent = 0;
     const unlistenTick = listen("sync-initial-tick-done", () => {
+      maxPercent = 0;
       setSyncProgress(null);
       refreshRef.current();
       countsRefreshRef.current();
       collectionsRefreshRef.current();
     });
     const unlistenProgress = listen<{ applied: number; total: number }>("sync-progress", (e) => {
-      setSyncProgress(e.payload);
+      const { applied, total } = e.payload;
+      if (total > 0) {
+        maxPercent = Math.max(maxPercent, Math.min(100, Math.floor((applied / total) * 100)));
+        setSyncProgress({ percent: maxPercent });
+      } else {
+        setSyncProgress((prev) => prev ?? { percent: null });
+      }
     });
     return () => {
       unlistenTick.then((fn) => fn());


### PR DESCRIPTION
Fixes #299.

The sidebar sync chip showed `applied/total` replay-log event counts — which reads like a book count (counting to 247 next to a 359-book library) — and sat at a bare spinner through the snapshot phase, where most of a first sync actually happens.

## Changes

- **Chip renders a percent** (`62%`) next to the spinner, or spinner alone while the total is unknown — never `N/M` (`Sidebar.tsx`).
- **Phase B now reports progress**: `Snapshot::apply_peer_with_progress` threads a per-row callback through the snapshot apply loops (`apply_peer` delegates with a no-op, so migration/test call sites are untouched), so the indicator moves during the longest part of a first sync.
- **Fixed denominator per tick**: progress is abstract work units — snapshot rows + raw log events, both knowable after Phase A's disk reads. A new pure `SyncProgressLedger` owns the accounting; events filtered by post-snapshot watermarks and short-circuited peer snapshots are credited as completed work, so `applied/total` is monotone by construction and Phase B can never claim 100% while a log tail remains.
- **Frontend clamps the percent monotonic** per sync session as defense, resetting on `sync-initial-tick-done` (clear behavior kept). Watcher ticks stay silent; no i18n keys needed for a bare percent.

## Tests

- `progress_ledger_holds_denominator_across_phases` — regression replaying the #299 shape (382 snapshot rows + 300 raw events, 247 surviving): fixed denominator, monotone applied, Phase B < 100%, ends at 682/682.
- Ledger crediting, throttling, and no-work cases; `work_units` accounting; per-row callback walks exactly `work_units()` on fresh apply and 0 on short-circuit.
- `cargo test` (265), `cargo clippy`, `npm run build`, `npm test` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)