### PR TITLE
fix(library): update availability after reader download

### DIFF
--- a/src/hooks/useBooks.test.tsx
+++ b/src/hooks/useBooks.test.tsx
@@ -169,4 +169,20 @@ describe("useBooks refresh modes", () => {
     });
     expect(current.books.map((loadedBook) => loadedBook.title)).toEqual(allTitles);
   });
+
+  it("patches one book in place without reloading unchanged books", async () => {
+    const initialPage = booksPage(["First", "Second"]);
+    initialPage.books[0] = { ...initialPage.books[0], available: false };
+    mocks.invoke.mockResolvedValueOnce(initialPage);
+
+    await act(async () => root.render(<HookHarness />));
+    const originalBooks = current.books;
+
+    act(() => current.patchBook("first", { available: true }));
+
+    expect(current.books).not.toBe(originalBooks);
+    expect(current.books[0]).toEqual({ ...originalBooks[0], available: true });
+    expect(current.books[1]).toBe(originalBooks[1]);
+    expect(mocks.invoke).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -65,6 +65,9 @@ export function useBooks(filter?: string, search?: string, collectionId?: string
 
   const refresh = useCallback(() => runRefresh(true), [runRefresh]);
   const refreshSilently = useCallback(() => runRefresh(false), [runRefresh]);
+  const patchBook = useCallback((id: string, partial: Partial<Book>) => {
+    setBooks((prev) => prev.map((book) => book.id === id ? { ...book, ...partial } : book));
+  }, []);
 
   const loadMore = useCallback(async () => {
     if (!cursor || loadingMore) return;
@@ -91,7 +94,7 @@ export function useBooks(filter?: string, search?: string, collectionId?: string
     refresh();
   }, [refresh]);
 
-  return { books, total, loading, loadingMore, hasMore, loadMore, refresh, refreshSilently };
+  return { books, total, loading, loadingMore, hasMore, loadMore, refresh, refreshSilently, patchBook };
 }
 
 async function pickFile(): Promise<string | null> {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -107,7 +107,16 @@ export default function Home() {
 
   const searchParam = debouncedSearchQuery || undefined;
 
-  const { books, loading, hasMore, loadMore, loadingMore, refreshSilently } = useBooks(statusFilter, searchParam, collectionId);
+  const { books, loading, hasMore, loadMore, loadingMore, refreshSilently, patchBook } = useBooks(statusFilter, searchParam, collectionId);
+
+  useEffect(() => {
+    const unlisten = getCurrentWebview().listen<string>("book-availability-changed", (event) => {
+      patchBook(event.payload, { available: true });
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [patchBook]);
 
   // Book counts for sidebar badges — lightweight, no book data loaded.
   const [bookCounts, setBookCounts] = useState({ all: 0, reading: 0, finished: 0 });

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+import { emitTo } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
   AlertCircle,
@@ -425,6 +426,7 @@ export default function Reader() {
           // Re-fetch book to get updated available flag
           const updated = await getBook(book.id).catch(() => null);
           if (updated) setBook(updated);
+          emitTo("main", "book-availability-changed", book.id).catch(() => {});
           setIcloudDownloading(false);
           return;
         }


### PR DESCRIPTION
## Summary

- notify the main webview when the reader finishes materializing an evicted book
- patch only the matching library book availability without a full list refresh
- cover the in-place hook update and unchanged-book identity behavior with a regression test

## Test plan

- `npx tsc --noEmit`
- `pnpm test`
- `pnpm build`
- `pnpm run lint`

Fixes #305