### PR TITLE
fix(library): preserve grid during background refreshes

### DIFF
--- a/src/components/BookGrid.tsx
+++ b/src/components/BookGrid.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { memo, useState, useEffect, useRef } from "react";
 import { Loader2 } from "lucide-react";
 import type { Book } from "../hooks/useBooks";
 import { openReaderWindow } from "../utils/openReaderWindow";
@@ -36,7 +36,7 @@ interface BookGridProps {
   onBooksChanged?: () => void;
 }
 
-export default function BookGrid({ books, hasMore, loadMore, loadingMore, activeCollectionId, onBooksChanged }: BookGridProps) {
+function BookGrid({ books, hasMore, loadMore, loadingMore, activeCollectionId, onBooksChanged }: BookGridProps) {
   const { t } = useTranslation();
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -142,6 +142,8 @@ export default function BookGrid({ books, hasMore, loadMore, loadingMore, active
     </>
   );
 }
+
+export default memo(BookGrid);
 
 function LoadMoreSentinel({ loadMore, loadingMore }: { loadMore?: () => void; loadingMore?: boolean }) {
   const ref = useRef<HTMLDivElement>(null);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { listen } from "@tauri-apps/api/event";
 import { Library, BookOpen, CheckCircle2, FolderClosed, BookA, Plus, MessageSquare, Pencil, Trash2, GripVertical, RefreshCw } from "lucide-react";
 import Button from "./ui/Button";
 import QuillLogo from "./QuillLogo";
@@ -24,7 +25,6 @@ interface SidebarProps {
   };
   userName?: string;
   onOpenSettings?: () => void;
-  syncProgress?: { percent: number | null } | null;
 }
 
 const SIDEBAR_MIN = 180;
@@ -41,9 +41,10 @@ function getStoredWidth(): number {
   return SIDEBAR_DEFAULT;
 }
 
-export default function Sidebar({ activeFilter, onFilterChange, bookCounts, collections: collectionsHook, userName, onOpenSettings, syncProgress }: SidebarProps) {
+export default function Sidebar({ activeFilter, onFilterChange, bookCounts, collections: collectionsHook, userName, onOpenSettings }: SidebarProps) {
   const { t } = useTranslation();
   const [sidebarWidth, setSidebarWidth] = useState(getStoredWidth);
+  const [syncProgress, setSyncProgress] = useState<{ percent: number | null } | null>(null);
   const resizingRef = useRef(false);
 
   const libraryFilters = [
@@ -137,6 +138,38 @@ export default function Sidebar({ activeFilter, onFilterChange, bookCounts, coll
     await remove(id);
     setContextMenu(null);
   };
+
+  useEffect(() => {
+    // `sync-progress` carries abstract work units (snapshot rows + raw log
+    // events), not book counts. The backend keeps the denominator fixed
+    // within a tick; the monotonic clamp is defense so the chip's percent
+    // still never walks backwards within one sync session.
+    let maxPercent = 0;
+    const unlistenTick = listen("sync-initial-tick-done", () => {
+      maxPercent = 0;
+      setSyncProgress(null);
+    });
+    const unlistenProgress = listen<{ applied: number; total: number }>("sync-progress", (e) => {
+      const { applied, total } = e.payload;
+      if (applied === 0) {
+        // A new tick's stream is starting — Rebuild from iCloud runs
+        // two back-to-back ticks (fold, then replay), and holding the
+        // first tick's 100% clamp would pin the chip there for the
+        // entire second one.
+        maxPercent = 0;
+      }
+      if (total > 0) {
+        maxPercent = Math.max(maxPercent, Math.min(100, Math.floor((applied / total) * 100)));
+        setSyncProgress({ percent: maxPercent });
+      } else {
+        setSyncProgress((prev) => prev ?? { percent: null });
+      }
+    });
+    return () => {
+      unlistenTick.then((fn) => fn());
+      unlistenProgress.then((fn) => fn());
+    };
+  }, []);
 
   // Dismiss context menu on outside click
   useEffect(() => {

--- a/src/hooks/useBooks.test.tsx
+++ b/src/hooks/useBooks.test.tsx
@@ -1,0 +1,172 @@
+/** @vitest-environment jsdom */
+
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn<(command: string, args?: object) => Promise<unknown>>(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
+import { type Book, useBooks } from "./useBooks";
+
+interface BookPageResult {
+  books: Book[];
+  next_cursor: string | null;
+  total: number;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function book(title: string): Book {
+  return {
+    id: title.toLowerCase(),
+    title,
+    author: "Author",
+    description: null,
+    cover_path: null,
+    file_path: `/books/${title}.epub`,
+    format: "epub",
+    genre: null,
+    pages: null,
+    status: "unread",
+    progress: 0,
+    current_cfi: null,
+    created_at: 1,
+    updated_at: 1,
+    available: true,
+    cover_data: null,
+  };
+}
+
+function booksPage(titles: string[], nextCursor: string | null = null, total = titles.length): BookPageResult {
+  return {
+    books: titles.map(book),
+    next_cursor: nextCursor,
+    total,
+  };
+}
+
+function page(title: string): BookPageResult {
+  return booksPage([title]);
+}
+
+let current: ReturnType<typeof useBooks>;
+
+function HookHarness({ filter }: { filter?: string }) {
+  const books = useBooks(filter);
+  useEffect(() => {
+    current = books;
+  }, [books]);
+  return <p>{books.loading ? "loading" : books.books[0]?.title}</p>;
+}
+
+describe("useBooks refresh modes", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    mocks.invoke.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows loading until the initial page and each changed query arrive", async () => {
+    const initialPage = deferred<BookPageResult>();
+    const filteredPage = deferred<BookPageResult>();
+    mocks.invoke
+      .mockReturnValueOnce(initialPage.promise)
+      .mockReturnValueOnce(filteredPage.promise);
+
+    act(() => root.render(<HookHarness />));
+    expect(container.textContent).toBe("loading");
+
+    await act(async () => {
+      initialPage.resolve(page("First"));
+      await initialPage.promise;
+    });
+    expect(container.textContent).toBe("First");
+
+    act(() => root.render(<HookHarness filter="finished" />));
+    expect(container.textContent).toBe("loading");
+
+    await act(async () => {
+      filteredPage.resolve(page("Finished"));
+      await filteredPage.promise;
+    });
+    expect(container.textContent).toBe("Finished");
+  });
+
+  it("keeps the current page visible during a silent refresh", async () => {
+    mocks.invoke.mockResolvedValueOnce(page("First"));
+    await act(async () => root.render(<HookHarness />));
+
+    const updatedPage = deferred<BookPageResult>();
+    mocks.invoke.mockReturnValueOnce(updatedPage.promise);
+    let refreshPromise!: Promise<void>;
+
+    act(() => {
+      refreshPromise = current.refreshSilently();
+    });
+    expect(current.loading).toBe(false);
+    expect(container.textContent).toBe("First");
+
+    await act(async () => {
+      updatedPage.resolve(page("Updated"));
+      await refreshPromise;
+    });
+    expect(container.textContent).toBe("Updated");
+  });
+
+  it("keeps every loaded page during a silent refresh", async () => {
+    const firstTitles = Array.from({ length: 20 }, (_, index) => `Book ${index + 1}`);
+    const secondTitles = Array.from({ length: 20 }, (_, index) => `Book ${index + 21}`);
+    const allTitles = [...firstTitles, ...secondTitles];
+    mocks.invoke.mockResolvedValueOnce(booksPage(firstTitles, "cursor-20", 40));
+
+    await act(async () => root.render(<HookHarness />));
+    expect(current.books).toHaveLength(20);
+
+    mocks.invoke.mockResolvedValueOnce(booksPage(secondTitles, null, 40));
+    await act(async () => {
+      await current.loadMore();
+    });
+    expect(current.books.map((loadedBook) => loadedBook.title)).toEqual(allTitles);
+
+    mocks.invoke.mockResolvedValueOnce(booksPage(allTitles, null, 40));
+    await act(async () => {
+      await current.refreshSilently();
+    });
+
+    expect(mocks.invoke).toHaveBeenLastCalledWith("list_books", {
+      filter: null,
+      search: null,
+      collectionId: null,
+      cursor: null,
+      limit: 40,
+    });
+    expect(current.books.map((loadedBook) => loadedBook.title)).toEqual(allTitles);
+  });
+});

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 
@@ -27,6 +27,8 @@ interface BookPage {
   total: number;
 }
 
+const DEFAULT_PAGE_SIZE = 20;
+
 export function useBooks(filter?: string, search?: string, collectionId?: string) {
   const [books, setBooks] = useState<Book[]>([]);
   const [total, setTotal] = useState(0);
@@ -34,16 +36,21 @@ export function useBooks(filter?: string, search?: string, collectionId?: string
   const [loadingMore, setLoadingMore] = useState(false);
   const [cursor, setCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
+  const booksLengthRef = useRef(0);
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
+  useEffect(() => {
+    booksLengthRef.current = books.length;
+  }, [books.length]);
+
+  const runRefresh = useCallback(async (showLoading: boolean) => {
+    if (showLoading) setLoading(true);
     try {
       const page = await invoke<BookPage>("list_books", {
         filter: filter || null,
         search: search || null,
         collectionId: collectionId || null,
         cursor: null,
-        limit: null,
+        limit: showLoading ? null : Math.max(booksLengthRef.current, DEFAULT_PAGE_SIZE),
       });
       setBooks(page.books);
       setTotal(page.total);
@@ -52,9 +59,12 @@ export function useBooks(filter?: string, search?: string, collectionId?: string
     } catch (err) {
       console.error("Failed to load books:", err);
     } finally {
-      setLoading(false);
+      if (showLoading) setLoading(false);
     }
   }, [filter, search, collectionId]);
+
+  const refresh = useCallback(() => runRefresh(true), [runRefresh]);
+  const refreshSilently = useCallback(() => runRefresh(false), [runRefresh]);
 
   const loadMore = useCallback(async () => {
     if (!cursor || loadingMore) return;
@@ -81,7 +91,7 @@ export function useBooks(filter?: string, search?: string, collectionId?: string
     refresh();
   }, [refresh]);
 
-  return { books, total, loading, loadingMore, hasMore, loadMore, refresh };
+  return { books, total, loading, loadingMore, hasMore, loadMore, refresh, refreshSilently };
 }
 
 async function pickFile(): Promise<string | null> {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,11 +35,11 @@ export default function Home() {
   const [importing, setImporting] = useState(false);
   const [importSlow, setImportSlow] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
-  const [syncProgress, setSyncProgress] = useState<{ percent: number | null } | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<SettingsSection>("general");
   const [userName, setUserName] = useState("");
   const collections = useCollections();
+  const refreshCollections = collections.refresh;
 
   // Load user name
   useEffect(() => {
@@ -107,7 +107,7 @@ export default function Home() {
 
   const searchParam = debouncedSearchQuery || undefined;
 
-  const { books, loading, hasMore, loadMore, loadingMore, refresh } = useBooks(statusFilter, searchParam, collectionId);
+  const { books, loading, hasMore, loadMore, loadingMore, refreshSilently } = useBooks(statusFilter, searchParam, collectionId);
 
   // Book counts for sidebar badges — lightweight, no book data loaded.
   const [bookCounts, setBookCounts] = useState({ all: 0, reading: 0, finished: 0 });
@@ -122,12 +122,12 @@ export default function Home() {
   useEffect(() => { refreshCounts(); }, [refreshCounts]);
 
   // Keep stable refs for refresh functions so the drag-drop effect doesn't re-register
-  const refreshRef = useRef(refresh);
+  const silentRefreshRef = useRef(refreshSilently);
   const countsRefreshRef = useRef(refreshCounts);
-  const collectionsRefreshRef = useRef(collections.refresh);
-  useEffect(() => { refreshRef.current = refresh; }, [refresh]);
+  const collectionsRefreshRef = useRef(refreshCollections);
+  useEffect(() => { silentRefreshRef.current = refreshSilently; }, [refreshSilently]);
   useEffect(() => { countsRefreshRef.current = refreshCounts; }, [refreshCounts]);
-  useEffect(() => { collectionsRefreshRef.current = collections.refresh; }, [collections.refresh]);
+  useEffect(() => { collectionsRefreshRef.current = refreshCollections; }, [refreshCollections]);
 
   // Auto-dismiss import error after 10s
   useEffect(() => {
@@ -150,37 +150,13 @@ export default function Home() {
   }, [importing]);
 
   useEffect(() => {
-    // `sync-progress` carries abstract work units (snapshot rows + raw log
-    // events), not book counts. The backend keeps the denominator fixed
-    // within a tick; the monotonic clamp is defense so the chip's percent
-    // still never walks backwards within one sync session.
-    let maxPercent = 0;
     const unlistenTick = listen("sync-initial-tick-done", () => {
-      maxPercent = 0;
-      setSyncProgress(null);
-      refreshRef.current();
+      silentRefreshRef.current();
       countsRefreshRef.current();
       collectionsRefreshRef.current();
     });
-    const unlistenProgress = listen<{ applied: number; total: number }>("sync-progress", (e) => {
-      const { applied, total } = e.payload;
-      if (applied === 0) {
-        // A new tick's stream is starting — Rebuild from iCloud runs
-        // two back-to-back ticks (fold, then replay), and holding the
-        // first tick's 100% clamp would pin the chip there for the
-        // entire second one.
-        maxPercent = 0;
-      }
-      if (total > 0) {
-        maxPercent = Math.max(maxPercent, Math.min(100, Math.floor((applied / total) * 100)));
-        setSyncProgress({ percent: maxPercent });
-      } else {
-        setSyncProgress((prev) => prev ?? { percent: null });
-      }
-    });
     return () => {
       unlistenTick.then((fn) => fn());
-      unlistenProgress.then((fn) => fn());
     };
   }, []);
 
@@ -193,14 +169,14 @@ export default function Home() {
     const unlistenBooks = listen("mcp:books-changed", () => {
       if (mcpDebounce) clearTimeout(mcpDebounce);
       mcpDebounce = setTimeout(() => {
-        refreshRef.current();
+        silentRefreshRef.current();
         countsRefreshRef.current();
         collectionsRefreshRef.current();
       }, 500);
     });
     const unlistenCollections = listen("mcp:collections-changed", () => {
       collectionsRefreshRef.current();
-      refreshRef.current();
+      silentRefreshRef.current();
       countsRefreshRef.current();
     });
     return () => {
@@ -218,7 +194,7 @@ export default function Home() {
     let coverDebounce: ReturnType<typeof setTimeout> | null = null;
     const unlisten = listen("sync-covers-ingested", () => {
       if (coverDebounce) clearTimeout(coverDebounce);
-      coverDebounce = setTimeout(() => refreshRef.current(), 500);
+      coverDebounce = setTimeout(() => silentRefreshRef.current(), 500);
     });
     return () => {
       if (coverDebounce) clearTimeout(coverDebounce);
@@ -249,7 +225,7 @@ export default function Home() {
                 setImportError(`${filePath.split("/").pop()}: ${formatError(err)}`);
               }
             }
-            refreshRef.current();
+            silentRefreshRef.current();
             countsRefreshRef.current();
           } finally {
             setImporting(false);
@@ -280,7 +256,7 @@ export default function Home() {
             setImportError(`${filePath.split("/").pop()}: ${formatError(err)}`);
           }
         }
-        refreshRef.current();
+        silentRefreshRef.current();
         countsRefreshRef.current();
       } finally {
         setImporting(false);
@@ -300,7 +276,7 @@ export default function Home() {
       try {
         const book = await importBookDialog.importFile(selected);
         if (book) {
-          refresh();
+          refreshSilently();
           refreshCounts();
         }
       } finally {
@@ -312,6 +288,12 @@ export default function Home() {
       setImportError(name ? `${name}: ${formatError(err)}` : formatError(err));
     }
   };
+
+  const handleBooksChanged = useCallback(() => {
+    refreshSilently();
+    refreshCounts();
+    refreshCollections();
+  }, [refreshSilently, refreshCounts, refreshCollections]);
 
   const title =
     activeFilter === "all"
@@ -333,7 +315,6 @@ export default function Home() {
         collections={collections}
         userName={userName}
         onOpenSettings={() => setSettingsOpen(true)}
-        syncProgress={syncProgress}
       />
 
       {activeFilter === "vocab" ? (
@@ -399,9 +380,9 @@ export default function Home() {
                 )}
               </div>
             ) : viewMode === "grid" ? (
-              <BookGrid books={displayBooks} hasMore={hasMore} loadMore={loadMore} loadingMore={loadingMore} activeCollectionId={isCollectionFilter ? activeFilter.replace("collection:", "") : undefined} onBooksChanged={() => { refresh(); refreshCounts(); collections.refresh();}} />
+              <BookGrid books={displayBooks} hasMore={hasMore} loadMore={loadMore} loadingMore={loadingMore} activeCollectionId={collectionId} onBooksChanged={handleBooksChanged} />
             ) : (
-              <BookList books={displayBooks} hasMore={hasMore} loadMore={loadMore} loadingMore={loadingMore} activeCollectionId={isCollectionFilter ? activeFilter.replace("collection:", "") : undefined} onBooksChanged={() => { refresh(); refreshCounts(); collections.refresh();}} />
+              <BookList books={displayBooks} hasMore={hasMore} loadMore={loadMore} loadingMore={loadingMore} activeCollectionId={collectionId} onBooksChanged={handleBooksChanged} />
             )}
           </div>
 


### PR DESCRIPTION
## Summary

- keep the library grid mounted during sync, MCP, cover, import, and book-mutation refreshes while preserving every loaded page
- move sync-progress state into Sidebar and memoize BookGrid with a stable change callback
- add hook regression coverage for foreground loading, silent replacement, and multi-page window preservation

Fixes #304

## Test plan

- `pnpm test`
- `npx tsc --noEmit`
- `pnpm run lint`
- `pnpm build`