### PR TITLE
fix(ai): seed Codex model catalog

### DIFF
--- a/src-tauri/src/ai/codex_models.rs
+++ b/src-tauri/src/ai/codex_models.rs
@@ -86,23 +86,60 @@ fn parse_models_response(body: &str) -> AppResult<Vec<CodexModel>> {
         .collect())
 }
 
-/// Bundled list used before OAuth connect or when the fetch fails. Empty
-/// `supported_reasoning_levels` makes the frontend fall back to the effort
-/// union.
+/// Bundled list used before OAuth connect or when the fetch fails.
+/// Keep in sync with src/components/settings/codexModels.ts.
 fn fallback_models() -> Vec<CodexModel> {
-    [
-        ("gpt-5.3-codex", "GPT-5.3 Codex"),
-        ("gpt-5.2-codex", "GPT-5.2 Codex"),
-        ("gpt-5.1-codex-max", "GPT-5.1 Codex Max"),
-    ]
-    .into_iter()
-    .map(|(slug, name)| CodexModel {
+    let model = |slug: &str, display_name: &str, description: &str, levels: &[&str]| CodexModel {
         slug: slug.to_string(),
-        display_name: name.to_string(),
-        description: String::new(),
-        supported_reasoning_levels: Vec::new(),
-    })
-    .collect()
+        display_name: display_name.to_string(),
+        description: description.to_string(),
+        supported_reasoning_levels: levels.iter().map(|level| (*level).to_string()).collect(),
+    };
+
+    vec![
+        model(
+            "gpt-5.6-sol",
+            "GPT-5.6-Sol",
+            "Latest frontier agentic coding model.",
+            &["low", "medium", "high", "xhigh", "max", "ultra"],
+        ),
+        model(
+            "gpt-5.6-terra",
+            "GPT-5.6-Terra",
+            "Balanced agentic coding model for everyday work.",
+            &["low", "medium", "high", "xhigh", "max", "ultra"],
+        ),
+        model(
+            "gpt-5.6-luna",
+            "GPT-5.6-Luna",
+            "Fast and affordable agentic coding model.",
+            &["low", "medium", "high", "xhigh", "max"],
+        ),
+        model(
+            "gpt-5.5",
+            "GPT-5.5",
+            "Frontier model for complex coding, research, and real-world work.",
+            &["low", "medium", "high", "xhigh"],
+        ),
+        model(
+            "gpt-5.4",
+            "GPT-5.4",
+            "Strong model for everyday coding.",
+            &["low", "medium", "high", "xhigh"],
+        ),
+        model(
+            "gpt-5.4-mini",
+            "GPT-5.4-Mini",
+            "Small, fast, and cost-efficient model for simpler coding tasks.",
+            &["low", "medium", "high", "xhigh"],
+        ),
+        model(
+            "gpt-5.3-codex-spark",
+            "GPT-5.3-Codex-Spark",
+            "Ultra-fast coding model.",
+            &["low", "medium", "high", "xhigh"],
+        ),
+    ]
 }
 
 /// Cache entries are scoped to the OAuth account they were fetched for, so
@@ -397,11 +434,65 @@ mod tests {
     }
 
     #[test]
-    fn fallback_contains_default_model() {
+    fn fallback_catalog_has_curated_content() {
         let models = fallback_models();
-        assert!(models.iter().any(|m| m.slug == "gpt-5.3-codex"));
-        // Bundled entries carry no levels — the frontend uses the union
-        assert!(models.iter().all(|m| m.supported_reasoning_levels.is_empty()));
+        let expected: &[(&str, &str, &str, &[&str])] = &[
+            (
+                "gpt-5.6-sol",
+                "GPT-5.6-Sol",
+                "Latest frontier agentic coding model.",
+                &["low", "medium", "high", "xhigh", "max", "ultra"],
+            ),
+            (
+                "gpt-5.6-terra",
+                "GPT-5.6-Terra",
+                "Balanced agentic coding model for everyday work.",
+                &["low", "medium", "high", "xhigh", "max", "ultra"],
+            ),
+            (
+                "gpt-5.6-luna",
+                "GPT-5.6-Luna",
+                "Fast and affordable agentic coding model.",
+                &["low", "medium", "high", "xhigh", "max"],
+            ),
+            (
+                "gpt-5.5",
+                "GPT-5.5",
+                "Frontier model for complex coding, research, and real-world work.",
+                &["low", "medium", "high", "xhigh"],
+            ),
+            (
+                "gpt-5.4",
+                "GPT-5.4",
+                "Strong model for everyday coding.",
+                &["low", "medium", "high", "xhigh"],
+            ),
+            (
+                "gpt-5.4-mini",
+                "GPT-5.4-Mini",
+                "Small, fast, and cost-efficient model for simpler coding tasks.",
+                &["low", "medium", "high", "xhigh"],
+            ),
+            (
+                "gpt-5.3-codex-spark",
+                "GPT-5.3-Codex-Spark",
+                "Ultra-fast coding model.",
+                &["low", "medium", "high", "xhigh"],
+            ),
+        ];
+
+        assert_eq!(models.len(), expected.len());
+        for (model, (slug, display_name, description, levels)) in models.iter().zip(expected) {
+            assert_eq!(model.slug, *slug);
+            assert_eq!(model.display_name, *display_name);
+            assert_eq!(model.description, *description);
+            let actual_levels: Vec<&str> = model
+                .supported_reasoning_levels
+                .iter()
+                .map(String::as_str)
+                .collect();
+            assert_eq!(actual_levels, *levels);
+        }
     }
 
     fn save_test_tokens(secrets: &Secrets, account_id: &str) {

--- a/src/components/settings/AiSettings.test.tsx
+++ b/src/components/settings/AiSettings.test.tsx
@@ -1,0 +1,302 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn<(command: string, args?: object) => Promise<unknown>>(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+import AiSettings from "./AiSettings";
+import { CODEX_EFFORT_LEVELS, CURATED_CODEX_MODELS, type CodexModel } from "./codexModels";
+
+interface CodexModelList {
+  models: CodexModel[];
+  from_fallback: boolean;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function buttonWithText(text: string): HTMLButtonElement {
+  const button = [...document.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === text,
+  );
+  expect(button).toBeDefined();
+  return button as HTMLButtonElement;
+}
+
+describe("AiSettings Codex model catalog", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    mocks.invoke.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function render(settings: Record<string, string>) {
+    await act(async () => {
+      root.render(
+        <AiSettings
+          settings={settings}
+          loading={false}
+          save={vi.fn()}
+          saveBulk={vi.fn().mockResolvedValue(undefined)}
+          showSavedToast={vi.fn()}
+        />,
+      );
+      await Promise.resolve();
+    });
+  }
+
+  it("ships full curated entries with the verified effort union", () => {
+    expect(CURATED_CODEX_MODELS.map((model) => model.slug)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.3-codex-spark",
+    ]);
+    expect(CURATED_CODEX_MODELS.every((model) => model.display_name.length > 0)).toBe(true);
+    expect(CURATED_CODEX_MODELS.every((model) => model.description.length > 0)).toBe(true);
+    expect(CURATED_CODEX_MODELS.every((model) => model.supported_reasoning_levels.length > 0)).toBe(true);
+    expect([
+      ...new Set(CURATED_CODEX_MODELS.flatMap((model) => model.supported_reasoning_levels)),
+    ]).toEqual(CODEX_EFFORT_LEVELS);
+  });
+
+  it("renders the seeded picker while the background request is pending", async () => {
+    const liveList = deferred<CodexModelList>();
+    mocks.invoke.mockImplementation((command) => {
+      if (command === "openai_oauth_status") {
+        return Promise.resolve({ connected: false, account_id: null });
+      }
+      if (command === "list_codex_models") return liveList.promise;
+      return Promise.resolve(undefined);
+    });
+
+    await render({
+      ai_provider: "openai",
+      ai_auth_mode: "oauth",
+      ai_model: "gpt-5.6-sol",
+    });
+
+    expect(buttonWithText("GPT-5.6-Sol")).toBeTruthy();
+    expect(container.querySelector('input[placeholder="gpt-5.6-sol"]')).toBeNull();
+    expect(mocks.invoke).toHaveBeenCalledWith("list_codex_models");
+  });
+
+  it("upgrades to the live list without changing an absent saved selection", async () => {
+    const liveList = deferred<CodexModelList>();
+    mocks.invoke.mockImplementation((command) => {
+      if (command === "openai_oauth_status") {
+        return Promise.resolve({ connected: false, account_id: null });
+      }
+      if (command === "list_codex_models") return liveList.promise;
+      return Promise.resolve(undefined);
+    });
+
+    await render({
+      ai_provider: "openai",
+      ai_auth_mode: "oauth",
+      ai_model: "gpt-5.6-sol",
+    });
+
+    await act(async () => {
+      liveList.resolve({
+        models: [
+          {
+            slug: "future-codex",
+            display_name: "Future Codex",
+            description: "New from the live catalog.",
+            supported_reasoning_levels: ["medium", "high"],
+          },
+        ],
+        from_fallback: false,
+      });
+      await liveList.promise;
+    });
+
+    expect(buttonWithText("settings.ai.modelCustom")).toBeTruthy();
+    expect(container.querySelector<HTMLInputElement>('input[placeholder="gpt-5.6-sol"]')?.value).toBe(
+      "gpt-5.6-sol",
+    );
+
+    act(() => buttonWithText("settings.ai.modelCustom").click());
+    expect(document.body.textContent).toContain("Future Codex");
+    expect(document.body.textContent).toContain("New from the live catalog.");
+  });
+
+  it("keeps a matching selection and adopts its live effort levels", async () => {
+    const liveList = deferred<CodexModelList>();
+    mocks.invoke.mockImplementation((command) => {
+      if (command === "openai_oauth_status") {
+        return Promise.resolve({ connected: false, account_id: null });
+      }
+      if (command === "list_codex_models") return liveList.promise;
+      return Promise.resolve(undefined);
+    });
+
+    await render({
+      ai_provider: "openai",
+      ai_auth_mode: "oauth",
+      ai_model: "gpt-5.6-sol",
+      ai_effort_quick: "medium",
+    });
+
+    await act(async () => {
+      liveList.resolve({
+        models: [
+          {
+            slug: "gpt-5.6-sol",
+            display_name: "Live Sol",
+            description: "Updated by the live catalog.",
+            supported_reasoning_levels: ["medium", "high"],
+          },
+          {
+            slug: "future-codex",
+            display_name: "Future Codex",
+            description: "New from the live catalog.",
+            supported_reasoning_levels: ["high"],
+          },
+        ],
+        from_fallback: false,
+      });
+      await liveList.promise;
+    });
+
+    expect(buttonWithText("Live Sol")).toBeTruthy();
+    expect(container.querySelector('input[placeholder="gpt-5.6-sol"]')).toBeNull();
+
+    act(() => buttonWithText("medium").click());
+    const buttonTexts = [...document.querySelectorAll("button")].map((button) => button.textContent?.trim());
+    expect(buttonTexts).toContain("high");
+    expect(buttonTexts).not.toContain("low");
+    expect(buttonTexts).not.toContain("xhigh");
+
+    act(() => buttonWithText("Live Sol").click());
+    expect(document.body.textContent).toContain("Future Codex");
+  });
+
+  it("uses the enriched backend fallback and keeps the failure hint", async () => {
+    mocks.invoke.mockImplementation((command) => {
+      if (command === "openai_oauth_status") {
+        return Promise.resolve({ connected: true, account_id: "acct" });
+      }
+      if (command === "list_codex_models") {
+        return Promise.resolve({
+          models: [
+            {
+              slug: "gpt-5.6-sol",
+              display_name: "Backend Sol",
+              description: "Bundled by the backend.",
+              supported_reasoning_levels: ["low", "medium"],
+            },
+          ],
+          from_fallback: true,
+        } satisfies CodexModelList);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await render({
+      ai_provider: "openai",
+      ai_auth_mode: "oauth",
+      ai_model: "gpt-5.6-sol",
+    });
+
+    expect(buttonWithText("Backend Sol")).toBeTruthy();
+    expect(container.textContent).toContain("settings.ai.modelListFallbackHint");
+    act(() => buttonWithText("Backend Sol").click());
+    expect(document.body.textContent).toContain("Bundled by the backend.");
+  });
+
+  it("keeps the curated seed when the model command fails", async () => {
+    mocks.invoke.mockImplementation((command) => {
+      if (command === "openai_oauth_status") {
+        return Promise.resolve({ connected: true, account_id: "acct" });
+      }
+      if (command === "list_codex_models") return Promise.reject(new Error("offline"));
+      return Promise.resolve(undefined);
+    });
+
+    await render({
+      ai_provider: "openai",
+      ai_auth_mode: "oauth",
+      ai_model: "gpt-5.6-sol",
+    });
+
+    expect(buttonWithText("GPT-5.6-Sol")).toBeTruthy();
+    expect(container.querySelector('input[placeholder="gpt-5.6-sol"]')).toBeNull();
+    expect(container.textContent).toContain("settings.ai.modelListFallbackHint");
+  });
+
+  it("keeps a saved effort visible when the seeded model does not support it", async () => {
+    const liveList = deferred<CodexModelList>();
+    mocks.invoke.mockImplementation((command) => {
+      if (command === "openai_oauth_status") {
+        return Promise.resolve({ connected: false, account_id: null });
+      }
+      if (command === "list_codex_models") return liveList.promise;
+      return Promise.resolve(undefined);
+    });
+
+    await render({
+      ai_provider: "openai",
+      ai_auth_mode: "oauth",
+      ai_model: "gpt-5.6-luna",
+      ai_effort_quick: "ultra",
+    });
+
+    expect(buttonWithText("GPT-5.6-Luna")).toBeTruthy();
+    expect(buttonWithText("ultra")).toBeTruthy();
+  });
+
+  it.each([
+    ["OpenAI API key", { ai_provider: "openai", ai_auth_mode: "api_key", ai_model: "gpt-4o" }, "gpt-4o"],
+    ["Anthropic", { ai_provider: "anthropic", ai_model: "claude-sonnet-4-20250514" }, "claude-sonnet-4-20250514"],
+    ["Ollama", { ai_provider: "ollama", ai_model: "qwen3.5" }, "qwen3.5"],
+  ])("leaves the %s model field as free text", async (_label, settings, placeholder) => {
+    mocks.invoke.mockImplementation((command) => {
+      if (command === "openai_oauth_status") {
+        return Promise.resolve({ connected: false, account_id: null });
+      }
+      if (command === "list_codex_models") {
+        return Promise.resolve({ models: CURATED_CODEX_MODELS, from_fallback: true });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await render(settings);
+
+    expect(container.querySelector(`input[placeholder="${placeholder}"]`)).not.toBeNull();
+  });
+});

--- a/src/components/settings/AiSettings.tsx
+++ b/src/components/settings/AiSettings.tsx
@@ -6,6 +6,7 @@ import Button from "../ui/Button";
 import Select from "../ui/Select";
 import Input from "../ui/Input";
 import Slider from "../ui/Slider";
+import { CODEX_EFFORT_LEVELS, CURATED_CODEX_MODELS, type CodexModel } from "./codexModels";
 import type { SettingsProps } from "./types";
 
 interface AiSettingsProps extends SettingsProps {
@@ -13,21 +14,10 @@ interface AiSettingsProps extends SettingsProps {
   onDirtyChange?: (dirty: boolean) => void;
 }
 
-interface CodexModel {
-  slug: string;
-  display_name: string;
-  description: string;
-  supported_reasoning_levels: string[];
-}
-
 interface CodexModelList {
   models: CodexModel[];
   from_fallback: boolean;
 }
-
-// Union of effort levels across Codex models, used when the selected model
-// is custom/unknown or doesn't report its supported levels.
-const EFFORT_LEVELS_UNION = ["low", "medium", "high", "xhigh", "max", "ultra"];
 
 const CUSTOM_MODEL = "__custom__";
 
@@ -38,7 +28,7 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
   // AI config
   const [provider, setProvider] = useState("openai");
   const [apiKey, setApiKey] = useState("");
-  const [model, setModel] = useState("gpt-5.3-codex");
+  const [model, setModel] = useState("gpt-5.6-sol");
   const [baseUrl, setBaseUrl] = useState("https://api.openai.com");
   const [temperature, setTemperature] = useState(0.3);
   const [keepAlive, setKeepAlive] = useState("30m");
@@ -50,7 +40,7 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
   const [oauthError, setOauthError] = useState<string | null>(null);
 
   // Codex model card + reasoning effort (OpenAI OAuth path only)
-  const [codexModels, setCodexModels] = useState<CodexModel[]>([]);
+  const [codexModels, setCodexModels] = useState<CodexModel[]>(CURATED_CODEX_MODELS);
   const [modelsFromFallback, setModelsFromFallback] = useState(false);
   const [customModel, setCustomModel] = useState(false);
   const [effortQuick, setEffortQuick] = useState("default");
@@ -89,12 +79,12 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
     invoke<CodexModelList>("list_codex_models")
       .then((list) => {
         if (stale) return;
-        setCodexModels(list.models);
         setModelsFromFallback(list.from_fallback);
+        setCodexModels(list.models);
       })
       .catch(() => {
         if (stale) return;
-        setCodexModels([]);
+        setCodexModels(CURATED_CODEX_MODELS);
         setModelsFromFallback(true);
       });
     return () => {
@@ -194,7 +184,7 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
   const effortLevels =
     selectedCodexModel && selectedCodexModel.supported_reasoning_levels.length > 0
       ? selectedCodexModel.supported_reasoning_levels
-      : EFFORT_LEVELS_UNION;
+      : CODEX_EFFORT_LEVELS;
   const effortOptions = (saved: string) => {
     const options = [
       { value: "default", label: t("settings.ai.effortDefault") },
@@ -226,7 +216,7 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
               if (p === "ollama") {
                 setBaseUrl("http://localhost:11434"); setModel("qwen3.5");
               } else if (p === "openai") {
-                setBaseUrl("https://api.openai.com"); setModel("gpt-5.3-codex"); setAuthMode("oauth");
+                setBaseUrl("https://api.openai.com"); setModel("gpt-5.6-sol"); setAuthMode("oauth");
               } else if (p === "anthropic") {
                 setBaseUrl(""); setModel("claude-sonnet-4-20250514");
               } else {
@@ -268,7 +258,7 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
                   ? "bg-accent text-white"
                   : "bg-bg-page text-text-secondary hover:bg-bg-input"
               }`}
-              onClick={() => { setAuthMode("oauth"); setModel("gpt-5.3-codex"); setCustomModel(false); setAiDirty(true); }}
+              onClick={() => { setAuthMode("oauth"); setModel("gpt-5.6-sol"); setCustomModel(false); setAiDirty(true); }}
             >
               <Shield size={14} />
               {t("settings.ai.oauthLogin")}
@@ -372,7 +362,7 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
         <p className="text-[14px] font-medium text-text-primary mb-1.5">
           {t("settings.ai.model")}
         </p>
-        {isCodexPath && codexModels.length > 0 ? (
+        {isCodexPath ? (
           <>
             <Select
               value={isCustomModel ? CUSTOM_MODEL : model}
@@ -392,7 +382,7 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
                 className="mt-2"
                 value={model}
                 onChange={(e) => { setModel(e.target.value); setAiDirty(true); }}
-                placeholder="gpt-5.3-codex"
+                placeholder="gpt-5.6-sol"
               />
             )}
             <p className="text-[12px] text-text-muted mt-1.5">
@@ -411,7 +401,7 @@ export default function AiSettings({ settings, loading, saveBulk, showSavedToast
               placeholder={
                 provider === "ollama" ? "qwen3.5" :
                 provider === "anthropic" ? "claude-sonnet-4-20250514" :
-                (provider === "openai" && authMode === "oauth") ? "gpt-5.3-codex" :
+                (provider === "openai" && authMode === "oauth") ? "gpt-5.6-sol" :
                 "gpt-4o"
               }
             />

--- a/src/components/settings/codexModels.ts
+++ b/src/components/settings/codexModels.ts
@@ -1,0 +1,54 @@
+export interface CodexModel {
+  slug: string;
+  display_name: string;
+  description: string;
+  supported_reasoning_levels: string[];
+}
+
+export const CODEX_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max", "ultra"];
+
+// Keep in sync with fallback_models() in src-tauri/src/ai/codex_models.rs.
+export const CURATED_CODEX_MODELS: CodexModel[] = [
+  {
+    slug: "gpt-5.6-sol",
+    display_name: "GPT-5.6-Sol",
+    description: "Latest frontier agentic coding model.",
+    supported_reasoning_levels: ["low", "medium", "high", "xhigh", "max", "ultra"],
+  },
+  {
+    slug: "gpt-5.6-terra",
+    display_name: "GPT-5.6-Terra",
+    description: "Balanced agentic coding model for everyday work.",
+    supported_reasoning_levels: ["low", "medium", "high", "xhigh", "max", "ultra"],
+  },
+  {
+    slug: "gpt-5.6-luna",
+    display_name: "GPT-5.6-Luna",
+    description: "Fast and affordable agentic coding model.",
+    supported_reasoning_levels: ["low", "medium", "high", "xhigh", "max"],
+  },
+  {
+    slug: "gpt-5.5",
+    display_name: "GPT-5.5",
+    description: "Frontier model for complex coding, research, and real-world work.",
+    supported_reasoning_levels: ["low", "medium", "high", "xhigh"],
+  },
+  {
+    slug: "gpt-5.4",
+    display_name: "GPT-5.4",
+    description: "Strong model for everyday coding.",
+    supported_reasoning_levels: ["low", "medium", "high", "xhigh"],
+  },
+  {
+    slug: "gpt-5.4-mini",
+    display_name: "GPT-5.4-Mini",
+    description: "Small, fast, and cost-efficient model for simpler coding tasks.",
+    supported_reasoning_levels: ["low", "medium", "high", "xhigh"],
+  },
+  {
+    slug: "gpt-5.3-codex-spark",
+    display_name: "GPT-5.3-Codex-Spark",
+    description: "Ultra-fast coding model.",
+    supported_reasoning_levels: ["low", "medium", "high", "xhigh"],
+  },
+];


### PR DESCRIPTION
## Summary

- seed the current Codex model catalog synchronously so the OAuth model picker has a stable first paint
- upgrade from backend/live catalogs in the background while preserving custom models and saved effort values
- enrich the Rust fallback catalog and cover first paint, fallback, error, live-upgrade, and provider regressions

## Test plan

- `npx tsc --noEmit`
- `npx vitest run`
- `pnpm build`
- `pnpm run lint`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo clippy -- -D warnings`

Closes #312.