### PR TITLE
fix(reader): preserve styles and zoom across sections

### DIFF
--- a/src/lib/appZoom.test.ts
+++ b/src/lib/appZoom.test.ts
@@ -28,6 +28,7 @@ import {
   applyAppZoom,
   handleAppZoomShortcut,
   nudgeAppZoom,
+  refreshAppZoom,
   syncTitlebarZoom,
 } from "./appZoom";
 import {
@@ -67,6 +68,17 @@ describe("app zoom", () => {
     expect(mocks.invoke).toHaveBeenCalledWith("window_set_titlebar_zoom", {
       zoom: 0.8,
     });
+  });
+
+  it("pulses native zoom to refresh newly loaded frames", async () => {
+    localStorage.setItem(STORAGE_APP_ZOOM, "1.1");
+
+    await refreshAppZoom();
+
+    expect(mocks.setZoom).toHaveBeenNthCalledWith(1, 1.101);
+    expect(mocks.setZoom).toHaveBeenNthCalledWith(2, 1.1);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(localStorage.getItem(STORAGE_APP_ZOOM)).toBe("1.1");
   });
 
   it("snaps stored values without writing them back", () => {

--- a/src/lib/appZoom.ts
+++ b/src/lib/appZoom.ts
@@ -27,6 +27,22 @@ export function restoreAppZoom(zoom: number): Promise<void> {
   return Promise.all([titlebarZoom, webviewZoom]).then(() => {});
 }
 
+export function refreshAppZoom(): Promise<void> {
+  const zoom = readAppZoom();
+  if (zoom === 1) return Promise.resolve();
+  try {
+    const webview = getCurrentWebview();
+    const refreshZoom = zoom === ZOOM_STEPS[ZOOM_STEPS.length - 1]
+      ? zoom - 0.001
+      : zoom + 0.001;
+    return webview.setZoom(refreshZoom)
+      .then(() => webview.setZoom(zoom))
+      .catch(() => {});
+  } catch {
+    return Promise.resolve();
+  }
+}
+
 export function applyAppZoom(next: number): void {
   writeAppZoom(next);
   try {

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -31,7 +31,7 @@ import TableOfContents from "../components/TableOfContents";
 import { getBook, updateReadingProgress, checkBookAvailable, checkBookReadable, type Book } from "../hooks/useBooks";
 import { getAllSettings } from "../hooks/useSettings";
 import type { Highlight } from "../hooks/useBookmarks";
-import { handleAppZoomShortcut } from "../lib/appZoom";
+import { handleAppZoomShortcut, refreshAppZoom } from "../lib/appZoom";
 
 // foliate-js <foliate-view> web component interface
 /* eslint-disable @typescript-eslint/no-explicit-any -- foliate-js has no TS definitions */
@@ -310,6 +310,8 @@ export default function Reader() {
   const viewerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<FoliateView | null>(null);
   const isDragging = useRef(false);
+  const readerSettingsRef = useRef(readerSettings);
+  readerSettingsRef.current = readerSettings;
   const chaptersRef = useRef<TocChapter[]>([]);
   const selectedTextRef = useRef<{ text: string; cfi: string } | null>(null);
   const tocChapters = useMemo(() => chapters.map((chapter, i) => ({
@@ -582,9 +584,11 @@ export default function Reader() {
         }
       });
 
-      // Handle section loads — text selection, keyboard, highlights
+      // Handle section loads — styles, zoom, text selection, keyboard, highlights
       view.addEventListener("load", ((e: CustomEvent) => {
         const { doc, index } = e.detail;
+        view.renderer.setStyles?.(getReaderCSS(readerSettingsRef.current));
+        if (book.format === "epub") void refreshAppZoom();
 
         // Text selection tracking
         doc.addEventListener("mouseup", () => {


### PR DESCRIPTION
Fixes #308.

Summary:
- apply reader CSS deterministically to each freshly loaded foliate document
- reapply the latest reader settings from the section-load listener without stale closures
- refresh WKWebView app zoom for newly created EPUB frames after cross-section navigation
- update foliate-js to the merged style-ordering fix from yicheng47/foliate-js#2

Test plan:
- npx tsc --noEmit
- npm test (11/11)
- npm run lint (0 errors; existing warnings only)
- npm run build
- node --check public/foliate-js/paginator.js
- git diff --check in both repositories
- manually reproduced app zoom plus cross-section TOC navigation in scrolled and paginated reader modes